### PR TITLE
Re-enable prolog/epilog by default in virtual cluster

### DIFF
--- a/virtual/vars_files/virt_slurm.yml
+++ b/virtual/vars_files/virt_slurm.yml
@@ -12,6 +12,3 @@ nfs_exports:
 # For virtual cluster, ensure hosts file correctly uses private network
 hosts_add_default_ipv4: false
 hosts_network_interface: "eth1"
-
-# Hardware-specific prolog/epilog may not work in virtual
-slurm_enable_prolog_epilog: false


### PR DESCRIPTION
Previously I had disabled prolog/epilog for the virtual cluster because it was hitting errors on setting performance states. But @dholt has made a bunch of improvements to those so now they work! \o/

## Test plan

Run a job on the virtual cluster:

```
vagrant@virtual-login:~$ sinfo
PARTITION AVAIL  TIMELIMIT  NODES  STATE NODELIST
batch*       up   infinite      1   idle virtual-gpu01
vagrant@virtual-login:~$ srun -n1 hostname
virtual-gpu01
vagrant@virtual-login:~$ sinfo
PARTITION AVAIL  TIMELIMIT  NODES  STATE NODELIST
batch*       up   infinite      1   idle virtual-gpu01
vagrant@virtual-login:~$
```

Look at logs on the node, confirm that scripts ran.

```
[2019-03-26T16:56:04.832] launch task 6.0 request from UID:1000 GID:1000 HOST:10.0.0.4 PORT:31429
[2019-03-26T16:56:04.834] ====================
[2019-03-26T16:56:04.834] step_id:6.0 job_mem:15238MB step_mem:15238MB
[2019-03-26T16:56:04.834] JobNode[0] CPU[0] Step alloc
[2019-03-26T16:56:04.834] JobNode[0] CPU[1] Step alloc
[2019-03-26T16:56:04.834] ====================
[2019-03-26T16:56:04.834] lllp_distribution jobid [6] auto binding off: mask_cpu,one_thread
[2019-03-26T16:56:05.014] _run_prolog: run job script took usec=179974
[2019-03-26T16:56:05.014] _run_prolog: prolog with lock for job 6 ran for 1 seconds
[2019-03-26T16:56:05.047] [6.0] task/cgroup: /slurm/uid_1000/job_6: alloc=15238MB mem.limit=15238MB memsw.limit=unlimited
[2019-03-26T16:56:05.047] [6.0] task/cgroup: /slurm/uid_1000/job_6/step_0: alloc=15238MB mem.limit=15238MB memsw.limit=unlimited
[2019-03-26T16:56:05.055] [6.0] task_p_pre_launch: Using sched_affinity for tasks
[2019-03-26T16:56:05.593] [6.0] done with job
```

And everything completed successfully and I can still run jobs!