### PR TITLE
Fix bootstrap refs

### DIFF
--- a/docs/dgx-pod.md
+++ b/docs/dgx-pod.md
@@ -180,7 +180,8 @@ SSH keys and sudo does not require a password, you may omit the `-k` and `-K`
 flags
 
 ```sh
-ansible-playbook -l management -k -K ansible/playbooks/bootstrap.yml
+ansible-playbook -l management -k -K ansible/playbooks/bootstrap-ssh.yml
+ansible-playbook -l management -k -K ansible/playbooks/bootstrap-sudo.yml
 ```
 
 Where `management` is the group of servers in your `config/inventory` file which will become
@@ -509,7 +510,8 @@ Type the default password for `dgxuser` on the DGX when prompted while running t
 The default password for `dgxuser` is `DgxUser123`:
 
 ```sh
-ansible-playbook -k -K -l dgx-servers ansible/playbooks/bootstrap.yml
+ansible-playbook -k -K -l dgx-servers ansible/playbooks/bootstrap-ssh.yml
+ansible-playbook -k -K -l dgx-servers ansible/playbooks/bootstrap-sudo.yml
 ```
 
 After running the first command, you may omit the `-K` flag on subsequent runs. The password
@@ -736,7 +738,8 @@ Modify the file `ansible/site.yml` to enable or disable various playbooks, or ru
 directly:
 
 ```sh
-ansible-playbook -k -K -l login ansible/playbooks/bootstrap.yml
+ansible-playbook -k -K -l login ansible/playbooks/bootstrap-ssh.yml
+ansible-playbook -k -K -l login ansible/playbooks/bootstrap-sudo.yml
 ansible-playbook -k -l login ansible/site.yml
 ```
 

--- a/playbooks/k8s-cluster.yml
+++ b/playbooks/k8s-cluster.yml
@@ -2,7 +2,7 @@
 # Kubernetes Cluster Playbook
 
 # Install python required for Ansible
-- include: bootstrap-ansible.yml
+- include: bootstrap-python.yml
   tags:
     - bootstrap
 
@@ -21,7 +21,10 @@
     - local
 
 # Set up passwordless sudo and SSH keys if needed
-- include: bootstrap.yml
+- include: bootstrap-ssh.yml
+  tags:
+    - bootstrap
+- include: bootstrap-sudo.yml
   tags:
     - bootstrap
 

--- a/playbooks/slurm-cluster.yml
+++ b/playbooks/slurm-cluster.yml
@@ -2,10 +2,11 @@
 # Slurm Cluster Playbook
 
 # Install python required for Ansible
-- include: bootstrap-ansible.yml
+- include: bootstrap-python.yml
 
 # Set up passwordless sudo and SSH keys if needed
-- include: bootstrap.yml
+- include: bootstrap-ssh.yml
+- include: bootstrap-sudo.yml
 
 # Set root SSH key to allow SSH/ansible when no slurm job running for ansible user
 - hosts: all


### PR DESCRIPTION
There were some leftover references to bootstrap playbook names changed in #143. Tested by turning up a virtual k8s cluster with `virtual/cluster_up.sh` and verifying it succeeds.

Also fixed some references in the dgx-pod.md doc.

Verified no other dangling references:

```
adeconinck@ubuntu-desktop:~/src/deepops$ grep -R bootstrap-ansible .
adeconinck@ubuntu-desktop:~/src/deepops$
adeconinck@ubuntu-desktop:~/src/deepops$ grep -R bootstrap.yml .
Binary file ./.git/index matches
adeconinck@ubuntu-desktop:~/src/deepops$
```