### PR TITLE
Fix role name after ansible_users renamed

### DIFF
--- a/playbooks/user-password.yml
+++ b/playbooks/user-password.yml
@@ -23,7 +23,7 @@
         ssh_max_auth_retries: 10
     - name: Set user password
       include_role:
-        name: unxnn.ansible_users
+        name: unxnn.users
       vars:
         # User Configuration
         users:

--- a/requirements.yml
+++ b/requirements.yml
@@ -3,7 +3,7 @@
 - src: dev-sec.ssh-hardening
   version: "6.0.0"
 
-- src: unxnn.ansible_users
+- src: unxnn.users
   version: 'fca2c5a6962db7696329c32a919d3d88cc8623c4'
 
 - src: geerlingguy.docker


### PR DESCRIPTION
The unxnn.ansible_users role was renamed to unxnn.users in this commit
to the source repository:
unxnn/ansible-users@56f9436

It was subsequently pushed to Ansible Galaxy with the new name, which
appears to have invalidated references to the old name. :( The result
was that, on a fresh checkout of DeepOps, I ran into the following error
when turning up a new virtual cluster:

```
ubuntu@ivb120:~/src/deepops/virtual$ ./cluster_up.sh
+++ dirname ./cluster_up.sh
++ cd .
++ pwd
+ VIRT_DIR=/home/ubuntu/src/deepops/virtual
+ ROOT_DIR=/home/ubuntu/src/deepops/virtual/..
+ cd /home/ubuntu/src/deepops/virtual/..
+ ansible-galaxy install -r
/home/ubuntu/src/deepops/virtual/../requirements.yml
- dev-sec.ssh-hardening (6.0.0) is already installed, skipping.
- downloading role 'ansible_users', owned by unxnn
 [WARNING]: - unxnn.ansible_users was NOT installed successfully: -
sorry, unxnn.ansible_users was not found on https://galaxy.ansib

ERROR! - you can use --ignore-errors to skip failed roles and finish
processing the list.
```

After changing the name of the role in requirements.yml, I was able to
successfully install the role and turn up the virtual cluster. Given
that we pin the role by git commit hash and it still installed
correctly, this is pretty good evidence it's exactly the same role and
just the name changed.