### PR TITLE
Fix variable name for RHEL driver install

### DIFF
--- a/roles/nvidia-driver/tasks/redhat-pre-install.yml
+++ b/roles/nvidia-driver/tasks/redhat-pre-install.yml
@@ -15,5 +15,5 @@
   yum_repository:
     name: cuda
     description: NVIDIA CUDA YUM Repo
-    gpgkey: "{{ cuda_gpgkey }}"
-    baseurl: "{{ cuda_baseurl }}"
+    gpgkey: "{{ rhel_cuda_gpgkey }}"
+    baseurl: "{{ rhel_cuda_baseurl }}"


### PR DESCRIPTION
Fixing a dumb mistake from #191. Tested by successfully running `playbooks/nvidia-driver.yml` on a CentOS host.