### PR TITLE
Permit to not have a public interface

### DIFF
--- a/containers/dgxie/dnsmasq.conf
+++ b/containers/dgxie/dnsmasq.conf
@@ -24,7 +24,7 @@ dhcp-authoritative
 dhcp-range=#DHCP_START#,#DHCP_END#,#LEASETIME#
 #dhcp-option-force=209,efi64/pxelinux.cfg
 dhcp-option=tag:green,option:domain-search,#DOMAIN#
-#dhcp-option=3,#IP#
+dhcp-option=3,#GATEWAY#
 #dhcp-option=6,#IP#
 #dhcp-match=set:efi-x86_64,option:client-arch,7
 #dhcp-match=set:efi-x86_64,option:client-arch,9

--- a/containers/dgxie/start
+++ b/containers/dgxie/start
@@ -85,11 +85,13 @@ sed -i "s/\#DHCP_END\#/${DHCP_END}/g" /etc/dnsmasq.conf
 # HTTP
 sed -i "s/\#HTTP_PORT\#/${HTTP_PORT}/g" /etc/nginx/nginx.conf
 
-# NAT
-/sbin/iptables -t nat -A POSTROUTING -o ${HOST_INT_PUB} -j MASQUERADE
-/sbin/iptables -A FORWARD -i ${HOST_INT_PUB} -o ${HOST_INT_PRV} -m state --state RELATED,ESTABLISHED -j ACCEPT
-/sbin/iptables -A FORWARD -i ${HOST_INT_PRV} -o ${HOST_INT_PUB} -j ACCEPT
-sysctl -w net.ipv4.ip_forward=1
+if [ ! -z "${HOST_INT_PUB}" ]; then
+  # NAT
+  /sbin/iptables -t nat -A POSTROUTING -o ${HOST_INT_PUB} -j MASQUERADE
+  /sbin/iptables -A FORWARD -i ${HOST_INT_PUB} -o ${HOST_INT_PRV} -m state --state RELATED,ESTABLISHED -j ACCEPT
+  /sbin/iptables -A FORWARD -i ${HOST_INT_PRV} -o ${HOST_INT_PUB} -j ACCEPT
+  sysctl -w net.ipv4.ip_forward=1
+fi
 
 # Run some servers
 nginx &


### PR DESCRIPTION
If no pub interface is set (empty env var), then no NAT rules are set, useful if we use a proxy to preseed.

Thanks for review.