### PR TITLE
dgxie iso nfs wrapper

### DIFF
--- a/containers/dgxie/Dockerfile
+++ b/containers/dgxie/Dockerfile
@@ -18,6 +18,8 @@ RUN mkdir -p /www /var/run/vsftpd/empty
     #echo 'pasv_max_port=10100' >> /etc/vsftpd.conf && \
     #echo 'pasv_min_port=10090' >> /etc/vsftpd.conf
 
+RUN apt-get -y install nfs-common
+
 COPY get_hosts.py /usr/local/bin
 COPY rest_api.py /usr/local/bin
 COPY api.py /api.py

--- a/containers/dgxie/start
+++ b/containers/dgxie/start
@@ -2,6 +2,7 @@
 
 ## CONFIG
 MNT=${MNT:-/data}
+NFS_DIR=${NFS_DIR:-}
 ISO=${ISO:-/iso}
 PRESEED=${ISO}/preseed/pxe.template.seed
 INT=${INT:-enp1s0f0}
@@ -28,6 +29,11 @@ NTP=${NTP:-}
 ###
 
 mkdir -p "${ISO}"
+
+if [ ! -z ${NFS_SERVICE_SERVICE_HOST} ]; then
+  mkdir -p ${MNT} || true
+  mount -o nolock -t nfs ${NFS_SERVICE_SERVICE_HOST}:${NFS_DIR} ${MNT}
+fi
 
 # Check for mounted DGX Server ISO
 find ${PRESEED} >/dev/null 2>&1

--- a/services/dgxie/Chart.yaml
+++ b/services/dgxie/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for Kubernetes
 name: dgxie
-version: 0.1.2
+version: 0.2.0

--- a/services/dgxie/templates/deployment.yaml
+++ b/services/dgxie/templates/deployment.yaml
@@ -33,8 +33,10 @@ spec:
               mountPath: "/etc/machines/"
             - name: dhcp-leases
               mountPath: "/var/lib/misc/"
+{{- if not .Values.isoNfsWrapper }}
             - name: cephfs
               mountPath: "{{ .Values.mntPath }}"
+{{- end }}
           env:
             # Path in container to storage containing ISO image
             - name: MNT
@@ -104,6 +106,10 @@ spec:
               value: "{{ .Values.extraPackages }}"
             - name: NTP
               value: "{{ .Values.ntp }}"
+{{- if .Values.isoNfsWrapper }}
+            - name: NFS_DIR
+              value: "{{ .Values.nfsDir }}"
+{{- end }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
     {{- with .Values.nodeSelector }}
@@ -125,6 +131,7 @@ spec:
         - name: pxe-machines-vol
           configMap:
             name: pxe-machines
+{{- if not .Values.isoNfsWrapper }}
         - name: cephfs
           flexVolume:
             driver: ceph.rook.io/rook
@@ -133,6 +140,7 @@ spec:
               fsName: cephfs
               clusterNamespace: rook-ceph
               path: /iso
+{{- end }}
         - name: dhcp-leases
           hostPath:
             path: /var/lib/dhcp

--- a/services/dgxie/values.yaml
+++ b/services/dgxie/values.yaml
@@ -6,6 +6,8 @@
 bootMode: DGX
 mntPath: /data
 isoPath: /iso
+isoNfsWrapper: false
+nfsDir: '/data/iso'
 dgxNetInt: enp1s0f0
 dgxDisk: sda
 dgxKbd: us

--- a/services/iso-loader-nfs.yml
+++ b/services/iso-loader-nfs.yml
@@ -1,0 +1,83 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: iso-loader-nfs
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: iso-loader-nfs
+    spec:
+      containers:
+      - name: iso-loader-nfs
+        image: djnos/docker-nfs-server:feat-qwant
+        imagePullPolicy: IfNotPresent
+        securityContext:
+          privileged: true
+        env:
+        - name: NFS_EXPORT_0
+          value: '/data                  *(ro,no_subtree_check)'
+        resources:
+          limits:
+            cpu: 100m
+            memory: 200Mi
+        volumeMounts:
+        - name: cephfs
+          mountPath: /data
+        - name: modules
+          mountPath: /lib/modules
+          readOnly: true
+      volumes:
+      - name: cephfs
+        flexVolume:
+          driver: ceph.rook.io/rook
+          fsType: ceph
+          options:
+            fsName: cephfs
+            clusterName: rook-ceph
+      - name: modules
+        hostPath:
+          path: /lib/modules
+          type: Directory
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: nfs-service
+spec:
+  selector:
+    app: iso-loader-nfs
+  ports:
+    - name: tcp-2049
+      port: 2049
+      protocol: TCP
+      targetPort: 2049
+    - name: udp-2049
+      port: 2049
+      protocol: UDP
+      targetPort: 2049
+    - name: tcp-111
+      port: 111
+      protocol: TCP
+      targetPort: 111
+    - name: udp-111
+      port: 111
+      protocol: UDP
+      targetPort: 111
+    - name: tcp-32765
+      port: 32765
+      protocol: TCP
+      targetPort: 32765
+    - name: udp-32765
+      port: 32765
+      protocol: UDP
+      targetPort: 32765
+    - name: tcp-32767
+      port: 32767
+      protocol: TCP
+      targetPort: 32767
+    - name: udp-32767
+      port: 32767
+      protocol: UDP
+      targetPort: 32767


### PR DESCRIPTION
Offer an alternative deployment for dxie iso-loader.
Idea behind that (and experience) is that in a small cluster, if you aggregate your worker nodes storage in a hyperconvergent spirit and offer it to ceph as osds, fact is that your DHCP (dgxie) running into the kube cluster have a hard dependency on a ceph flex volume, and if for any reason (just a kube worker node reboot) your volume gets unavailable, you lose your dgxie pod, so you lose your DHCP and then you lose all your worker nodes, that is something we faced to many time with deepops, the solution we found to take over incident was to modify the dgxie helm chart bundle to mount an empty volume to make dgxie run again and we retrieve all worker nodes thanks to dhcp and then the ceph cluster gone back healthy.
Here the idea, is to use a NFS mount command from dgxie pod to offer the ISO, that way, dgxie become ceph fault tolerant. I tested it turning off all my worker nodes, my dgxie pod stayed up and I "just" lost the NFS iso wrapper pods, when I turned on the worker nodes, the dgxie container retrieved its NFS mount itself.
Maybe it looks like a tricky thing but we have a great robustness gain that I would like to share.

You can find the iso loader container build chain here: https://github.com/hightoxicity/docker-nfs-server/tree/feat-qwant if you want to replace by one you build.

Thx.