### PR TITLE
nvidia-driver playbook: run on all hosts with GPUs

### DIFF
--- a/playbooks/nvidia-driver.yml
+++ b/playbooks/nvidia-driver.yml
@@ -1,10 +1,19 @@
-- hosts: gpu-servers:dgx-servers
+- hosts: all
   become: true
-  roles:
-    - nvidia-driver
-    - reboot
-
-- hosts: gpu-servers:dgx-servers
   tasks:
+    - name: Check for GPUs
+      shell: lspci | grep -i nvidia
+      register: has_gpu
+      ignore_errors: true
+
+    - include_role:
+        name: nvidia-driver
+      when: has_gpu.rc == 0
+
+    - include_role:
+        name: reboot
+      when: has_gpu.rc == 0
+
     - name: test nvidia-smi
       shell: nvidia-smi
+      when: has_gpu.rc == 0


### PR DESCRIPTION
This feature was originally introduced with https://github.com/NVIDIA/deepops/pull/83
Then, it was removed in https://github.com/NVIDIA/deepops/pull/84
Now, I'm bringing it back.