### PR TITLE
Fix warning about ssh role syntax

### DIFF
--- a/ansible/roles/ssh/handlers/main.yml
+++ b/ansible/roles/ssh/handlers/main.yml
@@ -5,10 +5,8 @@
 
 - name: restart ssh
   action: service name=ssh state=restarted
-  when: ssh_service_state != 'stopped'
-  when: ansible_os_family == "Debian"
+  when: (ssh_service_state != 'stopped' and ansible_os_family == "Debian")
 
 - name: restart ssh
   action: service name=sshd state=restarted
-  when: ssh_service_state != 'stopped'
-  when: ansible_os_family == "Redhat"
+  when: (ssh_service_state != 'stopped' and ansible_os_family == "Redhat")


### PR DESCRIPTION
@dholt does my fix line up with what you originally intended for this role?
```
 [WARNING]: While constructing a mapping from                                                                                                                                                                                                                                    
/home/lyeager/code/deepops/ansible/roles/ssh/handlers/main.yml, line 6, column                                                                                                                                                                                                   
3, found a duplicate dict key (when). Using last defined value only.            
                                                                                                                                                                                                                                                                                 
 [WARNING]: While constructing a mapping from                                   
/home/lyeager/code/deepops/ansible/roles/ssh/handlers/main.yml, line 11, column                                                                                                                                                                                                  
3, found a duplicate dict key (when). Using last defined value only.                                                                                                                                                                                                            
```