### PR TITLE
slurm - upgrade from heirloom-mailx to s-nail

### DIFF
--- a/roles/slurm/tasks/controller.yml
+++ b/roles/slurm/tasks/controller.yml
@@ -8,12 +8,12 @@
     - mariadb-server
     - python-mysqldb
 
-- name: install mailx and ssmtp
+- name: install s-nail and ssmtp
   apt:
     name: "{{ item }}"
     state: latest
   with_items:
-    - heirloom-mailx
+    - s-nail
     - ssmtp
 
 - name: setup slurm db user

--- a/roles/slurm/templates/slurm.conf
+++ b/roles/slurm/templates/slurm.conf
@@ -47,7 +47,7 @@ PrologFlags=contain
 {% endif %}
 Prolog=/etc/slurm/prolog.d/*
 Epilog=/etc/slurm/epilog.d/*
-MailProg=/usr/bin/heirloom-mailx
+MailProg=/usr/bin/s-nail
 #SrunProlog=
 #SrunEpilog=
 #TaskProlog=


### PR DESCRIPTION
Enables upgrade from xenial to bionic.

Looks like it should be a safe upgrade based on the notes here:
https://packages.ubuntu.com/source/xenial/s-nail