### PR TITLE
Add a check for required linters to enable script

### DIFF
--- a/scripts/enable_deepops_linting.sh
+++ b/scripts/enable_deepops_linting.sh
@@ -16,7 +16,7 @@ fi
 if [ ${FAILED} -ne 0 ]; then
 	echo
 	echo 'One or more required linters not found!'
-	echo 'Please install the missing linter using pip or your system pacjage manager,'
+	echo 'Please install the missing linter using pip or your system package manager,'
 	echo 'and try again.'
 	echo
 	echo 'Pre-commit hook not enabled.'

--- a/scripts/enable_deepops_linting.sh
+++ b/scripts/enable_deepops_linting.sh
@@ -1,5 +1,28 @@
 #!/bin/bash
 
+FAILED=0
+if ! which ansible-lint; then
+	echo "ansible-lint not found in PATH"
+	FAILED=1
+fi
+if ! which shellcheck; then
+	echo "shellcheck not found in PATH"
+	FAILED=1
+fi
+if ! which pylint; then
+	echo "pylint not found in PATH"
+	FAILED=1
+fi
+if [ ${FAILED} -ne 0 ]; then
+	echo
+	echo 'One or more required linters not found!'
+	echo 'Please install the missing linter using pip or your system pacjage manager,'
+	echo 'and try again.'
+	echo
+	echo 'Pre-commit hook not enabled.'
+	exit 1
+fi
+
 echo "Enabling pre-commit hooks to lint Ansible, Shell, and Python"
 cp -v .githooks/pre-commit .git/hooks/pre-commit
 chmod +x .git/hooks/pre-commit


### PR DESCRIPTION
If you don't have one or more linters installed, you'll get annoying
errors when you try to commit. So let's check for the linters before we
enable the hook.

I went back and forth about including the install commands directly, but
decided to go for principle of least surprise and let the user take care
of installs if they want.