### PR TITLE
Turn up Slurm and test in Jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -63,7 +63,7 @@ pipeline {
           sh '''
             pwd
             export GPU="$(echo ${GPUDATA} | cut -d"-" -f1)"
-            ssh -o "StrictHostKeyChecking no" -o "UserKnownHostsFile /dev/null" -l vagrant -i $HOME/.ssh/id_rsa 10.0.0.4$GPU srun -n1 hostname
+            ssh -v -o "StrictHostKeyChecking no" -o "UserKnownHostsFile /dev/null" -l vagrant -i $HOME/.ssh/id_rsa 10.0.0.4$GPU srun -n1 hostname
           '''
         }
       }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -37,6 +37,7 @@ pipeline {
           sh '''
             pwd
             cd virtual
+            export DEEPOPS_ENABLE_SLURM=1
             ./cluster_up.sh
           '''
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -37,7 +37,6 @@ pipeline {
           sh '''
             pwd
             cd virtual
-            export DEEPOPS_ENABLE_SLURM=1
             ./cluster_up.sh
           '''
 
@@ -51,6 +50,20 @@ pipeline {
             chmod 755 $K8S_CONFIG_DIR/artifacts/kubectl
             kubectl get nodes
             kubectl run gpu-test --rm -t -i --restart=Never --image=nvidia/cuda --limits=nvidia.com/gpu=1 -- nvidia-smi
+          '''
+
+          echo "Set up Slurm"
+          sh '''
+            pwd
+            cd virtual
+            ./scripts/setup_slurm.sh
+          '''
+
+          echo "Test Slurm"
+          sh '''
+            pwd
+            export GPU="$(echo ${GPUDATA} | cut -d"-" -f1)"
+            ssh -o "StrictHostKeyChecking no" -o "UserKnownHostsFile /dev/null" -l vagrant -i $HOME/.ssh/id_rsa 10.0.0.4$GPU srun -n1 hostname
           '''
         }
       }


### PR DESCRIPTION
Adds two steps to Jenkinsfile:

1. Runs `virtual/scripts/setup_slurm.sh` after the Kubernetes test to turn up the Slurm cluster.
1. Runs a simple slurm job (`srun -n1 hostname`) via SSH to the login node.

Pros:
* Ensure Slurm turnup continues to work
* Verifies minimal Slurm functionality
* Slurm steps only run if Kubernetes components finish successfully

Cons:
* Successful tests take longer. (~8 minutes longer based on ad-hoc testing)

I'm SO HAPPY Jenkins is set up because I should get to see how this test goes after I submit the PR! :D 