### PR TITLE
virtual - add prefix to hostnames

### DIFF
--- a/virtual/README.md
+++ b/virtual/README.md
@@ -37,7 +37,7 @@ To start the cluster, run the `cluster_up.sh` script...
 $ ./cluster_up.sh
 ```
 
-Vagrant will spin up three VMs - login01, mgmt, and dgx01. Afterwards, the script will use ansible
+Vagrant will spin up three VMs - login, mgmt, and gpu01. Afterwards, the script will use ansible
 to configure the nodes and set up DeepOps.
 
 The script should complete without errors and three nodes should show up when running `virsh
@@ -48,14 +48,14 @@ $ virsh list
  Id    Name                           State
 ----------------------------------------------------
  7     vagrant_mgmt                   running
- 8     vagrant_login01                running
- 9     vagrant_dgx01                  running
+ 8     vagrant_login                  running
+ 9     vagrant_gpu01                  running
 ```
 
 Connect to any of the nodes via vagrant ssh...
 
 ```
-$ vagrant ssh dgx01
+$ vagrant ssh gpu01
 ```
 
 ## Destroy the cluster
@@ -70,7 +70,7 @@ Check that there are no running VMs using `virsh list`.
 
 ## Configure GPU passthrough
 
-If your host machine has a GPU, it is possible to enable GPU passthrough to the dgx01 VM.
+If your host machine has a GPU, it is possible to enable GPU passthrough to the gpu01 VM.
 
 Run `lspci` to discover the appropriate bus...
 

--- a/virtual/Vagrantfile
+++ b/virtual/Vagrantfile
@@ -8,22 +8,22 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.hostmanager.ignore_private_ip = false
   config.hostmanager.include_offline = true
 
-  config.vm.define "mgmt" do |mgmt|
+  config.vm.define "virtual-mgmt" do |mgmt|
     mgmt.vm.provider "libvirt" do |v|
       v.memory = 2048
     end
     mgmt.vm.box = BOX_IMAGE
-    mgmt.vm.hostname = "mgmt"
+    mgmt.vm.hostname = "virtual-mgmt"
     mgmt.vm.network :private_network, ip: "10.0.0.2"
   end
 
-  config.vm.define "login01" do |login|
+  config.vm.define "virtual-login" do |login|
     login.vm.box = BOX_IMAGE
-    login.vm.hostname = "login01"
+    login.vm.hostname = "virtual-login"
     login.vm.network :private_network, ip: "10.0.0.4"
   end
 
-  config.vm.define "gpu01" do |gpu|
+  config.vm.define "virtual-gpu01" do |gpu|
     config.vm.provider "libvirt" do |v|
       v.memory = 16384
       v.cpus = 2
@@ -34,7 +34,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       #v.pci :bus => '0x08', :slot => '0x00', :function => '0x0'
     end
     gpu.vm.box = BOX_IMAGE
-    gpu.vm.hostname = "gpu01"
+    gpu.vm.hostname = "virtual-gpu01"
     gpu.vm.network :private_network, ip: "10.0.0.11"
   end
 end

--- a/virtual/virtual_inventory
+++ b/virtual/virtual_inventory
@@ -7,30 +7,21 @@
 # Management Servers
 # See group_vars/management.yml for configuration
 [management]
-mgmt
-#mgmt       ansible_host=10.0.0.1
-
+virtual-mgmt
 
 # Login Servers
 # See group_vars/login.yml for configuration
 [login]
-login01
-#login01    ansible_host=10.0.0.2
+virtual-login
 
 # GPU Servers - All GPU servers, including DGX if desired
 # See group_vars/gpu-servers.yml for configuration
 [gpu-servers]
-gpu01
-#gpu01      ansible_host=10.0.2.1
-#gpu02      ansible_host=10.0.2.2
-#gpu03      ansible_host=10.0.2.3
+virtual-gpu01
 
 # DGX Servers - DGX specific
 # See group_vars/dgx-servers.yml for configuration
 [dgx-servers]
-#dgx01      ansible_host=10.0.3.1
-#dgx02      ansible_host=10.0.3.2
-#dgx03      ansible_host=10.0.3.3
 
 # Configure nodes for Kubernetes
 # Only add the 'gpu-servers' and 'dgx-servers' group once the GPU/DGX nodes are up and available


### PR DESCRIPTION
* Less chance of collision with real, external hosts
* Allows us to rename "login01" to "login" without colliding with the
    group name