### PR TITLE
Add support for running CentOS in virtual cluster

### DIFF
--- a/virtual/README.md
+++ b/virtual/README.md
@@ -16,7 +16,7 @@ Also, using VMs and optionally GPU passthrough assumes that the host machine has
 enable virtualization in the BIOS. For instructions on how to accomplish this, refer to the sections
 at the bottom of this README: `Enabling virtualization and GPU passthrough`.
 
-## Bootstrap virtual
+## Bootstrap virtualization dependencies
 
 This project leverages vagrant and libvirt to spin up the appropriate VMs to model a DeepOps
 cluster. To install the necessary dependencies, such as ansible, vagrant, libvirt, etc, run the
@@ -28,6 +28,16 @@ $ ./setup.sh
 
 After you've run this, it's a good idea to start a fresh login shell to ensure your environment is up to date.
 For example, you will need to be in the "libvirt" group to mangage VMs, but your current session won't include this group if libvirt was just installed.
+
+## Select the Vagrant file for your Linux distro
+
+If you want to run your virtual cluster on CentOS, set the `DEEPOPS_VAGRANT_FILE` variable to point to the CentOS Vagrant file:
+
+```
+$ export DEEPOPS_VAGRANT_FILE=./Vagrantfile-centos
+```
+
+If you want to use Ubuntu, you can set this variable to point to the Ubuntu Vagrant file, or just leave it unset (Ubuntu is the default).
 
 ## Start the cluster
 
@@ -47,15 +57,15 @@ list`...
 $ virsh list
  Id    Name                           State
 ----------------------------------------------------
- 7     vagrant_mgmt                   running
- 8     vagrant_login                  running
- 9     vagrant_gpu01                  running
+ 22    virtual_virtual-mgmt           running
+ 23    virtual_virtual-gpu01          running
+ 24    virtual_virtual-login          running
 ```
 
 Connect to any of the nodes via vagrant ssh...
 
 ```
-$ vagrant ssh gpu01
+$ vagrant ssh virtual-gpu01
 ```
 
 ## Destroy the cluster

--- a/virtual/Vagrantfile-centos
+++ b/virtual/Vagrantfile-centos
@@ -1,0 +1,43 @@
+VAGRANTFILE_API_VERSION = "2"
+BOX_IMAGE = "centos/7"
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+  config.ssh.insert_key = false
+  config.ssh.private_key_path = ["~/.ssh/id_rsa", "~/.vagrant.d/insecure_private_key"]
+  config.vm.provision "file", source: "~/.ssh/id_rsa.pub", destination: "~/.ssh/authorized_keys"
+
+  config.hostmanager.manage_host = true
+  config.hostmanager.manage_guest = true
+  config.hostmanager.include_offline = true
+  config.vm.provision :hostmanager
+
+  config.vm.define "virtual-mgmt" do |mgmt|
+    mgmt.vm.provider "libvirt" do |v|
+      v.memory = 2048
+    end
+    mgmt.vm.box = BOX_IMAGE
+    mgmt.vm.hostname = "virtual-mgmt"
+    mgmt.vm.network :private_network, ip: "10.0.0.2"
+  end
+
+  config.vm.define "virtual-login" do |login|
+    login.vm.box = BOX_IMAGE
+    login.vm.hostname = "virtual-login"
+    login.vm.network :private_network, ip: "10.0.0.4"
+  end
+
+  config.vm.define "virtual-gpu01" do |gpu|
+    config.vm.provider "libvirt" do |v|
+      v.memory = 16384
+      v.cpus = 2
+      v.machine_type = "q35"
+      v.cpu_mode = "host-passthrough"
+      # comment in for pci passthrough (and change bus according
+      # to local hw setup - `lspci -nnk | grep NVIDIA`)
+      #v.pci :bus => '0x08', :slot => '0x00', :function => '0x0'
+    end
+    gpu.vm.box = BOX_IMAGE
+    gpu.vm.hostname = "virtual-gpu01"
+    gpu.vm.network :private_network, ip: "10.0.0.11"
+  end
+end

--- a/virtual/Vagrantfile-ubuntu
+++ b/virtual/Vagrantfile-ubuntu
@@ -2,6 +2,10 @@ VAGRANTFILE_API_VERSION = "2"
 BOX_IMAGE = "generic/ubuntu1804"
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+  config.ssh.insert_key = false
+  config.ssh.private_key_path = ["~/.ssh/id_rsa", "~/.vagrant.d/insecure_private_key"]
+  config.vm.provision "file", source: "~/.ssh/id_rsa.pub", destination: "~/.ssh/authorized_keys"
+
   config.hostmanager.manage_host = true
   config.hostmanager.manage_guest = true
   config.hostmanager.include_offline = true

--- a/virtual/k8s_hosts.ini
+++ b/virtual/k8s_hosts.ini
@@ -1,6 +1,6 @@
 [all:vars]
 ansible_user=vagrant
-ansible_password=vagrant
+ansible_ssh_private_key_file="~/.ssh/id_rsa"
 
 [all]
 node1 	 ansible_host=10.0.0.2 ip=10.0.0.2

--- a/virtual/scripts/setup_vagrant.sh
+++ b/virtual/scripts/setup_vagrant.sh
@@ -9,6 +9,15 @@ VIRT_DIR="${SCRIPT_DIR}/.."
 # Set up VMs for virtual cluster
 #####################################
 
+# Create SSH key in default location if it doesn't exist
+yes n | ssh-keygen -q -t rsa -f ~/.ssh/id_rsa -C "" -N "" || echo "key exists"
+
+# Default to using provided Ubuntu Vagrantfile
+if [ -z "${DEEPOPS_VAGRANT_FILE}" ]; then
+	DEEPOPS_VAGRANT_FILE="${VIRT_DIR}/Vagrantfile-ubuntu"
+fi
+cp "${DEEPOPS_VAGRANT_FILE}" "${VIRT_DIR}/Vagrantfile"
+
 # Ensure we're in the right directory for Vagrant
 cd "${VIRT_DIR}" || exit 1
 


### PR DESCRIPTION
- Add an alternate Vagrantfile which uses CentOS Vagrant box
- Add an environment variable used by `virtual/scripts/setup_vagrant.sh`
to select the right Vagrantfile
- Vagrant uses key-based auth because the CentOS box disables password
auth