### PR TITLE
Update kube.yml

### DIFF
--- a/config.example/kube.yml
+++ b/config.example/kube.yml
@@ -16,7 +16,11 @@ kube_apiserver_admission_control:
 nvidia_accelerator_enabled: true
 nvidia_gpu_flavor: tesla
 # nvidia_driver_version: "384.111"
+
 docker_storage_options: -s overlay2
+docker_insecure_registries: []
+#  - registry.local
+
 
 ## Array with nvida_gpu_nodes, leave empty or comment if you dont't want to install drivers.
 ## Labels and taints won't be set to nodes if they are not in the array.


### PR DESCRIPTION
adding stub for `docker_insecure_registries` in kube.yml

We should document the [Kubernetes Configuration Guide](https://github.com/NVIDIA/deepops/blob/refactor/docs/kubernetes-cluster.md) the how to install a local docker registry.  This document still appears to be a WIP on the refactor branch.