### PR TITLE
dns-config - new role

### DIFF
--- a/config.example/group_vars/all.yml
+++ b/config.example/group_vars/all.yml
@@ -5,6 +5,10 @@
 #docker_daemon_json:
 #  bip: 192.168.99.1/24
 
+# dns-config
+#dns_config_servers: [8.8.8.8]
+#dns_config_search: [example.com]
+
 # NIS configuration
 #nisdomain: example.com
 #nisserver: 10.0.0.1

--- a/playbooks/dns-config.yml
+++ b/playbooks/dns-config.yml
@@ -1,0 +1,5 @@
+---
+- hosts: all
+  become: true
+  roles:
+    - dns-config

--- a/roles/dns-config/defaults/main.yml
+++ b/roles/dns-config/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+dns_config_servers: []
+dns_config_search: []

--- a/roles/dns-config/tasks/main.yml
+++ b/roles/dns-config/tasks/main.yml
@@ -1,0 +1,20 @@
+---
+- name: disable systemd-resolved
+  service:
+    name: systemd-resolved
+    state: stopped
+    enabled: no
+
+- name: install /etc/resolv.conf
+  template:
+    src: resolv.conf.j2
+    dest: /etc/resolv.conf
+    owner: root
+    group: root
+    mode: '0644'
+
+- name: update /etc/nsswitch.conf
+  lineinfile:
+    path: /etc/nsswitch.conf
+    regexp: '^hosts:'
+    line: 'hosts: files dns'

--- a/roles/dns-config/tasks/main.yml
+++ b/roles/dns-config/tasks/main.yml
@@ -16,9 +16,6 @@
     enabled: no
   when: ansible_distribution == 'Ubuntu' and ansible_distribution_major_version == '18'
 
-- debug:
-    msg: "{{ansible_distribution}} {{ansible_distribution_major_version}}"
-
 - name: install /etc/resolv.conf
   template:
     src: resolv.conf.j2

--- a/roles/dns-config/tasks/main.yml
+++ b/roles/dns-config/tasks/main.yml
@@ -1,9 +1,23 @@
 ---
-- name: disable systemd-resolved
+- name: disable services (xenial)
+  service:
+    name: "{{ item }}"
+    state: stopped
+    enabled: no
+  loop:
+    - resolvconf
+    - systemd-resolved
+  when: ansible_distribution == 'Ubuntu' and ansible_distribution_major_version == '16'
+
+- name: disable services (bionic)
   service:
     name: systemd-resolved
     state: stopped
     enabled: no
+  when: ansible_distribution == 'Ubuntu' and ansible_distribution_major_version == '18'
+
+- debug:
+    msg: "{{ansible_distribution}} {{ansible_distribution_major_version}}"
 
 - name: install /etc/resolv.conf
   template:

--- a/roles/dns-config/templates/resolv.conf.j2
+++ b/roles/dns-config/templates/resolv.conf.j2
@@ -1,0 +1,8 @@
+# {{ ansible_managed }}
+
+{% for server in dns_config_servers %}
+nameserver {{ server }}
+{% endfor %}
+{% if dns_config_search %}
+search {{ dns_config_search | join(' ') }}
+{% endif %}


### PR DESCRIPTION
For now, this is geared towards enabling DNS in the libvirt VMs.
We like libvirt because GPU passthrough is easier. But it's missing the
handy one-liner to turn on DNS proxying that Virtualbox has.

To get around that, let's just implement a simple role to setup DNS
manually, without relying on a proxy. It might be useful in other
scenarios, too.