### PR TITLE
Pin nvidia-docker/runtime versions

### DIFF
--- a/playbooks/docker.yml
+++ b/playbooks/docker.yml
@@ -5,10 +5,12 @@
   vars:
     docker_daemon_json: {}
   tasks:
+
     - name: create docker config directory
       file:
         path: /etc/docker
         state: directory
+
     - name: write new docker config
       copy:
         content: "{{ docker_daemon_json | to_nice_json }}"
@@ -16,5 +18,19 @@
         owner: root
         group: root
         mode: 0644
-  roles:
-    - geerlingguy.docker
+
+    - name: install docker
+      include_role:
+        name: geerlingguy.docker
+      vars:
+        # matches: kubespray/roles/container-engine/docker/vars/ubuntu-bionic.yml
+        docker_package: 'docker-ce=18.06.1~ce~3-0~ubuntu'
+      when: ansible_distribution == "Ubuntu"
+
+    - name: install docker
+      include_role:
+        name: geerlingguy.docker
+      vars:
+        # matches: kubespray/roles/container-engine/docker/vars/redhat.yml
+        docker_package: 'docker-ce-18.06.2.ce-3.el7'
+      when: ansible_os_family == "RedHat"

--- a/playbooks/k8s-cluster.yml
+++ b/playbooks/k8s-cluster.yml
@@ -37,7 +37,6 @@
     kubeconfig_localhost: true
     helm_enabled: true
     tiller_node_selectors: "node-role.kubernetes.io/master=''"
-    docker_version: latest
     docker_dns_servers_strict: no
     docker_storage_options: -s overlay2
 

--- a/playbooks/nvidia-docker.yml
+++ b/playbooks/nvidia-docker.yml
@@ -9,4 +9,15 @@
     - name: install nvidia-docker
       include_role:
         name: nvidia-docker
-      when: ansible_local['gpus']['count']
+      vars:
+        nvidia_docker2_package_version: '2.0.3+docker18.06.1-1'
+        nvidia_container_runtime_package_version: '2.0.0+docker18.06.1-1'
+      when: ansible_local['gpus']['count'] and ansible_distribution == "Ubuntu"
+
+    - name: install nvidia-docker
+      include_role:
+        name: nvidia-docker
+      vars:
+        nvidia_docker2_package_version: '2.0.3-1.docker18.06.1.ce'
+        nvidia_container_runtime_package_version: '2.0.0-1.docker18.06.'
+      when: ansible_local['gpus']['count'] and ansible_os_family == "RedHat"

--- a/playbooks/nvidia-docker.yml
+++ b/playbooks/nvidia-docker.yml
@@ -10,6 +10,7 @@
       include_role:
         name: nvidia-docker
       vars:
+        # matches: kubespray/roles/container-engine/docker/vars/ubuntu-bionic.yml
         nvidia_docker2_package_version: '2.0.3+docker18.06.1-1'
         nvidia_container_runtime_package_version: '2.0.0+docker18.06.1-1'
       when: ansible_local['gpus']['count'] and ansible_distribution == "Ubuntu"
@@ -18,6 +19,7 @@
       include_role:
         name: nvidia-docker
       vars:
-        nvidia_docker2_package_version: '2.0.3-1.docker18.06.1.ce'
-        nvidia_container_runtime_package_version: '2.0.0-1.docker18.06.'
+        # matches: kubespray/roles/container-engine/docker/vars/redhat.yml
+        nvidia_docker2_package_version: '2.0.3-1.docker18.06.2'
+        nvidia_container_runtime_package_version: '2.0.0-1.docker18.06.2'
       when: ansible_local['gpus']['count'] and ansible_os_family == "RedHat"


### PR DESCRIPTION
Avoids mismatch when Docker updates and a corresponding build of nvidia-docker doesn't yet exist.