### PR TITLE
Purge + re-install galaxy roles in virtual cluster

### DIFF
--- a/virtual/cluster_up.sh
+++ b/virtual/cluster_up.sh
@@ -13,7 +13,9 @@ ROOT_DIR="${VIRT_DIR}/.."
 cd "${ROOT_DIR}"
 
 # Ensure a fresh start for Ansible Galaxy roles
-rm -r "${ROOT_DIR}/galaxy-roles"
+if [ -d "${ROOT_DIR}/galaxy-roles" ]; then
+	rm -r "${ROOT_DIR}/galaxy-roles"
+fi
 ansible-galaxy install -r "${ROOT_DIR}/requirements.yml"
 
 # Create the config for deepops servers (and use the virtual inventory)

--- a/virtual/cluster_up.sh
+++ b/virtual/cluster_up.sh
@@ -12,7 +12,8 @@ ROOT_DIR="${VIRT_DIR}/.."
 # Ensure working directory is root
 cd "${ROOT_DIR}"
 
-# Ensure Ansible Galaxy dependencies are present
+# Ensure a fresh start for Ansible Galaxy roles
+rm -r "${ROOT_DIR}/galaxy-roles"
 ansible-galaxy install -r "${ROOT_DIR}/requirements.yml"
 
 # Create the config for deepops servers (and use the virtual inventory)


### PR DESCRIPTION
I've had a couple cases where a galaxy dependency didn't correctly make
it into the `requirements.yml`, but I failed to notice because it was
cached locally in `galaxy-roles/`. This is especially problematic when
working in the virtual cluster, which is commonly used for test
workflows and CI.

This change just nukes the `galaxy-roles/` directory as part of
`cluster_up.sh`, and ensures that all dependencies are re-installed
fresh.

Cons to this change:

* This adds some time (~20-40 s) to cluster turnup, but this is a small
fraction of the total time.
* This could cause `cluster_up.sh` to fail if a download fails. But
we're downloading a ton of data in the whole turnup process, so we're
already exposed to this risk, and this at least fails at the beginning
of the process.