### PR TITLE
Requirements.yml 'unxnn' name change

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -3,8 +3,8 @@
 - src: dev-sec.ssh-hardening
   version: "6.0.0"
 
-- src: unxnn.ansible_users
-  version: 'fca2c5a6962db7696329c32a919d3d88cc8623c4'
+- src: unxnn.users
+  version: '56f9436e0d1e92a743e9f960d0b978ac8b72e070'
 
 - src: geerlingguy.docker
   version: "2.5.2"


### PR DESCRIPTION
I think you need to change “unxnn.ansible_users” to “unxnn.users” in the Requirements.yml file.

Is it okay that the version change as below?

fca2c5a6962db7696329c32a919d3d88cc8623c4
--> 56f9436e0d1e92a743e9f960d0b978ac8b72e070