### PR TITLE
fix url for rook helm charts

### DIFF
--- a/scripts/k8s_deploy_rook.sh
+++ b/scripts/k8s_deploy_rook.sh
@@ -5,7 +5,7 @@
 # `helm search rook` # get latest version number
 # `helm upgrade --namespace rook-ceph-system rook-ceph rook-master/rook-ceph --version v0.9.0-174.g3b14e51`
 
-HELM_ROOK_CHART_REPO="${HELM_ROOK_CHART_REPO:-HELM_ROOK_CHART_REPO}"
+HELM_ROOK_CHART_REPO="${HELM_ROOK_CHART_REPO:-https://charts.rook.io/master}"
 
 type helm >/dev/null 2>&1
 if [ $? -ne 0 ] ; then


### PR DESCRIPTION
This broke in my earlier #196, but wasn't caught because all test hosts already had the helm repo present.