### PR TITLE
Add a simple Slurm + MPI Hello, World example

### DIFF
--- a/examples/slurm-mpi-hello/README.md
+++ b/examples/slurm-mpi-hello/README.md
@@ -1,0 +1,79 @@
+"Hello, World" with MPI on a Slurm cluster
+==========================================
+
+Slurm is an open-source job scheduling system for Linux clusters, most frequently used for high-performance computing (HPC) applications.
+Many HPC applications are built on the Message Passing Interface (MPI) standard, which allows multiple processes in an application to communicate across nodes.
+
+This example demonstrates how to build and run simple "hello, world" MPI application on a Slurm cluster.
+It assumes that you have already deployed a cluster with a login node and at least one compute node, and that Slurm has already been set up and configured.
+It also assumes the presence of a shared NFS filesystem on all nodes in the cluster, which is given the path `/shared` in this example.
+If you haven't configured a Slurm cluster yet, see the [Slurm guide](/docs/slurm-cluster.md) for information on building a GPU-enabled Slurm cluster.
+
+1. **Install the OpenMPI packages:**
+    On many clusters, MPI libraries and tools are built from source to take advantage of the specific cluster hardware.
+    In this example, we'll just use the OpenMPI provided by Ubuntu to demonstrate running an MPI job.
+    To install OpenMPI, run the `bootstrap-mpi.yml` Ansible playbook in this directory. 
+    If you only want to install on a subset of nodes, use the `-l ${HOST_GROUP}` argument to restrict where this playbook is run.
+    ```
+    $ ansible-playbook -i ${INVENTORY_FILE} [-l ${HOST_GROUP}] examples/slurm-mpi-hello/bootstrap-mpi.yml
+    ```
+1. Upload the source code and job script to the shared filesystem on your login node:
+    ```
+    $ scp examples/slurm-mpi-hello/mpi-hello.c login:/shared/
+    ```
+1. Log into your cluster and build the MPI application.
+    ```
+    $ ssh login
+    $ cd /shared
+    $ mpicc -o mpi-hello mpi-hello.c
+    ```
+1. One way to run Slurm jobs is in "interactive" mode, where you get a resource allocation and then launch processes by hand.
+    To run our hello app interactively, you can do the following:
+
+    ```
+    # Validate that we're on the login node
+    $ hostname
+    login
+
+    # Allocate two processors from Slurm
+    # (in this case, both processors are on the same node)
+    $ salloc -n 2
+    salloc: Granted job allocation 7
+
+    # Run the MPI application using mpirun
+    $ mpirun -np 2 /shared/mpi-hello
+    Hello from process 0 of 2 on host virtual-gpu01
+    Hello from process 1 of 2 on host virtual-gpu01
+
+    # Release the allocation
+    $ exit
+    exit
+    salloc: Relinquishing job allocation 7
+    salloc: Job allocation 7 has been revoked.
+    ```
+1. The other way to run a Slurm job is using a batch script.
+    This is just a shell script which contains the commands needed to run your app,
+    as well as comments prefixed `#SBATCH` which tell Slurm about the job you're running.
+    The output of your job is saved to a file.
+    ```
+    $ cat hello-job.sh
+    #!/bin/bash
+    #SBATCH -J mpi-hello            # Job name
+    #SBATCH -n 2                    # Number of processes
+    #SBATCH -t 0:10:00              # Max wall time
+    #SBATCH -o hello-job.out        # Output file name
+    
+    # Disable the Infiniband transport for OpenMPI (not present on all clusters)
+    export OMPI_MCA_btl="^openib"
+    
+    # Run the job (assumes the batch script is submitted from the same directory)
+    mpirun -np 2 ./mpi-hello
+    
+    $ sbatch hello-job.sh
+    Submitted batch job 9
+    $ cat hello-job.out
+    Hello from process 0 of 2 on host virtual-gpu01
+    Hello from process 1 of 2 on host virtual-gpu01
+    ```
+
+To learn more about how to use Slurm, see the [Slurm user documentation](https://slurm.schedmd.com/documentation.html).

--- a/examples/slurm-mpi-hello/bootstrap-mpi.yml
+++ b/examples/slurm-mpi-hello/bootstrap-mpi.yml
@@ -1,0 +1,13 @@
+---
+# Install OpenMPI packages from Ubuntu repos
+- hosts: all
+  become: true
+  tasks:
+  - name: install openmpi packages
+    apt:
+      name: "{{ item }}"
+    with_items:
+    - openmpi-bin
+    - libopenmpi-dev
+    - libpmi2-pmix
+    - libpmi-pmix-dev

--- a/examples/slurm-mpi-hello/hello-job.sh
+++ b/examples/slurm-mpi-hello/hello-job.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+#SBATCH -J mpi-hello            # Job name
+#SBATCH -n 2                    # Number of processes
+#SBATCH -t 0:10:00              # Max wall time
+#SBATCH -o hello-job.out        # Output file name
+
+# Disable the Infiniband transport for OpenMPI (not present on all clusters)
+export OMPI_MCA_btl="^openib"
+
+# Run the job (assumes the batch script is submitted from the same directory)
+mpirun -np 2 ./mpi-hello

--- a/examples/slurm-mpi-hello/mpi-hello.c
+++ b/examples/slurm-mpi-hello/mpi-hello.c
@@ -1,0 +1,26 @@
+#include <mpi.h>
+#include <unistd.h>
+#include <stdio.h>
+
+int main(int argc, char **argv) {
+    // Initialize MPI
+    MPI_Init(&argc, &argv);
+
+    // Get the number of processes in the global communicator
+    int count;
+    MPI_Comm_size(MPI_COMM_WORLD, &count);
+
+    // Get the rank of the current process
+    int rank;
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+
+    // Get the current hostname
+    char hostname[1024];
+    gethostname(hostname, sizeof(hostname));
+
+    // Print a hello world message for this rank
+    printf("Hello from process %d of %d on host %s\n", rank, count, hostname);
+
+    // Finalize the MPI environment before exiting
+    MPI_Finalize();
+}


### PR DESCRIPTION
(Take 2! This is a re-do after I messed up PR #160.)

Getting the examples section started with a very simple MPI example,
demonstrated to work in a virtual Slurm DeepOps cluster.

While we will want to have some more impressive examples, e.g. Deep
Learning training and all that jazz, we should also have some simple and
clear examples that are easy for new users to build on and get running.
This example is about as simple as you can get while still being an MPI,
but also provides a Slurm usage example.

Next one I'm working on is an equivalent "hello, world" Flask service
running in k8s, but running into fun with the registry which is delaying
that. So might as well open a PR for this on its own. :)