### PR TITLE
Clear facts cache in virtual turnup

### DIFF
--- a/virtual/cluster_up.sh
+++ b/virtual/cluster_up.sh
@@ -20,6 +20,9 @@ export DEEPOPS_CONFIG_DIR="${VIRT_DIR}/config"
 cp -r "${ROOT_DIR}/config.example/" "${DEEPOPS_CONFIG_DIR}/"
 cp "${VIRT_DIR}/virtual_inventory" "${DEEPOPS_CONFIG_DIR}/inventory"
 
+# Clear any stale fact cache in Ansible
+ansible -m meta -a "clear_facts" -i "${DEEPOPS_CONFIG_DIR}/inventory" all
+
 # Set up VMs for the virtual cluster
 "${VIRT_DIR}"/scripts/setup_vagrant.sh
 


### PR DESCRIPTION
I use the virtual cluster for a lot of iterative testing and
development, and do wacky things like switch between Ubuntu and CentOS.
However, Ansible caches facts based on the cluster hostname... which led
to an annoying condition where a CentOS host thought its
`ansible_os_family` was Debian.

This change adds a command to the virtual `cluster_up.sh` script that
nukes any cached facts about the hosts in inventory. This should help
make sure fresh turnups are actually fresh.

Tested by using this command to fix the bug above, and by kicking off a
cluster turnup with the command in place and verifying nothing broke. :)