### PR TITLE
Purge ansible_user

### DIFF
--- a/playbooks/bootstrap.yml
+++ b/playbooks/bootstrap.yml
@@ -21,12 +21,12 @@
 - hosts: all
   become: true
   tasks:
-    - name: Allow password-less sudo to "{{ ansible_user }}"
+    - name: Allow password-less sudo to ansible user"
       copy:
-        content: "{{ ansible_user }} ALL=(ALL) NOPASSWD:ALL"
-        dest: "/etc/sudoers.d/{{ ansible_user }}"
-    - name: Add SSH public key to "{{ ansible_user }}" user authorized keys
+        content: "{{ ansible_user | default(ansible_env.SUDO_USER) }} ALL=(ALL) NOPASSWD:ALL"
+        dest: "/etc/sudoers.d/{{ ansible_user | default(ansible_env.SUDO_USER) }}"
+    - name: Add SSH public key to ansible user user authorized keys
       authorized_key:
-        user: "{{ ansible_user }}"
+        user: "{{ ansible_user | default(ansible_env.SUDO_USER) }}"
         state: present
         key: "{{ lookup('file', lookup('env','HOME') + '/.ssh/id_rsa.pub') }}"

--- a/playbooks/bootstrap.yml
+++ b/playbooks/bootstrap.yml
@@ -21,7 +21,7 @@
 - hosts: all
   become: true
   tasks:
-    - name: Allow password-less sudo to ansible user"
+    - name: Allow password-less sudo to ansible user
       copy:
         content: "{{ ansible_user | default(ansible_env.SUDO_USER) }} ALL=(ALL) NOPASSWD:ALL"
         dest: "/etc/sudoers.d/{{ ansible_user | default(ansible_env.SUDO_USER) }}"

--- a/playbooks/slurm-cluster.yml
+++ b/playbooks/slurm-cluster.yml
@@ -7,7 +7,7 @@
 # Set up passwordless sudo and SSH keys if needed
 - include: bootstrap.yml
 
-# Set root SSH key to allow SSH/ansible when no slurm job running for ansible_user
+# Set root SSH key to allow SSH/ansible when no slurm job running for ansible user
 - hosts: all
   become: true
   tasks:

--- a/playbooks/slurm.yml
+++ b/playbooks/slurm.yml
@@ -16,7 +16,7 @@
       include_role:
         name: slurm
       vars:
-        user: "{{ ansible_user }}"
+        user: "{{ ansible_user | default(ansible_env.SUDO_USER) }}"
         is_controller: yes
 
 - hosts: compute-nodes
@@ -26,5 +26,5 @@
       include_role:
         name: slurm
       vars:
-        user: "{{ ansible_user }}"
+        user: "{{ ansible_user | default(ansible_env.SUDO_USER) }}"
         is_compute: yes

--- a/playbooks/user-password.yml
+++ b/playbooks/user-password.yml
@@ -27,7 +27,7 @@
       vars:
         # User Configuration
         users:
-          - username: "{{ ansible_user }}"
+          - username: "{{ ansible_user | default(ansible_env.SUDO_USER) }}"
             password: "{{ passwd | password_hash('sha512', 'salty') }}"
     - debug:
-       msg: "Set password for {{ ansible_user }} to: {{ passwd }}"
+       msg: "Set password for {{ ansible_user | default(ansible_env.SUDO_USER) }} to: {{ passwd }}"


### PR DESCRIPTION
Don't rely on `ansible_user` being set. This is the case when playbooks are run against the local host and there's no SSH connection.