### PR TITLE
Fixes to virtual Slurm cluster to run simple jobs

### DIFF
--- a/roles/slurm/defaults/main.yml
+++ b/roles/slurm/defaults/main.yml
@@ -33,3 +33,6 @@ slurm_exclusive: "EXCLUSIVE"
 # Sets: DefaultTime={{ slurm_default_job_timelimit }}
 # Default: <not included>
 # slurm_default_job_timelimit: 
+
+# Use the provided prolog/epilog
+slurm_enable_prolog_epilog: true

--- a/roles/slurm/tasks/compute.yml
+++ b/roles/slurm/tasks/compute.yml
@@ -1,11 +1,5 @@
 ---
 
-- name: install apt requirements
-  apt:
-    name: "{{ item }}"
-  with_items:
-    - linux-tools-generic  # for cpupower, used in prolog+epilog
-
 - name: fail if NVIDIA driver not installed
   command: which nvidia-smi
   changed_when: false
@@ -52,92 +46,9 @@
   with_fileglob:
     - shared/bin/*
 
-- name: create prolog directories
-  file:
-    path: "{{ item }}"
-    state: directory
-    owner: slurm
-    group: slurm
-    mode: 0755
-  with_items:
-    - /etc/slurm/prolog.d/
-    - /etc/slurm/prolog-exclusive.d/
-  tags:
-    - prolog
-
-- name: create epilog directories
-  file:
-    path: "{{ item }}"
-    state: directory
-    owner: slurm
-    group: slurm
-    mode: 0755
-  with_items:
-    - /etc/slurm/epilog.d/
-    - /etc/slurm/epilog-exclusive.d/
-    - /etc/slurm/epilog-last-user.d/
-  tags:
-    - epilog
-
-- name: copy prologs
-  copy:
-    src: "{{ item }}"
-    dest: /etc/slurm/prolog.d/
-    owner: slurm
-    group: slurm
-    mode: 0755
-  with_fileglob:
-    - prolog.d/*
-  tags:
-    - prolog
-
-- name: copy prologs
-  copy:
-    src: "{{ item }}"
-    dest: /etc/slurm/prolog-exclusive.d/
-    owner: slurm
-    group: slurm
-    mode: 0755
-  with_fileglob:
-    - prolog-exclusive.d/*
-  tags:
-    - prolog
-
-- name: copy epilogs
-  copy:
-    src: "{{ item }}"
-    dest: /etc/slurm/epilog.d/
-    owner: slurm
-    group: slurm
-    mode: 0755
-  with_fileglob:
-    - epilog.d/*
-  tags:
-    - epilog
-
-- name: copy epilogs
-  copy:
-    src: "{{ item }}"
-    dest: /etc/slurm/epilog-exclusive.d/
-    owner: slurm
-    group: slurm
-    mode: 0755
-  with_fileglob:
-    - epilog-exclusive.d/*
-  tags:
-    - epilog
-
-- name: copy epilogs
-  copy:
-    src: "{{ item }}"
-    dest: /etc/slurm/epilog-last-user.d/
-    owner: slurm
-    group: slurm
-    mode: 0755
-  with_fileglob:
-    - epilog-last-user.d/*
-  tags:
-    - epilog
+- name: include prolog/epilog
+  include: prolog_epilog.yml
+  when: slurm_enable_prolog_epilog
 
 - name: copy configuration files
   template:

--- a/roles/slurm/tasks/prolog_epilog.yml
+++ b/roles/slurm/tasks/prolog_epilog.yml
@@ -1,0 +1,94 @@
+---
+- name: install apt requirements
+  apt:
+    name: "{{ item }}"
+  with_items:
+    - linux-tools-generic  # for cpupower, used in prolog+epilog
+
+- name: create prolog directories
+  file:
+    path: "{{ item }}"
+    state: directory
+    owner: slurm
+    group: slurm
+    mode: 0755
+  with_items:
+    - /etc/slurm/prolog.d/
+    - /etc/slurm/prolog-exclusive.d/
+  tags:
+    - prolog
+
+- name: create epilog directories
+  file:
+    path: "{{ item }}"
+    state: directory
+    owner: slurm
+    group: slurm
+    mode: 0755
+  with_items:
+    - /etc/slurm/epilog.d/
+    - /etc/slurm/epilog-exclusive.d/
+    - /etc/slurm/epilog-last-user.d/
+  tags:
+    - epilog
+
+- name: copy prologs
+  copy:
+    src: "{{ item }}"
+    dest: /etc/slurm/prolog.d/
+    owner: slurm
+    group: slurm
+    mode: 0755
+  with_fileglob:
+    - prolog.d/*
+  tags:
+    - prolog
+
+- name: copy prologs
+  copy:
+    src: "{{ item }}"
+    dest: /etc/slurm/prolog-exclusive.d/
+    owner: slurm
+    group: slurm
+    mode: 0755
+  with_fileglob:
+    - prolog-exclusive.d/*
+  tags:
+    - prolog
+
+- name: copy epilogs
+  copy:
+    src: "{{ item }}"
+    dest: /etc/slurm/epilog.d/
+    owner: slurm
+    group: slurm
+    mode: 0755
+  with_fileglob:
+    - epilog.d/*
+  tags:
+    - epilog
+
+- name: copy epilogs
+  copy:
+    src: "{{ item }}"
+    dest: /etc/slurm/epilog-exclusive.d/
+    owner: slurm
+    group: slurm
+    mode: 0755
+  with_fileglob:
+    - epilog-exclusive.d/*
+  tags:
+    - epilog
+
+- name: copy epilogs
+  copy:
+    src: "{{ item }}"
+    dest: /etc/slurm/epilog-last-user.d/
+    owner: slurm
+    group: slurm
+    mode: 0755
+  with_fileglob:
+    - epilog-last-user.d/*
+  tags:
+    - epilog
+

--- a/roles/slurm/templates/slurm.conf
+++ b/roles/slurm/templates/slurm.conf
@@ -41,8 +41,10 @@ PropagateResourceLimitsExcept=MEMLOCK
 {% if slurm_contain_ssh is defined %}
 PrologFlags=contain
 {% endif %}
+{% if slurm_enable_prolog_epilog %}
 Prolog=/etc/slurm/prolog.d/*
 Epilog=/etc/slurm/epilog.d/*
+{% endif %}
 MailProg=/usr/bin/s-nail
 #SrunProlog=
 #SrunEpilog=

--- a/virtual/scripts/setup_slurm.sh
+++ b/virtual/scripts/setup_slurm.sh
@@ -13,7 +13,16 @@ ROOT_DIR="${SCRIPT_DIR}/../.."
 # Move working directory to root of DeepOps repo
 cd "${ROOT_DIR}" || exit 1
 
+# Configure Slurm cluster
 ansible-playbook \
 	-i "${VIRT_DIR}/config/inventory" \
 	-l slurm-cluster \
+	-e "@${VIRT_DIR}/vars_files/virt_slurm.yml" \
 	"${ROOT_DIR}/playbooks/slurm-cluster.yml"
+
+# Configure NFS for /shared
+ansible-playbook \
+	-i "${VIRT_DIR}/config/inventory" \
+	-l slurm-cluster \
+	-e "@${VIRT_DIR}/vars_files/virt_slurm.yml" \
+	"${ROOT_DIR}/playbooks/nfs.yml"

--- a/virtual/vars_files/virt_slurm.yml
+++ b/virtual/vars_files/virt_slurm.yml
@@ -1,0 +1,17 @@
+---
+# Configure a global NFS share across the slurm cluster
+nfs_mounts:
+- mountpoint: "/shared"
+  path: "/shared"
+  options: "nfsvers=3,rw,sync"
+
+nfs_exports:
+- path: "/shared"
+  options: "*(rw,sync)"
+
+# For virtual cluster, ensure hosts file correctly uses private network
+hosts_add_default_ipv4: false
+hosts_network_interface: "eth1"
+
+# Hardware-specific prolog/epilog may not work in virtual
+slurm_enable_prolog_epilog: false


### PR DESCRIPTION
Making a few changes to successfully run simple jobs in the virtual slurm cluster. This are some incremental changes I made in the course of using the virtual cluster to test some simple workflow examples.

- Disable prolog/epilog in virtual cluster because some HW config scripts are not supported in VMs, e.g. setting CPU performance mode
- Add an NFS shared filesystem mounted at `/shared`

Test plan:

```
vagrant@virtual-login:/shared$ ls
hello.sh
vagrant@virtual-login:/shared$ cat hello.sh
#!/bin/bash
echo "Hello, world from $(hostname)"
vagrant@virtual-login:/shared$ salloc -n1
salloc: Granted job allocation 5
vagrant@virtual-login:/shared$ srun -n1 /shared/hello.sh
Hello, world from virtual-gpu01
vagrant@virtual-login:/shared$ exit
exit
salloc: Relinquishing job allocation 5
salloc: Job allocation 5 has been revoked.
vagrant@virtual-login:/shared$
```