### PR TITLE
Add an env file for virtual k8s cluster

### DIFF
--- a/virtual/cluster_up.sh
+++ b/virtual/cluster_up.sh
@@ -25,11 +25,8 @@ cp virtual/virtual_inventory ${DEEPOPS_CONFIG_DIR}/inventory
 # Deploy the K8s cluster
 ansible-playbook -i virtual/k8s-config/hosts.ini -b playbooks/k8s-cluster.yml -e "ansible_user=vagrant ansible_password=vagrant"
 
-# Export k8s config so we can use it throughout the rest of the script
-export KUBECONFIG=virtual/k8s-config/artifacts/admin.conf
-
-# Put local kubectl in the PATH for following commands and scripts
-export PATH="$(pwd)/virtual/k8s-config/artifacts:${PATH}"
+# Source K8s environment for interacting with the cluster
+source ./virtual/k8s_environment.sh
 
 # Verify that the cluster is up
 kubectl get nodes

--- a/virtual/k8s_environment.sh
+++ b/virtual/k8s_environment.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+#
+# Set up local environment to work with virtual k8s cluster
+
+K8S_CONFIG_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )/k8s-config"
+
+export KUBECONFIG="${K8S_CONFIG_DIR}/artifacts/admin.conf"
+export PATH="${K8S_CONFIG_DIR}/artifacts:${PATH}"


### PR DESCRIPTION
After running `cluster_up.sh`, you still need to set up your local
environment if you want to interact with the cluster via `kubectl`. This
is annoying :) so this change just moves the environment for interacting
with `kubectl` into its own file for handy sourcing.