### PR TITLE
Move all SSH configuration into inventory

### DIFF
--- a/config.example/group_vars/all.yml
+++ b/config.example/group_vars/all.yml
@@ -8,9 +8,6 @@ ssh_password_authentication: 'yes'
 # If this is `false`, pass the `-K` flag to all Ansible commands to prompt for the SUDO password
 enable_sudo_without_password: true
 
-# Configure Ansible to use a proxy if remote machines are unroutable
-#ansible_ssh_common_args: '-o ProxyCommand="ssh -W %h:%p -q ubuntu@10.0.0.1"'
-
 # Docker Configuration
 #docker_daemon_json:
 #  bip: 192.168.99.1/24

--- a/config.example/group_vars/dgx-servers.yml
+++ b/config.example/group_vars/dgx-servers.yml
@@ -1,8 +1,6 @@
 ---
 # DGX Server Configuration
 
-ansible_user: dgxuser
-
 # Collectd
 collectd_python_modules:
   - dcgm_collectd

--- a/config.example/inventory
+++ b/config.example/inventory
@@ -9,7 +9,6 @@
 [management]
 #mgmt       ansible_host=10.0.0.1
 
-
 # Slurm Controller/Login Servers
 # See group_vars/login.yml for configuration
 [login]
@@ -41,9 +40,22 @@ management
 #gpu-servers
 #dgx-servers
 
+######
+# SSH connection configuration
+######
+
+[all:vars]
+#ansible_user=ubuntu
+# Configure SSH bastion/jumpbox for the cluster
+#ansible_ssh_common_args='-o ProxyCommand="ssh -W %h:%p -q ubuntu@10.0.0.1"'
+
+[dgx-servers:vars]
+#ansible_user=dgxuser
+
+
 ###############################################################################
-## You shouldn't need to make changes below here
-################################################################################
+# You shouldn't need to make changes below here
+###############################################################################
 
 ######
 # Cluster compute (non-management/login) nodes


### PR DESCRIPTION
This logical grouping makes sense to me. The inventory tells you where your machines are, and how to connect to them. Then, all the stuff under `./config/group_vars/` is for configuring the playbooks+roles.

Then, if the user wants just "the default stuff", they should only ever need to edit the inventory.