### PR TITLE
Add optional pre-commit hook to lint changed files

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,0 +1,6 @@
+---
+exclude_paths:
+- ./galaxy-roles/
+- ./kubespray/
+use_default_rules: true
+verbosity: 2

--- a/.githooks/check-ansible.py
+++ b/.githooks/check-ansible.py
@@ -1,8 +1,14 @@
 #!/usr/bin/env python
+"""
+Get a list of Ansible playbooks and roles that have changes staged in Git.
+Run ansible-lint on only those playbooks and roles.
+"""
+
 
 from __future__ import print_function
 import subprocess
 import re
+
 
 def get_changed_ansible_paths():
     """
@@ -17,7 +23,18 @@ def get_changed_ansible_paths():
         # Add role directories
         role_match = re.match(r"^roles/(\w+)/.*", f)
         if role_match:
-            ansible_lint_paths_to_check.append(role_match.group(1))
+            ansible_lint_paths_to_check.append(
+                "roles/{}".format(role_match.group(1)))
     return ansible_lint_paths_to_check
 
-print(get_changed_ansible_paths())
+
+def run_ansible_lint(paths):
+    cmd = ["ansible-lint"] + paths
+    subprocess.call(cmd)
+
+
+if __name__ == "__main__":
+    paths = get_changed_ansible_paths()
+    print(paths)
+    if len(paths) > 0:
+        run_ansible_lint(paths)

--- a/.githooks/check-ansible.py
+++ b/.githooks/check-ansible.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python
+
+from __future__ import print_function
+import subprocess
+import re
+
+def get_changed_ansible_paths():
+    """
+    Get a list of playbook files and role directories that are staged for commit
+    """
+    git_diff = subprocess.check_output("git diff --name-only --cached".split())
+    ansible_lint_paths_to_check = []
+    for f in git_diff.split("\n"):
+        # Add playbook files
+        if re.match(r"^playbooks/.*(yml|yaml)$", f):
+            ansible_lint_paths_to_check.append(f)
+        # Add role directories
+        role_match = re.match(r"^roles/(\w+)/.*", f)
+        if role_match:
+            ansible_lint_paths_to_check.append(role_match.group(1))
+    return ansible_lint_paths_to_check
+
+print(get_changed_ansible_paths())

--- a/.githooks/check-ansible.py
+++ b/.githooks/check-ansible.py
@@ -35,6 +35,6 @@ def run_ansible_lint(paths):
 
 
 if __name__ == "__main__":
-    paths = get_changed_ansible_paths()
-    if len(paths) > 0:
-        sys.exit(run_ansible_lint(paths))
+    changed = get_changed_ansible_paths()
+    if len(changed) > 0:
+        sys.exit(run_ansible_lint(changed))

--- a/.githooks/check-ansible.py
+++ b/.githooks/check-ansible.py
@@ -8,6 +8,7 @@ Run ansible-lint on only those playbooks and roles.
 from __future__ import print_function
 import subprocess
 import re
+import sys
 
 
 def get_changed_ansible_paths():
@@ -30,11 +31,10 @@ def get_changed_ansible_paths():
 
 def run_ansible_lint(paths):
     cmd = ["ansible-lint"] + paths
-    subprocess.call(cmd)
+    return subprocess.call(cmd)
 
 
 if __name__ == "__main__":
     paths = get_changed_ansible_paths()
-    print(paths)
     if len(paths) > 0:
-        run_ansible_lint(paths)
+        sys.exit(run_ansible_lint(paths))

--- a/.githooks/check-python.py
+++ b/.githooks/check-python.py
@@ -11,22 +11,22 @@ import re
 import sys
 
 
-def get_changed_shell_paths():
+def get_changed_paths():
     git_diff = subprocess.check_output("git diff --name-only --cached".split())
     paths = []
     for f in git_diff.split("\n"):
         # Add playbook files
-        if re.match(r".*(\.sh|\.bash)$", f):
+        if re.match(r".*(\.py)$", f):
             paths.append(f)
     return paths
 
 
 def run_lint(paths):
-    cmd = ["shellcheck", "-x"] + paths
+    cmd = ["pylint", "-rn", "-sn", "-d", "R,C"] + paths
     return subprocess.call(cmd)
 
 
 if __name__ == "__main__":
-    changed = get_changed_shell_paths()
+    changed = get_changed_paths()
     if len(changed) > 0:
         sys.exit(run_lint(changed))

--- a/.githooks/check-python.py
+++ b/.githooks/check-python.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 """
-Get a list of changed bash scripts that are staged for commit.
+Get a list of changed python scripts that are staged for commit.
 Run shellcheck on only those files.
 """
 

--- a/.githooks/check-shell.py
+++ b/.githooks/check-shell.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python
+"""
+Get a list of changed bash scripts that are staged for commit.
+Run shellcheck on only those files.
+"""
+
+
+from __future__ import print_function
+import subprocess
+import re
+import sys
+
+
+def get_changed_shell_paths():
+    git_diff = subprocess.check_output("git diff --name-only --cached".split())
+    paths = []
+    for f in git_diff.split("\n"):
+        # Add playbook files
+        if re.match(r".*(\.sh|\.bash)$", f):
+            paths.append(f)
+    return paths
+
+
+def run_lint(paths):
+    cmd = ["shellcheck", "-x"] + paths
+    return subprocess.call(cmd)
+
+
+if __name__ == "__main__":
+    paths = get_changed_shell_paths()
+    if len(paths) > 0:
+        sys.exit(run_lint(paths))

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -4,11 +4,24 @@ if [ "${DEEPOPS_BYPASS_LINT}" ]; then
 	exit 0
 fi
 
+FAILED=0
+
 # Lint changed Ansible files
-.githooks/check-ansible.py
+if ! .githooks/check-ansible.py; then
+	FAILED=1
+	echo "Failed Ansible lint"
+fi
 
 # Lint changed shell scripts
-.githooks/check-shell.py
+if ! .githooks/check-shell.py; then
+	FAILED=1
+	echo "Failed shell lint"
+fi
 
 # Lint changed Python files
-.githooks/check-python.py
+if ! .githooks/check-python.py; then
+	FAILED=1
+	echo "Failed python lint"
+fi
+
+exit ${FAILED}

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+if [ "${DEEPOPS_BYPASS_LINT}" ]; then
+	exit 0
+fi
+
+# Lint changed Ansible files
+.githooks/check-ansible.py
+
+# Lint changed shell scripts
+.githooks/check-shell.py
+
+# Lint changed Python files
+.githooks/check-python.py

--- a/scripts/enable_deepops_linting.sh
+++ b/scripts/enable_deepops_linting.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+echo "Enabling pre-commit hooks to lint Ansible, Shell, and Python"
+cp -v .githooks/pre-commit .git/hooks/pre-commit
+chmod +x .git/hooks/pre-commit


### PR DESCRIPTION
I've had very good experiences in the past using linters to catch common coding mistakes. It sometimes makes sense to bypass them; but in most cases, if a linter is complaining you should probably fix the issue. :)

This PR adds the optional capability to enable three linters in a pre-commit hook for DeepOps:

* [ansible-lint](https://github.com/ansible/ansible-lint) for Ansible
* [shellcheck](https://www.shellcheck.net/) for Bash scripts
* [pylint](https://www.pylint.org/) for Python

The pre-commit hook only runs the linter on files that are staged for commit. This avoids, for example, any given commit from being blocked on every lint issue in our Ansible playbooks. :) Instead, it will only report issues in files you're trying to change this time around.

To enable the pre-commit hook in your local checkout:

```
adeconinck@ubuntu-desktop:~/src/deepops$ ./scripts/enable_deepops_linting.sh
Enabling pre-commit hooks to lint Ansible, Shell, and Python
'.githooks/pre-commit' -> '.git/hooks/pre-commit'
adeconinck@ubuntu-desktop:~/src/deepops$
```

And here's an example of the `shellcheck` linter complaining about an unquoted variable and preventing me from committing:

```
adeconinck@ubuntu-desktop:~/src/deepops$ git diff
diff --git a/virtual/cluster_up.sh b/virtual/cluster_up.sh
index 944fc91..f273f8d 100755
--- a/virtual/cluster_up.sh
+++ b/virtual/cluster_up.sh
@@ -35,3 +35,5 @@ fi
 if [ -n "${DEEPOPS_ENABLE_SLURM}" ]; then
        "${VIRT_DIR}"/scripts/setup_slurm.sh
 fi
+
+echo Not quoted ${FAKE_VAR}
adeconinck@ubuntu-desktop:~/src/deepops$ git add .
adeconinck@ubuntu-desktop:~/src/deepops$ git commit -m 'commit this code!'

In virtual/cluster_up.sh line 39:
echo Not quoted ${FAKE_VAR}
                ^-- SC2086: Double quote to prevent globbing and word splitting.

Failed shell lint
adeconinck@ubuntu-desktop:~/src/deepops$ git status
On branch linters
Your branch is up to date with 'origin/linters'.
  (use "git push" to publish your local commits)

Changes to be committed:
  (use "git reset HEAD <file>..." to unstage)

        modified:   virtual/cluster_up.sh

adeconinck@ubuntu-desktop:~/src/deepops$
```

Note, things **not** included in this commit:

* This commit doesn't turn on the pre-commit hook by default. It's purely an optional tool to help improve your development workflow. :)
* This commit doesn't attempt to fix any existing lint issues in the repo. I might try to do a big fixup PR at some point, but for now I'd just love to see issues fixed as we go.