### PR TITLE
virtual - allow `up` without `--no-parallel`

### DIFF
--- a/virtual/Vagrantfile
+++ b/virtual/Vagrantfile
@@ -2,11 +2,10 @@ VAGRANTFILE_API_VERSION = "2"
 BOX_IMAGE = "generic/ubuntu1804"
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
-  config.hostmanager.enabled = true
   config.hostmanager.manage_host = true
   config.hostmanager.manage_guest = true
-  config.hostmanager.ignore_private_ip = false
   config.hostmanager.include_offline = true
+  config.vm.provision :hostmanager
 
   config.vm.define "virtual-mgmt" do |mgmt|
     mgmt.vm.provider "libvirt" do |v|

--- a/virtual/scripts/setup_vagrant.sh
+++ b/virtual/scripts/setup_vagrant.sh
@@ -6,7 +6,7 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 VIRT_DIR="${SCRIPT_DIR}/.."
 
 #####################################
-# Set up VMs for virtual cluster 
+# Set up VMs for virtual cluster
 #####################################
 
 # Ensure we're in the right directory for Vagrant
@@ -16,7 +16,7 @@ cd "${VIRT_DIR}" || exit 1
 vagrant global-status --prune
 
 # Start vagrant via libvirt - set up the VMs
-vagrant up --no-parallel --provider=libvirt
+vagrant up --provider=libvirt
 
 # Show the running VMs
 virsh list


### PR DESCRIPTION
Before:
```
$ time vagrant up --no-parallel
real    1m16.901s
user    0m3.042s
sys     0m0.391s
```
After:
```
$ time vagrant up
real    0m33.220s
user    0m3.180s
sys     0m0.421s
```