### PR TITLE
nvidia-driver: updates

### DIFF
--- a/playbooks/nvidia-driver.yml
+++ b/playbooks/nvidia-driver.yml
@@ -10,10 +10,6 @@
         name: nvidia-driver
       when: has_gpu.rc == 0
 
-    - include_role:
-        name: reboot
-      when: has_gpu.rc == 0
-
     - name: test nvidia-smi
       command: nvidia-smi
       when: has_gpu.rc == 0

--- a/playbooks/nvidia-driver.yml
+++ b/playbooks/nvidia-driver.yml
@@ -15,5 +15,5 @@
       when: has_gpu.rc == 0
 
     - name: test nvidia-smi
-      shell: nvidia-smi
+      command: nvidia-smi
       when: has_gpu.rc == 0

--- a/roles/nvidia-driver/defaults/main.yml
+++ b/roles/nvidia-driver/defaults/main.yml
@@ -1,6 +1,4 @@
-# Pin the package version for "cuda-drivers"
-driver_package_version: ''
-
-persistence_mode_on: yes
-
-reinstall_nvidia_driver: no
+nvidia_driver_package_version: ''
+nvidia_driver_persistence_mode_on: yes
+nvidia_driver_force_reinstall: no
+nvidia_driver_skip_reboot: no

--- a/roles/nvidia-driver/defaults/main.yml
+++ b/roles/nvidia-driver/defaults/main.yml
@@ -2,3 +2,5 @@
 driver_package_version: ''
 
 persistence_mode_on: yes
+
+reinstall_nvidia_driver: no

--- a/roles/nvidia-driver/tasks/install.yml
+++ b/roles/nvidia-driver/tasks/install.yml
@@ -76,5 +76,6 @@
     name: nvidia-persistenced
     enabled: yes
 
-# Rather than attempt to cleanup the kernel modules (noveau, nvidia), we
-#   recommend a reboot to be safe.
+# Reboot rather than attempt to cleanup the kernel modules (noveau, nvidia).
+- include_role:
+    name: reboot

--- a/roles/nvidia-driver/tasks/install.yml
+++ b/roles/nvidia-driver/tasks/install.yml
@@ -1,0 +1,80 @@
+#
+# Checks
+#
+
+- name: check distro
+  fail:
+    msg: "distro {{ ansible_facts['distribution'] }} not supported"
+  when: ansible_facts['distribution'] != 'Ubuntu'
+
+#
+# Cleanup
+#
+
+- name: remove apt packages
+  apt:
+    name: "{{ item }}"
+    state: absent
+    purge: yes
+    autoremove: yes
+  ignore_errors: yes
+
+  # Use a loop instead of a list here. We want to apply ignore_errors for each
+  #   package because ansible throws an error if it cannot complete the glob.
+  loop:
+    - cuda-drivers
+    - nvidia-3*
+    - nvidia-4*
+    - nvidia-driver-*
+    - nvidia-utils-*
+
+- name: remove ppa
+  apt_repository:
+    repo: ppa:graphics-drivers/ppa
+    state: absent
+
+- name: remove persistenced service override
+  file:
+    path: /etc/systemd/system/nvidia-persistenced.service.d/override.conf
+    state: absent
+
+#
+# Install
+#
+
+- name: add key
+  apt_key:
+    url: "https://developer.download.nvidia.com/compute/cuda/repos/{{ repo_dir }}/7fa2af80.pub"
+    id: 7fa2af80
+
+- name: add repo
+  apt_repository:
+    repo: "deb http://developer.download.nvidia.com/compute/cuda/repos/{{ repo_dir }} /"
+    update_cache: yes
+
+- name: install driver packages
+  apt:
+    name: "{{ item }}"
+    install_recommends: no
+  with_items:
+    - "{{ driver_package_version | ternary('cuda-drivers='+driver_package_version, 'cuda-drivers') }}"
+
+- name: create persistenced override dir
+  file:
+    path: /etc/systemd/system/nvidia-persistenced.service.d/
+    state: directory
+    recurse: yes
+
+- name: configure persistenced service to turn on persistence mode
+  copy:
+    src: nvidia-persistenced-override.conf
+    dest: /etc/systemd/system/nvidia-persistenced.service.d/override.conf
+  when: persistence_mode_on
+
+- name: enable persistenced
+  systemd:
+    name: nvidia-persistenced
+    enabled: yes
+
+# Rather than attempt to cleanup the kernel modules (noveau, nvidia), we
+#   recommend a reboot to be safe.

--- a/roles/nvidia-driver/tasks/install.yml
+++ b/roles/nvidia-driver/tasks/install.yml
@@ -57,7 +57,7 @@
     name: "{{ item }}"
     install_recommends: no
   with_items:
-    - "{{ driver_package_version | ternary('cuda-drivers='+driver_package_version, 'cuda-drivers') }}"
+    - "{{ nvidia_driver_package_version | ternary('cuda-drivers='+nvidia_driver_package_version, 'cuda-drivers') }}"
 
 - name: create persistenced override dir
   file:
@@ -69,7 +69,7 @@
   copy:
     src: nvidia-persistenced-override.conf
     dest: /etc/systemd/system/nvidia-persistenced.service.d/override.conf
-  when: persistence_mode_on
+  when: nvidia_driver_persistence_mode_on
 
 - name: enable persistenced
   systemd:
@@ -79,3 +79,4 @@
 # Reboot rather than attempt to cleanup the kernel modules (noveau, nvidia).
 - include_role:
     name: reboot
+  when: not nvidia_driver_skip_reboot

--- a/roles/nvidia-driver/tasks/main.yml
+++ b/roles/nvidia-driver/tasks/main.yml
@@ -5,4 +5,4 @@
 
 - name: include install tasks
   include_tasks: install.yml
-  when: nvidia_smi.rc != 0 or reinstall_nvidia_driver
+  when: nvidia_smi.rc != 0 or nvidia_driver_force_reinstall

--- a/roles/nvidia-driver/tasks/main.yml
+++ b/roles/nvidia-driver/tasks/main.yml
@@ -1,80 +1,8 @@
-#
-# Checks
-#
+- name: check if driver already installed
+  command: nvidia-smi
+  register: nvidia_smi
+  ignore_errors: true
 
-- name: check distro
-  fail:
-    msg: "distro {{ ansible_facts['distribution'] }} not supported"
-  when: ansible_facts['distribution'] != 'Ubuntu'
-
-#
-# Cleanup
-#
-
-- name: remove apt packages
-  apt:
-    name: "{{ item }}"
-    state: absent
-    purge: yes
-    autoremove: yes
-  ignore_errors: yes
-
-  # Use a loop instead of a list here. We want to apply ignore_errors for each
-  #   package because ansible throws an error if it cannot complete the glob.
-  loop:
-    - cuda-drivers
-    - nvidia-3*
-    - nvidia-4*
-    - nvidia-driver-*
-    - nvidia-utils-*
-
-- name: remove ppa
-  apt_repository:
-    repo: ppa:graphics-drivers/ppa
-    state: absent
-
-- name: remove persistenced service override
-  file:
-    path: /etc/systemd/system/nvidia-persistenced.service.d/override.conf
-    state: absent
-
-#
-# Install
-#
-
-- name: add key
-  apt_key:
-    url: "https://developer.download.nvidia.com/compute/cuda/repos/{{ repo_dir }}/7fa2af80.pub"
-    id: 7fa2af80
-
-- name: add repo
-  apt_repository:
-    repo: "deb http://developer.download.nvidia.com/compute/cuda/repos/{{ repo_dir }} /"
-    update_cache: yes
-
-- name: install driver packages
-  apt:
-    name: "{{ item }}"
-    install_recommends: no
-  with_items:
-    - "{{ driver_package_version | ternary('cuda-drivers='+driver_package_version, 'cuda-drivers') }}"
-
-- name: create persistenced override dir
-  file:
-    path: /etc/systemd/system/nvidia-persistenced.service.d/
-    state: directory
-    recurse: yes
-
-- name: configure persistenced service to turn on persistence mode
-  copy:
-    src: nvidia-persistenced-override.conf
-    dest: /etc/systemd/system/nvidia-persistenced.service.d/override.conf
-  when: persistence_mode_on
-
-- name: enable persistenced
-  systemd:
-    name: nvidia-persistenced
-    enabled: yes
-
-# Rather than attempt to cleanup the kernel modules (noveau, nvidia), we
-#   recommend a reboot to be safe.
+- name: include install tasks
+  include_tasks: install.yml
+  when: nvidia_smi.rc != 0 or reinstall_nvidia_driver


### PR DESCRIPTION
* Skip the slow driver reinstall if it looks like it's already installed
  * CLI override to reinstall
    `ansible-playbook playbooks/nvidia-driver.yml -e '{nvidia_driver_force_reinstall: yes}'`
* Only reboot if we actually changed something
  * CLI override to skip reboot
    `ansible-playbook playbooks/nvidia-driver.yml -e '{nvidia_driver_skip_reboot: yes}'`