### PR TITLE
Refactor virt cluster up

### DIFF
--- a/virtual/cluster_destroy.sh
+++ b/virtual/cluster_destroy.sh
@@ -1,4 +1,11 @@
 #!/bin/bash
 set -ex
 
+# To destroy the virtual cluster, we just tear down all VMs
+VIRT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+cd "${VIRT_DIR}" || exit 1
 vagrant destroy -f
+cd -
+
+# List running VMs for crosscheck
+virsh list

--- a/virtual/cluster_up.sh
+++ b/virtual/cluster_up.sh
@@ -1,49 +1,28 @@
 #!/bin/bash
 set -ex
 
-# Start vagrant via libvirt - set up the VMs
-vagrant up --no-parallel --provider=libvirt
+#####################################
+# Set up a virtual DeepOps cluster
+#####################################
 
-# Show the running VMs
-virsh list
-
-cd ..
-
-# Create the K8s config (for mgmt=10.0.0.2, gpu01=10.0.0.11 nodes)
-K8S_CONFIG_DIR=./virtual/k8s-config ./scripts/k8s_inventory.sh 10.0.0.2 10.0.0.11
-cp ./virtual/k8s_hosts.ini ./virtual/k8s-config/hosts.ini
+# Get absolute path for the virtual DeepOps directory
+VIRT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+ROOT_DIR="${VIRT_DIR}/.."
 
 # Create the config for deepops servers (and use the virtual inventory)
-export DEEPOPS_CONFIG_DIR="$(pwd)/virtual/config"
-cp -r config.example/ ${DEEPOPS_CONFIG_DIR}/
-cp virtual/virtual_inventory ${DEEPOPS_CONFIG_DIR}/inventory
+export DEEPOPS_CONFIG_DIR="${VIRT_DIR}/config"
+cp -r "${ROOT_DIR}/config.example/" "${DEEPOPS_CONFIG_DIR}/"
+cp "${VIRT_DIR}/virtual_inventory" "${DEEPOPS_CONFIG_DIR}/inventory"
 
-#####################################
-# K8s
-#####################################
+# Set up VMs for the virtual cluster
+"${VIRT_DIR}"/scripts/setup_vagrant.sh
 
-# Deploy the K8s cluster
-ansible-playbook -i virtual/k8s-config/hosts.ini -b playbooks/k8s-cluster.yml
+# Set up Kubernetes (enabled by default)
+if [ -z "${DEEPOPS_DISABLE_K8S}" ]; then
+	"${VIRT_DIR}"/scripts/setup_k8s.sh
+fi
 
-# Source K8s environment for interacting with the cluster
-source ./virtual/k8s_environment.sh
-
-# Verify that the cluster is up
-kubectl get nodes
-#kubectl run gpu-test --rm -t -i --restart=Never --image=nvidia/cuda --limits=nvidia.com/gpu=1 -- nvidia-smi
-
-# Deploy dashboard (optional)
-./scripts/k8s_deploy_dashboard_user.sh
-
-# Deploy rook (optional, but highly recommended)
-./scripts/k8s_deploy_rook.sh
-
-# Deploy monitoring (optional)
-./scripts/k8s_deploy_monitoring.sh
-
-#####################################
-# Slurm
-#####################################
-
-# Deploy the Slurm cluster
-#ansible-playbook -i virtual/config/inventory -l slurm-cluster playbooks/slurm-cluster.yml
+# Set up Slurm (disabled by default)
+if [ -n "${DEEPOPS_ENABLE_SLURM}" ]; then
+	"${VIRT_DIR}"/scripts/setup_slum.sh
+fi

--- a/virtual/cluster_up.sh
+++ b/virtual/cluster_up.sh
@@ -9,6 +9,12 @@ set -ex
 VIRT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 ROOT_DIR="${VIRT_DIR}/.."
 
+# Ensure working directory is root
+cd "${ROOT_DIR}"
+
+# Ensure Ansible Galaxy dependencies are present
+ansible-galaxy install -r "${ROOT_DIR}/requirements.yml"
+
 # Create the config for deepops servers (and use the virtual inventory)
 export DEEPOPS_CONFIG_DIR="${VIRT_DIR}/config"
 cp -r "${ROOT_DIR}/config.example/" "${DEEPOPS_CONFIG_DIR}/"
@@ -24,5 +30,5 @@ fi
 
 # Set up Slurm (disabled by default)
 if [ -n "${DEEPOPS_ENABLE_SLURM}" ]; then
-	"${VIRT_DIR}"/scripts/setup_slum.sh
+	"${VIRT_DIR}"/scripts/setup_slurm.sh
 fi

--- a/virtual/scripts/setup_k8s.sh
+++ b/virtual/scripts/setup_k8s.sh
@@ -10,12 +10,15 @@ ROOT_DIR="${SCRIPT_DIR}/../.."
 # Configure k8s in virtual cluster 
 #####################################
 
+# Move working directory to root of DeepOps repo
+cd "${ROOT_DIR}" || exit 1
+
 # Create the K8s config (for mgmt=10.0.0.2, gpu01=10.0.0.11 nodes)
 K8S_CONFIG_DIR="${VIRT_DIR}/k8s-config" "${ROOT_DIR}/scripts/k8s_inventory.sh" 10.0.0.2 10.0.0.11
 cp "${VIRT_DIR}/k8s_hosts.ini" "${VIRT_DIR}/k8s-config/hosts.ini"
 
 # Deploy the K8s cluster
-ansible-playbook -i "${VIRT_DIR}/k8s-config/hosts.ini" -b "${ROOT_DIR}playbooks/k8s-cluster.yml"
+ansible-playbook -i "${VIRT_DIR}/k8s-config/hosts.ini" -b "${ROOT_DIR}/playbooks/k8s-cluster.yml"
 
 # Source K8s environment for interacting with the cluster
 # shellcheck source=../k8s_environment.sh

--- a/virtual/scripts/setup_k8s.sh
+++ b/virtual/scripts/setup_k8s.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+set -ex
+
+# Get absolute path for script, and convenience vars for virtual and root
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+VIRT_DIR="${SCRIPT_DIR}/.."
+ROOT_DIR="${SCRIPT_DIR}/../.."
+
+#####################################
+# Configure k8s in virtual cluster 
+#####################################
+
+# Create the K8s config (for mgmt=10.0.0.2, gpu01=10.0.0.11 nodes)
+K8S_CONFIG_DIR="${VIRT_DIR}/k8s-config" "${ROOT_DIR}/scripts/k8s_inventory.sh" 10.0.0.2 10.0.0.11
+cp "${VIRT_DIR}/k8s_hosts.ini" "${VIRT_DIR}/k8s-config/hosts.ini"
+
+# Deploy the K8s cluster
+ansible-playbook -i "${VIRT_DIR}/k8s-config/hosts.ini" -b "${ROOT_DIR}playbooks/k8s-cluster.yml"
+
+# Source K8s environment for interacting with the cluster
+# shellcheck source=../k8s_environment.sh
+source "${VIRT_DIR}/k8s_environment.sh"
+
+# Verify that the cluster is up
+kubectl get nodes
+#kubectl run gpu-test --rm -t -i --restart=Never --image=nvidia/cuda --limits=nvidia.com/gpu=1 -- nvidia-smi
+
+# Deploy dashboard (optional)
+./scripts/k8s_deploy_dashboard_user.sh
+
+# Deploy rook (optional, but highly recommended)
+./scripts/k8s_deploy_rook.sh
+
+# Deploy monitoring (optional)
+./scripts/k8s_deploy_monitoring.sh

--- a/virtual/scripts/setup_slurm.sh
+++ b/virtual/scripts/setup_slurm.sh
@@ -10,6 +10,9 @@ ROOT_DIR="${SCRIPT_DIR}/../.."
 # Configure slurm in virtual cluster 
 #####################################
 
+# Move working directory to root of DeepOps repo
+cd "${ROOT_DIR}" || exit 1
+
 ansible-playbook \
 	-i "${VIRT_DIR}/config/inventory" \
 	-l slurm-cluster \

--- a/virtual/scripts/setup_slurm.sh
+++ b/virtual/scripts/setup_slurm.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -ex
+
+# Get absolute path for script, and convenience vars for virtual and root
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+VIRT_DIR="${SCRIPT_DIR}/.."
+ROOT_DIR="${SCRIPT_DIR}/../.."
+
+#####################################
+# Configure slurm in virtual cluster 
+#####################################
+
+ansible-playbook \
+	-i "${VIRT_DIR}/config/inventory" \
+	-l slurm-cluster \
+	"${ROOT_DIR}/playbooks/slurm-cluster.yml"

--- a/virtual/scripts/setup_vagrant.sh
+++ b/virtual/scripts/setup_vagrant.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -ex
+
+# Get absolute path for script, and convenience vars for virtual and root
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+VIRT_DIR="${SCRIPT_DIR}/.."
+
+#####################################
+# Set up VMs for virtual cluster 
+#####################################
+
+# Ensure we're in the right directory for Vagrant
+cd "${VIRT_DIR}" || exit 1
+
+# Start vagrant via libvirt - set up the VMs
+vagrant up --no-parallel --provider=libvirt
+# Show the running VMs
+virsh list
+
+# Return to previous dir, if we were in any
+cd -

--- a/virtual/scripts/setup_vagrant.sh
+++ b/virtual/scripts/setup_vagrant.sh
@@ -12,8 +12,12 @@ VIRT_DIR="${SCRIPT_DIR}/.."
 # Ensure we're in the right directory for Vagrant
 cd "${VIRT_DIR}" || exit 1
 
+# Make sure our environment is clean
+vagrant global-status --prune
+
 # Start vagrant via libvirt - set up the VMs
 vagrant up --no-parallel --provider=libvirt
+
 # Show the running VMs
 virsh list
 


### PR DESCRIPTION
Separates out the vagrant, k8s, and slurm setup into their own scripts called from `cluster_up.sh`.

This makes it easier to turn up a cluster "piecemeal", for example, turning up a k8s cluster and then adding slurm after the fact.

I also made some changes to make scripts run correctly regardless of the working directory they were launched from, and ran the `shellcheck` linter to make the bash code a little nicer.