### PR TITLE
Enable vagrant_startup.sh to run cross-OS

### DIFF
--- a/virtual/README.md
+++ b/virtual/README.md
@@ -34,7 +34,7 @@ For example, you will need to be in the "libvirt" group to mangage VMs, but your
 If you want to run your virtual cluster on CentOS, set the `DEEPOPS_VAGRANT_FILE` variable to point to the CentOS Vagrant file:
 
 ```
-$ export DEEPOPS_VAGRANT_FILE=./Vagrantfile-centos
+$ export DEEPOPS_VAGRANT_FILE=$(pwd)/Vagrantfile-centos
 ```
 
 If you want to use Ubuntu, you can set this variable to point to the Ubuntu Vagrant file, or just leave it unset (Ubuntu is the default).

--- a/virtual/vagrant_startup.sh
+++ b/virtual/vagrant_startup.sh
@@ -4,7 +4,6 @@
 set -xe
 # Get absolute path for script, and convenience vars for virtual and root
 VIRT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-SCRIPT_DIR="${VIRT_DIR}/scripts"
 
 #####################################
 # Install Vagrant and Dependencies
@@ -34,13 +33,12 @@ case "$ID_LIKE" in
     sudo yum install -y qemu virt-manager firewalld OVMF
 
     # Start up libvirt as our VM method for Vagrant
-    sudo usermod -a -G libvirt $(whoami)
+    sudo usermod -a -G libvirt "$(whoami)"
     sudo systemctl enable libvirtd
     sudo systemctl start libvirtd
 
     # Install Vagrant
-    type vagrant >/dev/null 2>&1
-    if [ $? -ne 0 ] ; then
+    if ! vagrant >/dev/null 2>&1; then
       # install vagrant (frozen at 2.2.3 to avoid various issues)
       pushd "$(mktemp -d)"
       wget https://releases.hashicorp.com/vagrant/2.2.3/vagrant_2.2.3_x86_64.rpm -O vagrant.rpm
@@ -55,7 +53,7 @@ case "$ID_LIKE" in
     vagrant --version
 
     # Set up Vagrantfile and start up the configuration in Vagrant
-    export DEEPOPS_VAGRANT_FILE="${VIRT_DIR}/Vagrantfile-centos"
+    export DEEPOPS_VAGRANT_FILE="${DEEPOPS_VAGRANT_FILE:-${VIRT_DIR}/Vagrantfile-centos}"
 
     # End Install Vagrant & Dependencies for RHEL Systems
     ;;
@@ -77,8 +75,7 @@ case "$ID_LIKE" in
     sudo apt install -y qemu ovmf virt-manager firewalld
 
     # Install Vagrant
-    type vagrant >/dev/null 2>&1
-    if [ $? -ne 0 ] ; then
+    if ! vagrant >/dev/null 2>&1; then
       # install vagrant (frozen at 2.2.3 to avoid various issues)
       pushd "$(mktemp -d)"
       wget https://releases.hashicorp.com/vagrant/2.2.3/vagrant_2.2.3_x86_64.deb -O vagrant.deb
@@ -92,7 +89,7 @@ case "$ID_LIKE" in
     vagrant --version
 
     # Set up Vagrantfile and start up the configuration in Vagrant
-    export DEEPOPS_VAGRANT_FILE="${VIRT_DIR}/Vagrantfile-ubuntu"
+    export DEEPOPS_VAGRANT_FILE="${DEEPOPS_VAGRANT_FILE:-${VIRT_DIR}/Vagrantfile-ubuntu}"
 
     # End Install Vagrant & Dependencies for Debian Systems
     ;;
@@ -101,10 +98,6 @@ case "$ID_LIKE" in
     echo "You are on your own to install Vagrant and build a Vagrantfile then you can manually start the DeepOps virtual setup"
     ;;
 esac
-
-# Get absolute path for script, and convenience vars for virtual and root
-VIRT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-SCRIPT_DIR="${VIRT_DIR}/scripts"
 
 #####################################
 # Set up VMs for virtual cluster


### PR DESCRIPTION
Recent changes to `vagrant_startup.sh` enabled the setup process to work on CentOS, but had a baked-in assumption that your host OS version should be the same as your cluster. I.e., Ubuntu hosts would always turn up Ubuntu clusters, and CentOS hosts would always turn up CentOS clusters.

This PR adjusts the script so setting `DEEPOPS_VAGRANT_FILE` will let you set an alternate Vagrantfile.

The main change is this:
```
<    export DEEPOPS_VAGRANT_FILE="${VIRT_DIR}/Vagrantfile-ubuntu"
>    export DEEPOPS_VAGRANT_FILE="${DEEPOPS_VAGRANT_FILE:-${VIRT_DIR}/Vagrantfile-ubuntu}"
```
and a similar change in the CentOS section.  The other lines are just lint fixes to make the pre-commit hook happy. :)

## Test plan

Ran `vagrant_setup.sh` twice. The first time I left `DEEPOPS_VAGRANT_FILE` unset, and confirmed that my Ubuntu host turned up Ubuntu VMs:

```
Bringing machine 'virtual-mgmt' up with 'libvirt' provider...
Bringing machine 'virtual-login' up with 'libvirt' provider...
Bringing machine 'virtual-gpu01' up with 'libvirt' provider...
==> virtual-login: Checking if box 'generic/ubuntu1804' version '1.9.6' is up to date...
==> virtual-gpu01: Checking if box 'generic/ubuntu1804' version '1.9.6' is up to date...
==> virtual-mgmt: Checking if box 'generic/ubuntu1804' version '1.9.6' is up to date...
```

The second time I set `export DEEPOPS_VAGRANT_FILE=$(pwd)/Vagrantfile-centos`, and confirmed that we turned up CentOS VMs:

```
Bringing machine 'virtual-mgmt' up with 'libvirt' provider...
Bringing machine 'virtual-login' up with 'libvirt' provider...
Bringing machine 'virtual-gpu01' up with 'libvirt' provider...
==> virtual-mgmt: Checking if box 'centos/7' version '1902.01' is up to date...
==> virtual-login: Checking if box 'centos/7' version '1902.01' is up to date...
==> virtual-gpu01: Checking if box 'centos/7' version '1902.01' is up to date...
```