### PR TITLE
Replace hardcoded variables in playbooks and scripts with configurable vars

### DIFF
--- a/config.example/group_vars/all.yml
+++ b/config.example/group_vars/all.yml
@@ -1,9 +1,6 @@
 # Configuration common to all hosts
 # Define per-group or per-host values in the other configuration files
 
-# External URLs for downloads. Override these variables if using local mirrors.
-nvidia_k8s_device_plugin_def: "https://raw.githubusercontent.com/NVIDIA/k8s-device-plugin/v1.12/nvidia-device-plugin.yml"
-
 # Docker Configuration
 #docker_daemon_json:
 #  bip: 192.168.99.1/24

--- a/config.example/group_vars/all.yml
+++ b/config.example/group_vars/all.yml
@@ -1,6 +1,9 @@
 # Configuration common to all hosts
 # Define per-group or per-host values in the other configuration files
 
+# External URLs for downloads. Override these variables if using local mirrors.
+nvidia_k8s_device_plugin_def: "https://raw.githubusercontent.com/NVIDIA/k8s-device-plugin/v1.12/nvidia-device-plugin.yml"
+
 # Docker Configuration
 #docker_daemon_json:
 #  bip: 192.168.99.1/24

--- a/config.example/kubespray_deepops_vars.yml
+++ b/config.example/kubespray_deepops_vars.yml
@@ -1,0 +1,5 @@
+---
+# Extra variables to be used during kubernetes turnup
+# Will be copied into the k8s-config directory when building config for Kubespray
+
+nvidia_k8s_device_plugin_def: "https://raw.githubusercontent.com/NVIDIA/k8s-device-plugin/v1.12/nvidia-device-plugin.yml"

--- a/playbooks/k8s-gpu-plugin.yml
+++ b/playbooks/k8s-gpu-plugin.yml
@@ -25,7 +25,7 @@
     - name: create GPU device plugin
       k8s:
         state: present
-        definition: "{{ lookup('url', 'https://raw.githubusercontent.com/NVIDIA/k8s-device-plugin/v1.12/nvidia-device-plugin.yml', split_lines=False) }}"
+        definition: "{{ lookup('url', nvidia_k8s_device_plugin_def, split_lines=False) }}"
       run_once: true
   tags:
     - k8s_gpu_device_plugin

--- a/roles/container-registry/defaults/main.yml
+++ b/roles/container-registry/defaults/main.yml
@@ -1,4 +1,5 @@
 tiller_host: localhost
+helm_chart_location: "https://kubernetes-charts.storage.googleapis.com"
 container_registry_name: docker-registry
 container_registry_namespace: default
 container_registry_version: 1.7.0

--- a/roles/container-registry/tasks/main.yml
+++ b/roles/container-registry/tasks/main.yml
@@ -6,7 +6,7 @@
       version: "{{ container_registry_version }}"
       source:
         type: repo
-        location: https://kubernetes-charts.storage.googleapis.com
+        location: "{{ helm_chart_location }}"
     state: present
     name: "{{ container_registry_name }}"
     namespace: "{{ container_registry_namespace }}"

--- a/roles/nvidia-docker/defaults/main.yml
+++ b/roles/nvidia-docker/defaults/main.yml
@@ -7,3 +7,6 @@ docker_daemon_json:
     nvidia:
       path: /usr/bin/nvidia-container-runtime
       runtimeArgs: []
+
+nvdocker_repo_base_url: "https://nvidia.github.io/nvidia-docker"
+nvdocker_gpg_path: "{{ nvdocker_repo_base_url }}/gpgkey"

--- a/roles/nvidia-docker/tasks/redhat-pre-install.yml
+++ b/roles/nvidia-docker/tasks/redhat-pre-install.yml
@@ -8,7 +8,7 @@
 
 - name: add repo
   get_url:
-    url: "https://nvidia.github.io/nvidia-docker/{{ rhel_repo_dist_name }}/{{ rhel_repo_file_name }}"
+    url: "{{ nvdocker_repo_base_url }}/{{ rhel_repo_dist_name }}/{{ rhel_repo_file_name }}"
     dest: "{{ rhel_repo_file_path }}"
     mode: 0644
     owner: root

--- a/roles/nvidia-docker/tasks/ubuntu-pre-install.yml
+++ b/roles/nvidia-docker/tasks/ubuntu-pre-install.yml
@@ -9,12 +9,12 @@
 
 - name: add key
   apt_key:
-    url: https://nvidia.github.io/nvidia-docker/gpgkey
+    url: "{{ nvdocker_gpg_path }}"
     state: present
 
 - name: add repo
   get_url:
-    url: "https://nvidia.github.io/nvidia-docker/{{ ubuntu_repo_dist_name }}/{{ ubuntu_repo_file_name }}"
+    url: "{{ nvdocker_repo_base_url }}/{{ ubuntu_repo_dist_name }}/{{ ubuntu_repo_file_name }}"
     dest: "{{ ubuntu_repo_file_path }}"
     mode: 0644
     owner: root

--- a/roles/nvidia-driver/defaults/main.yml
+++ b/roles/nvidia-driver/defaults/main.yml
@@ -1,3 +1,10 @@
 nvidia_driver_package_version: ''
 nvidia_driver_persistence_mode_on: yes
 nvidia_driver_skip_reboot: no
+epel_baseurl: "https://download.fedoraproject.org/pub/epel/$releasever/$basearch/"
+epel_gpgkey: "https://epel.mirror.constant.com//RPM-GPG-KEY-EPEL-{{ ansible_distribution_major_version }}"
+rhel_cuda_baseurl: "https://developer.download.nvidia.com/compute/cuda/repos/{{ rhel_repo_dir }}/"
+rhel_cuda_gpgkey: "https://developer.download.nvidia.com/compute/cuda/repos/{{ rhel_repo_dir }}/7fa2af80.pub"
+ubuntu_cuda_gpgkey: "https://developer.download.nvidia.com/compute/cuda/repos/{{ ubuntu_repo_dir }}/7fa2af80.pub"
+ubuntu_cuda_apt_key: "7fa2af80"
+ubuntu_cuda_baseurl: "http://developer.download.nvidia.com/compute/cuda/repos/{{ ubuntu_repo_dir }}"

--- a/roles/nvidia-driver/tasks/redhat-pre-install.yml
+++ b/roles/nvidia-driver/tasks/redhat-pre-install.yml
@@ -3,8 +3,8 @@
   yum_repository:
     name: epel
     description: EPEL YUM repo
-    baseurl: https://download.fedoraproject.org/pub/epel/$releasever/$basearch/
-    gpgkey: "https://epel.mirror.constant.com//RPM-GPG-KEY-EPEL-{{ ansible_distribution_major_version }}"
+    baseurl: "{{ epel_baseurl }}"
+    gpgkey: "{{ epel_gpgkey }}"
 
 - name: install dependencies
   yum:
@@ -15,5 +15,5 @@
   yum_repository:
     name: cuda
     description: NVIDIA CUDA YUM Repo
-    gpgkey: "https://developer.download.nvidia.com/compute/cuda/repos/{{ rhel_repo_dir }}/7fa2af80.pub"
-    baseurl: "https://developer.download.nvidia.com/compute/cuda/repos/{{ rhel_repo_dir }}/"
+    gpgkey: "{{ cuda_gpgkey }}"
+    baseurl: "{{ cuda_baseurl }}"

--- a/roles/nvidia-driver/tasks/ubuntu-pre-install.yml
+++ b/roles/nvidia-driver/tasks/ubuntu-pre-install.yml
@@ -6,10 +6,10 @@
 
 - name: add key
   apt_key:
-    url: "https://developer.download.nvidia.com/compute/cuda/repos/{{ ubuntu_repo_dir }}/7fa2af80.pub"
-    id: 7fa2af80
+    url: "{{ ubuntu_cuda_gpgkey }}"
+    id: "{{ ubuntu_cuda_apt_key }}"
 
 - name: add repo
   apt_repository:
-    repo: "deb http://developer.download.nvidia.com/compute/cuda/repos/{{ ubuntu_repo_dir }} /"
+    repo: "deb {{ ubuntu_cuda_baseurl }} /"
     update_cache: yes

--- a/roles/nvidia-ml/defaults/main.yml
+++ b/roles/nvidia-ml/defaults/main.yml
@@ -1,3 +1,10 @@
 nvidia_ml_package_state: present
 nvidia_cudnn_package_version: ''
 nvidia_nccl_package_version: ''
+epel_baseurl: "https://download.fedoraproject.org/pub/epel/$releasever/$basearch/"
+epel_gpgkey: "https://epel.mirror.constant.com//RPM-GPG-KEY-EPEL-{{ ansible_distribution_major_version }}"
+rhel_nvidiaml_gpgkey: "https://developer.download.nvidia.com/compute/machine-learning/repos/{{ rhel_repo_dir }}/7fa2af80.pub"
+rhel_nvidiaml_baseurl: "https://developer.download.nvidia.com/compute/machine-learning/repos/{{ rhel_repo_dir }}/"
+ubuntu_nvidiaml_gpgkey: "https://developer.download.nvidia.com/compute/machine-learning/repos/{{ ubuntu_repo_dir }}/7fa2af80.pub"
+ubuntu_nvidiaml_baseurl: "http://developer.download.nvidia.com/compute/machine-learning/repos/{{ ubuntu_repo_dir }}"
+ubuntu_nvidiaml_keyid: "7fa2af80"

--- a/roles/nvidia-ml/tasks/redhat-pre-install.yml
+++ b/roles/nvidia-ml/tasks/redhat-pre-install.yml
@@ -3,12 +3,12 @@
   yum_repository:
     name: epel
     description: EPEL YUM repo
-    baseurl: https://download.fedoraproject.org/pub/epel/$releasever/$basearch/
-    gpgkey: "https://epel.mirror.constant.com//RPM-GPG-KEY-EPEL-{{ ansible_distribution_major_version }}"
+    baseurl: "{{ epel_baseurl }}"
+    gpgkey: "{{ epel_gpgkey }}"
 
 - name: add repo
   yum_repository:
     name: machine-learning
     description: NVIDIA Machine Learning YUM Repo
-    gpgkey: "https://developer.download.nvidia.com/compute/machine-learning/repos/{{ rhel_repo_dir }}/7fa2af80.pub"
-    baseurl: "https://developer.download.nvidia.com/compute/machine-learning/repos/{{ rhel_repo_dir }}/"
+    gpgkey: "{{ rhel_nvidiaml_gpgkey }}"
+    baseurl: "{{ rhel_nvidiaml_baseurl }}"

--- a/roles/nvidia-ml/tasks/ubuntu-pre-install.yml
+++ b/roles/nvidia-ml/tasks/ubuntu-pre-install.yml
@@ -1,10 +1,10 @@
 ---
 - name: add key
   apt_key:
-    url: "https://developer.download.nvidia.com/compute/machine-learning/repos/{{ ubuntu_repo_dir }}/7fa2af80.pub"
-    id: 7fa2af80
+    url: "{{ ubuntu_nvidiaml_gpgkey }}"
+    id: "{{ ubuntu_nvidiaml_keyid }}"
 
 - name: add repo
   apt_repository:
-    repo: "deb http://developer.download.nvidia.com/compute/machine-learning/repos/{{ ubuntu_repo_dir }} /"
+    repo: "deb {{ ubuntu_nvidiaml_baseurl }} /"
     update_cache: yes

--- a/roles/slurm/defaults/main.yml
+++ b/roles/slurm/defaults/main.yml
@@ -1,3 +1,11 @@
+epel_baseurl: "https://download.fedoraproject.org/pub/epel/$releasever/$basearch/"
+epel_gpgkey: "https://epel.mirror.constant.com//RPM-GPG-KEY-EPEL-{{ ansible_distribution_major_version }}"
+
+slurm_xenial_deb_url: "https://github.com/lukeyeager/ubuntu-slurm/releases/download/docker-1.3/slurm_18.08.5-2-xenial_amd64.deb"
+slurm_bionic_deb_url: "https://github.com/lukeyeager/ubuntu-slurm/releases/download/docker-1.3/slurm_18.08.5-2-bionic_amd64.deb"
+
+slurm_pkg_url: "https://github.com/DeepOps/slurm/releases/download/"
+
 slurm_pkg_tag: docker-1.4
 
 slurm_cluster_name: deepops

--- a/roles/slurm/tasks/main.yml
+++ b/roles/slurm/tasks/main.yml
@@ -4,8 +4,8 @@
   yum_repository:
     name: epel
     description: EPEL YUM repo
-    baseurl: https://download.fedoraproject.org/pub/epel/$releasever/$basearch/
-    gpgkey: "https://epel.mirror.constant.com//RPM-GPG-KEY-EPEL-{{ ansible_distribution_major_version }}"
+    baseurl: "{{ epel_baseurl }}"
+    gpgkey: "{{ epel_gpgkey }}"
   when: ansible_os_family == "RedHat"
 
 - include: munge.yml
@@ -13,7 +13,7 @@
 - name: install slurm (xenial)
   when: ansible_facts['distribution'] == 'Ubuntu' and ansible_facts['distribution_major_version'] == '16'
   apt:
-    deb: https://github.com/lukeyeager/ubuntu-slurm/releases/download/docker-1.3/slurm_18.08.5-2-xenial_amd64.deb
+    deb: "{{ slurm_xenial_deb_url }}" 
   notify:
     - restart slurmd
     - restart slurmdbd
@@ -23,7 +23,7 @@
 - name: install slurm (bionic)
   when: (ansible_facts['distribution'] == 'Ubuntu' and ansible_facts['distribution_major_version'] == '18')
   apt:
-    deb: https://github.com/lukeyeager/ubuntu-slurm/releases/download/docker-1.3/slurm_18.08.5-2-bionic_amd64.deb
+    deb: "{{ slurm_bionic_deb_url }}"
   notify:
     - restart slurmd
     - restart slurmdbd

--- a/roles/slurm/vars/main.yml
+++ b/roles/slurm/vars/main.yml
@@ -1,1 +1,0 @@
-slurm_pkg_url: https://github.com/DeepOps/slurm/releases/download/

--- a/scripts/install_docker.sh
+++ b/scripts/install_docker.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+DOCKER_COMPOSE_URL="${DOCKER_COMPOSE_URL:-https://github.com/docker/compose/releases/download/1.23.2/docker-compose-$(uname -s)-$(uname -m)}"
+
 type docker >/dev/null 2>&1
 if [ $? -ne 0 ] ; then
     get_docker=$(mktemp)
@@ -11,6 +13,6 @@ fi
 
 type docker-compose >/dev/null 2>&1
 if [ $? -ne 0 ] ; then
-sudo curl -L "https://github.com/docker/compose/releases/download/1.23.2/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+sudo curl -L "${DOCKER_COMPOSE_URL}" -o /usr/local/bin/docker-compose
 sudo chmod +x /usr/local/bin/docker-compose
 fi

--- a/scripts/install_helm.sh
+++ b/scripts/install_helm.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 HELM_INSTALL_DIR=/usr/local/bin
+HELM_INSTALL_SCRIPT_URL="${HELM_INSTALL_SCRIPT_URL:-https://raw.githubusercontent.com/kubernetes/helm/master/scripts/get}"
 
 # Install dependencies
 . /etc/os-release
@@ -23,7 +24,7 @@ case "$ID_LIKE" in
         ;;
 esac
 
-curl https://raw.githubusercontent.com/kubernetes/helm/master/scripts/get > /tmp/get_helm.sh
+curl "${HELM_INSTALL_SCRIPT_URL}" > /tmp/get_helm.sh
 chmod +x /tmp/get_helm.sh
 #sed -i 's/sudo//g' /tmp/get_helm.sh
 mkdir -p ${HELM_INSTALL_DIR}

--- a/scripts/k8s_deploy_kubeflow.sh
+++ b/scripts/k8s_deploy_kubeflow.sh
@@ -8,6 +8,9 @@ export KUBEFLOW_TAG=v0.4.1
 export KFAPP=kubeflow
 export KUBEFLOW_SRC=/opt/kubeflow
 
+KSONNET_URL="${KSONNET_URL:-https://github.com/ksonnet/ksonnet/releases/download/v${KS_VER}/${KS_PKG}.tar.gz}"
+KUBEFLOW_URL="${KUBEFLOW_URL:-https://raw.githubusercontent.com/kubeflow/kubeflow/${KUBEFLOW_TAG}/scripts/download.sh}"
+
 ###
 
 # Install dependencies
@@ -40,7 +43,7 @@ if [ $? -eq 0 ] ; then
 fi
 
 # Ksonnet
-wget -O /tmp/${KS_PKG}.tar.gz https://github.com/ksonnet/ksonnet/releases/download/v${KS_VER}/${KS_PKG}.tar.gz \
+wget -O /tmp/${KS_PKG}.tar.gz "${KSONNET_URL}" \
       --no-check-certificate
 mkdir -p ${KS_INSTALL_DIR}
 tempd=$(mktemp -d)
@@ -52,7 +55,7 @@ rm -rf ${tempd} /tmp/${KS_PKG}.tar.gz
 if [ ! -d ${KUBEFLOW_SRC} ] ; then
     tempd=$(mktemp -d)
     cd ${tempd}
-    curl https://raw.githubusercontent.com/kubeflow/kubeflow/${KUBEFLOW_TAG}/scripts/download.sh | bash
+    curl "${KUBEFLOW_URL}" | bash
     cd -
     sudo mv ${tempd} ${KUBEFLOW_SRC}
 fi

--- a/scripts/k8s_deploy_monitoring.sh
+++ b/scripts/k8s_deploy_monitoring.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+HELM_COREOS_CHART_REPO="${HELM_COREOS_CHART_REPO:-https://s3-eu-west-1.amazonaws.com/coreos-charts/stable/}"
+
 type helm >/dev/null 2>&1
 if [ $? -ne 0 ] ; then
     ./scripts/install_helm.sh
@@ -8,7 +10,7 @@ fi
 # Add repo for prometheus charts
 helm repo list | grep coreos >/dev/null 2>&1
 if [ $? -ne 0 ] ; then
-    helm repo add coreos https://s3-eu-west-1.amazonaws.com/coreos-charts/stable/
+    helm repo add coreos "${HELM_COREOS_CHART_REPO}"
 fi
 
 # Determine DeepOps config dir

--- a/scripts/k8s_deploy_rapids_dask.sh
+++ b/scripts/k8s_deploy_rapids_dask.sh
@@ -5,6 +5,8 @@
 # The Dask workers can be scaled from  the K8S command line using `kubectl scale` commands or through jupyter using dask_kubernetes commands
 # See the included sample notebooks for details.
 
+RAPIDS_DASK_DOCKER_REPO="${RAPIDS_DASK_DOCKER_REPO:-https://github.com/supertetelman/k8s-rapids-dask.git}"
+
 NAMESPACE="rapids" # TODO: Pass through different ns end to end
 if [ -z "${NAMESPACE}" ]; then
     NAMESPACE="rapids"
@@ -26,7 +28,7 @@ function build_image() {
 	;;
     esac
   fi	  
-  git clone https://github.com/supertetelman/k8s-rapids-dask.git tmp-rapids-build
+  git clone "${RAPIDS_DASK_DOCKER_REPO}" tmp-rapids-build
   pushd tmp-rapids-build
 
   # Build the docker image

--- a/scripts/k8s_deploy_rook.sh
+++ b/scripts/k8s_deploy_rook.sh
@@ -5,6 +5,8 @@
 # `helm search rook` # get latest version number
 # `helm upgrade --namespace rook-ceph-system rook-ceph rook-master/rook-ceph --version v0.9.0-174.g3b14e51`
 
+HELM_ROOK_CHART_REPO="${HELM_ROOK_CHART_REPO:-HELM_ROOK_CHART_REPO}"
+
 type helm >/dev/null 2>&1
 if [ $? -ne 0 ] ; then
     ./scripts/install_helm.sh
@@ -12,7 +14,7 @@ fi
 
 helm repo list | grep rook-master >/dev/null 2>&1
 if [ $? -ne 0 ] ; then
-    helm repo add rook-master https://charts.rook.io/master
+    helm repo add rook-master "${HELM_ROOK_CHART_REPO}"
 fi
 
 helm status rook-ceph >/dev/null 2>&1

--- a/scripts/k8s_inventory.sh
+++ b/scripts/k8s_inventory.sh
@@ -3,10 +3,14 @@
 git submodule update --init
 
 k8s_config_dir=${K8S_CONFIG_DIR:-./k8s-config}
+deepops_config=${DEEPOPS_CONFIG_DIR:-$(pwd)/config}
 
 if [ ! -d "${k8s_config_dir}" ] ; then
 	# Copy the kubespray default configuration
 	cp -rfp kubespray/inventory/sample/ "${k8s_config_dir}"
 fi
+
+# Copy extra vars file from deepops config dir to k8s config dir for overrides
+cp -v "${deepops_config}/kubespray_deepops_vars.yml" "${k8s_config_dir}/group_vars/all/deepops.yml"
 
 CONFIG_FILE=${k8s_config_dir}/hosts.ini python3 kubespray/contrib/inventory_builder/inventory.py ${@}

--- a/scripts/setup_remote_k8s.sh
+++ b/scripts/setup_remote_k8s.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+KUBECTL_BINARY_URL="${KUBECTL_BINARY_URL:-https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl}"
+
 # Install dependencies
 . /etc/os-release
 case "$ID_LIKE" in
@@ -25,7 +27,7 @@ esac
 ansible gpu-servers -b -m fetch -a "src=/etc/kubernetes/admin.conf flat=yes dest=./"
 
 # Grab kubectl binary
-curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl
+curl -LO "${KUBECTL_BINARY_URL}"
 chmod +x ./kubectl
 sudo mv ./kubectl /usr/local/bin
 


### PR DESCRIPTION
Partially addresses issue #191. Hard-coded URLs that point to the Internet won't work in an air-gapped environment, so we need to provide some mechanism for the user to override these paths.

* In Ansible, replace any hard-coded paths with variables that can be overridden through `config/` directory.
* In shell scripts, replace hard-coded paths with environment variables the user can set, with default values referring to the existing URLs.

Additional work will be needed to find external URLs hiding in dependencies of dependencies, e.g. anything pulled in by Kubespray or Galaxy roles.

## Test plan

Successfully ran a local virtual turnup with these changes. We should also obviously make sure Jenkins passes.