### PR TITLE
Re-add nvidia-docker config to k8s cluster playbook

### DIFF
--- a/playbooks/k8s-cluster.yml
+++ b/playbooks/k8s-cluster.yml
@@ -98,6 +98,26 @@
   tags:
     - nvidia
 - include: nvidia-docker.yml
+  vars:
+    # Docker Configuration
+    # Setting reference: https://docs.nvidia.com/deeplearning/dgx/user-guide/index.html
+    docker_daemon_json:
+      bip: 192.168.99.1/24
+      default-shm-size: 1G
+      default-ulimits:
+        memlock:
+          name: memlock
+          hard: -1
+          soft: -1
+        stack:
+          name: stack
+          hard: 67108864
+          soft: 67108864
+      default-runtime: nvidia
+      runtimes:
+        nvidia:
+          path: /usr/bin/nvidia-container-runtime
+          runtimeArgs: []
   tags:
     - nvidia
 


### PR DESCRIPTION
The current k8s cluster build process doesn't use `config/group_vars/*`