### PR TITLE
Configure monitoring to use Ingress

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,9 +17,9 @@ pipeline {
             export GPU="$(echo ${GPUDATA} | cut -d"-" -f1)"
             export BUS="$(echo ${GPUDATA} | cut -d"-" -f2)"
             sed -i -e "s/#v.pci :bus => '0x08', :slot => '0x00', :function => '0x0'/v.pci :bus => '$BUS', :slot => '0x00', :function => '0x0'/g" virtual/Vagrant*
-            git grep -lz virtual-mgmt | xargs -0 sed -i -e "s/virtual-mgmt/virtual-mgmt-$GPU/g"
-            git grep -lz virtual-login | xargs -0 sed -i -e "s/virtual-login/virtual-login-$GPU/g"
-            git grep -lz virtual-gpu01 | xargs -0 sed -i -e "s/virtual-gpu01/virtual-gpu01-$GPU/g"
+            git grep -lz virtual-mgmt virtual/ | xargs -0 sed -i -e "s/virtual-mgmt/virtual-mgmt-$GPU/g"
+            git grep -lz virtual-login virtual/ | xargs -0 sed -i -e "s/virtual-login/virtual-login-$GPU/g"
+            git grep -lz virtual-gpu01 virtual/ | xargs -0 sed -i -e "s/virtual-gpu01/virtual-gpu01-$GPU/g"
             git grep -lz 10.0.0.2 virtual/ | xargs -0 sed -i -e "s/10.0.0.2/10.0.0.2$GPU/g"
             git grep -lz 10.0.0.4 virtual/ | xargs -0 sed -i -e "s/10.0.0.4/10.0.0.4$GPU/g"
             git grep -lz 10.0.0.11 virtual/ | xargs -0 sed -i -e "s/10.0.0.11/10.0.0.11$GPU/g"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -47,6 +47,7 @@ pipeline {
             pwd
             cd virtual
             ./vagrant_startup.sh
+            export DEEPOPS_FORCE_DNS=0
             ./cluster_up.sh
           '''
 

--- a/config.example/helm/ingress.yml
+++ b/config.example/helm/ingress.yml
@@ -9,7 +9,10 @@ controller:
   hostNetwork: true
   # Service type LoadBalancer requires a load balancer to be configured, e.g.
   # MetalLB in an on-prem cluster. See metallb.yml for a sample definition.
-  # Use NodePort for on-prem where we don't have a load balancer
+  # NodePort can be used instead for on-prem where we don't have a load balancer,
+  # but since we're using the host network, the service type can be left as
+  # LoadBalancer and the ingress controller can be reached on an IP of any
+  # master node
   service:
     type: LoadBalancer
   # Always run on master nodes

--- a/config.example/helm/ingress.yml
+++ b/config.example/helm/ingress.yml
@@ -9,12 +9,11 @@ controller:
   hostNetwork: true
   # Service type LoadBalancer requires a load balancer to be configured, e.g.
   # MetalLB in an on-prem cluster. See metallb.yml for a sample definition.
-  # NodePort can be used instead for on-prem where we don't have a load balancer,
-  # but since we're using the host network, the service type can be left as
-  # LoadBalancer and the ingress controller can be reached on an IP of any
-  # master node
+  # NodePort can be used instead where we don't have a load balancer.
+  # Since we're using the host network, the ingress controller can be reached
+  # on an IP of any master node
   service:
-    type: LoadBalancer
+    type: NodePort
   # Always run on master nodes
   nodeSelector:
     node-role.kubernetes.io/master: ""

--- a/config.example/helm/ingress.yml
+++ b/config.example/helm/ingress.yml
@@ -13,7 +13,7 @@ controller:
   # Since we're using the host network, the ingress controller can be reached
   # on an IP of any master node
   service:
-    type: NodePort
+    type: LoadBalancer
   # Always run on master nodes
   nodeSelector:
     node-role.kubernetes.io/master: ""

--- a/config.example/helm/kube-prometheus.yml
+++ b/config.example/helm/kube-prometheus.yml
@@ -1,21 +1,8 @@
 prometheus:
   ingress:
     enabled: true
-    hosts:
-    - prometheus.local
-    annotations:
-      kubernetes.io/ingress.class: "nginx"
-      nginx.ingress.kubernetes.io/ssl-redirect: "false"
-      nginx.ingress.kubernetes.io/rewrite-target: /
-    # Support HTTPS (required)
-    tls:
-    - hosts:
-      -  prometheus.local
   nodeSelector:
     node-role.kubernetes.io/master: ""
-  service:
-    type: NodePort
-    nodePort: 30500
   serviceMonitors:
   - name: dcgm-exporter
     selector:
@@ -32,39 +19,13 @@ prometheus:
 alertmanager:
   ingress:
     enabled: true
-    hosts:
-    - alertmanager.local
-    annotations:
-      kubernetes.io/ingress.class: "nginx"
-      nginx.ingress.kubernetes.io/ssl-redirect: "false"
-      nginx.ingress.kubernetes.io/rewrite-target: /
-    # Support HTTPS (required)
-    tls:
-    - hosts:
-      -  alertmanager.local
   nodeSelector:
     node-role.kubernetes.io/master: ""
-  service:
-    type: NodePort
-    nodePort: 30400
 
 grafana:
   ingress:
     enabled: true
-    hosts:
-    - grafana.local
-    annotations:
-      kubernetes.io/ingress.class: "nginx"
-      nginx.ingress.kubernetes.io/ssl-redirect: "false"
-      nginx.ingress.kubernetes.io/rewrite-target: /
-    # Support HTTPS (required)
-    tls:
-    - hosts:
-      -  grafana.local
   nodeSelector:
     node-role.kubernetes.io/master: ""
-  service:
-    type: NodePort
-    nodePort: 30200
   serverDashboardConfigmaps:
     - kube-prometheus-grafana-gpu

--- a/config.example/helm/kube-prometheus.yml
+++ b/config.example/helm/kube-prometheus.yml
@@ -3,6 +3,9 @@ prometheus:
     enabled: true
   nodeSelector:
     node-role.kubernetes.io/master: ""
+  service:
+    type: NodePort
+    nodePort: 30500
   serviceMonitors:
   - name: dcgm-exporter
     selector:
@@ -21,11 +24,17 @@ alertmanager:
     enabled: true
   nodeSelector:
     node-role.kubernetes.io/master: ""
+  service:
+    type: NodePort
+    nodePort: 30400
 
 grafana:
   ingress:
     enabled: true
   nodeSelector:
     node-role.kubernetes.io/master: ""
+  service:
+    type: NodePort
+    nodePort: 30200
   serverDashboardConfigmaps:
     - kube-prometheus-grafana-gpu

--- a/config.example/helm/kube-prometheus.yml
+++ b/config.example/helm/kube-prometheus.yml
@@ -1,6 +1,10 @@
 prometheus:
   ingress:
     enabled: true
+    annotations:
+      kubernetes.io/ingress.class: "nginx"
+      nginx.ingress.kubernetes.io/ssl-redirect: "false"
+      nginx.ingress.kubernetes.io/rewrite-target: /
   nodeSelector:
     node-role.kubernetes.io/master: ""
   service:
@@ -22,6 +26,10 @@ prometheus:
 alertmanager:
   ingress:
     enabled: true
+    annotations:
+      kubernetes.io/ingress.class: "nginx"
+      nginx.ingress.kubernetes.io/ssl-redirect: "false"
+      nginx.ingress.kubernetes.io/rewrite-target: /
   nodeSelector:
     node-role.kubernetes.io/master: ""
   service:
@@ -31,6 +39,10 @@ alertmanager:
 grafana:
   ingress:
     enabled: true
+    annotations:
+      kubernetes.io/ingress.class: "nginx"
+      nginx.ingress.kubernetes.io/ssl-redirect: "false"
+      nginx.ingress.kubernetes.io/rewrite-target: /
   nodeSelector:
     node-role.kubernetes.io/master: ""
   service:

--- a/docs/ingress.md
+++ b/docs/ingress.md
@@ -8,13 +8,32 @@ Two key concepts for routing traffic to your services are:
 * [Ingress controllers](https://kubernetes.io/docs/concepts/services-networking/ingress/), which provide a mapping between external HTTP routes and internal services.
     Ingress controllers are typically exposed using a Load Balancer external IP.
 
-DeepOps provides a script you can run to configure a simple Load Balancer + Ingress setup:
+DeepOps provides scripts you can run to configure a simple Load Balancer and/or Ingress setup:
+
+### Ingress controller
+
+By default the Ingress controller will use host networking and can be accessed at the IP of any master node.
+
+To expose the Ingress controller on an external IP managed by the Load Balancer, modify `config/helm/ingress.yml` and set the service type to `LoadBalancer`.
+
+Run the script to deploy the Ingress controller:
 
 ```
-./scripts/k8s_deploy_ingress_metallb.sh
+./scripts/k8s_deploy_ingress.sh
+```
+This script will set up an Ingress controller based on [NGINX](https://github.com/kubernetes/ingress-nginx).
+
+### Load Balancer
+
+Modify `config/helm/metallb.yml` to configure the IP range that the load balancer will hand out.
+
+Run the script to deploy the load balancer:
+
+```
+./scripts/k8s_deploy_loadbalancer.sh
 ```
 
-This script will set up a software-based L2 Load Balancer using [MetalLb](https://metallb.universe.tf/), as well as a basic Ingress controller based on [NGINX](https://github.com/kubernetes/ingress-nginx).
+This script will set up a software-based L2 Load Balancer using [MetalLb](https://metallb.universe.tf/)
 
 ----------------------
 

--- a/scripts/install_helm.sh
+++ b/scripts/install_helm.sh
@@ -6,6 +6,9 @@ HELM_INSTALL_SCRIPT_URL="${HELM_INSTALL_SCRIPT_URL:-https://raw.githubuserconten
 # un-taint master nodes so they'll run the tiller pod
 kubectl taint nodes --all node-role.kubernetes.io/master- 2>&1
 
+# wait for tiller pod
+kubectl wait --for=condition=Ready -l app=tiller,component=controller --timeout=90s pod
+
 # Install dependencies
 . /etc/os-release
 case "$ID_LIKE" in

--- a/scripts/install_helm.sh
+++ b/scripts/install_helm.sh
@@ -3,11 +3,17 @@
 HELM_INSTALL_DIR=/usr/local/bin
 HELM_INSTALL_SCRIPT_URL="${HELM_INSTALL_SCRIPT_URL:-https://raw.githubusercontent.com/kubernetes/helm/master/scripts/get}"
 
+kubectl version
+if [ $? -ne 0 ] ; then
+    echo "Unable to talk to Kubernetes API"
+    exit 1
+fi
+
 # un-taint master nodes so they'll run the tiller pod
-kubectl taint nodes --all node-role.kubernetes.io/master- 2>&1
+kubectl taint nodes --all node-role.kubernetes.io/master:NoSchedule- >/dev/null 2>&1
 
 # wait for tiller pod
-kubectl wait --for=condition=Ready -l app=tiller,component=controller --timeout=90s pod
+kubectl -n kube-system wait --for=condition=Ready -l app=helm,name=tiller --timeout=90s pod
 
 # Install dependencies
 . /etc/os-release

--- a/scripts/k8s_deploy_ingress.sh
+++ b/scripts/k8s_deploy_ingress.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+set -x
+
+# Get absolute path for script and root
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+ROOT_DIR="${SCRIPT_DIR}/.."
+
+# Allow overriding config dir to look in
+config_dir=${DEEPOPS_CONFIG_DIR:-"${ROOT_DIR}/config"}
+if [ ! -d "${config_dir}" ]; then
+	echo "Can't find configuration in ${config_dir}"
+	echo "Please set DEEPOPS_CONFIG_DIR env variable to point to config location"
+	exit 1
+fi
+
+# Set up the ingress controller
+if ! helm status nginx-ingress >/dev/null 2>&1; then
+	helm install --name nginx-ingress --values "${config_dir}/helm/ingress.yml" stable/nginx-ingress
+fi
+
+for i in {1..10}; do
+	echo "Check for ingress online... check ${i}"
+	if kubectl get pods -l app=nginx-ingress,component=controller --no-headers | grep -i running;
+	then
+		break
+	else
+		sleep 30
+	fi
+done
+
+# Show services
+kubectl get services

--- a/scripts/k8s_deploy_ingress.sh
+++ b/scripts/k8s_deploy_ingress.sh
@@ -13,6 +13,12 @@ if [ ! -d "${config_dir}" ]; then
 	exit 1
 fi
 
+kubectl version
+if [ $? -ne 0 ] ; then
+    echo "Unable to talk to Kubernetes API"
+    exit 1
+fi
+
 # Set up the ingress controller
 if ! helm status nginx-ingress >/dev/null 2>&1; then
 	helm install --name nginx-ingress --values "${config_dir}/helm/ingress.yml" stable/nginx-ingress

--- a/scripts/k8s_deploy_ingress.sh
+++ b/scripts/k8s_deploy_ingress.sh
@@ -18,4 +18,4 @@ if ! helm status nginx-ingress >/dev/null 2>&1; then
 	helm install --name nginx-ingress --values "${config_dir}/helm/ingress.yml" stable/nginx-ingress
 fi
 
-kubectl wait --for=condition=Ready -l app=nginx-ingress,component=controller pod
+kubectl wait --for=condition=Ready -l app=nginx-ingress,component=controller --timeout=90s pod

--- a/scripts/k8s_deploy_ingress.sh
+++ b/scripts/k8s_deploy_ingress.sh
@@ -18,15 +18,4 @@ if ! helm status nginx-ingress >/dev/null 2>&1; then
 	helm install --name nginx-ingress --values "${config_dir}/helm/ingress.yml" stable/nginx-ingress
 fi
 
-for i in {1..10}; do
-	echo "Check for ingress online... check ${i}"
-	if kubectl get pods -l app=nginx-ingress,component=controller --no-headers | grep -i running;
-	then
-		break
-	else
-		sleep 30
-	fi
-done
-
-# Show services
-kubectl get services
+kubectl wait --for=condition=Ready -l app=nginx-ingress,component=controller pod

--- a/scripts/k8s_deploy_loadbalancer.sh
+++ b/scripts/k8s_deploy_loadbalancer.sh
@@ -28,20 +28,5 @@ for i in {1..10}; do
 	fi
 done
 
-# Set up the ingress controller
-if ! helm status nginx-ingress >/dev/null 2>&1; then
-	helm install --name nginx-ingress --values "${config_dir}/helm/ingress.yml" stable/nginx-ingress
-fi
-
-for i in {1..10}; do
-	echo "Check for ingress online... check ${i}"
-	if kubectl get pods -l app=nginx-ingress,component=controller --no-headers | grep -i running;
-	then
-		break
-	else
-		sleep 30
-	fi
-done
-
 # Show services
 kubectl get services

--- a/scripts/k8s_deploy_loadbalancer.sh
+++ b/scripts/k8s_deploy_loadbalancer.sh
@@ -18,15 +18,4 @@ if ! helm status metallb >/dev/null 2>&1; then
 	helm install --values "${config_dir}/helm/metallb.yml" --name metallb stable/metallb
 fi
 
-for i in {1..10}; do
-	echo "Check for load balancer online... check ${i}"
-	if kubectl get pods -l app=metallb,component=controller --no-headers | grep -i running;
-	then
-		break
-	else
-		sleep 30
-	fi
-done
-
-# Show services
-kubectl get services
+kubectl wait --for=condition=Ready -l app=metallb,component=controller pod

--- a/scripts/k8s_deploy_loadbalancer.sh
+++ b/scripts/k8s_deploy_loadbalancer.sh
@@ -13,6 +13,12 @@ if [ ! -d "${config_dir}" ]; then
 	exit 1
 fi
 
+kubectl version
+if [ $? -ne 0 ] ; then
+    echo "Unable to talk to Kubernetes API"
+    exit 1
+fi
+
 # Set up the MetalLB load balancer
 if ! helm status metallb >/dev/null 2>&1; then
 	helm install --values "${config_dir}/helm/metallb.yml" --name metallb stable/metallb

--- a/scripts/k8s_deploy_monitoring.sh
+++ b/scripts/k8s_deploy_monitoring.sh
@@ -40,9 +40,7 @@ if ! kubectl -n monitoring get configmap kube-prometheus-grafana-gpu >/dev/null 
 fi
 
 # Deploy the ingress controller
-if ! helm status nginx-ingress >/dev/null 2>&1; then
-	helm install --name nginx-ingress --values "${config_dir}/helm/ingress.yml" stable/nginx-ingress
-fi
+./scripts/k8s_deploy_ingress.sh
 
 # Deploy Monitoring stack
 if ! helm status kube-prometheus >/dev/null 2>&1 ; then

--- a/scripts/k8s_deploy_monitoring.sh
+++ b/scripts/k8s_deploy_monitoring.sh
@@ -3,7 +3,7 @@
 HELM_COREOS_CHART_REPO="${HELM_COREOS_CHART_REPO:-https://s3-eu-west-1.amazonaws.com/coreos-charts/stable/}"
 
 # Determine DeepOps config dir
-config_dir="$(pwd)/config.example"
+config_dir="$(pwd)/config"
 if [ "${DEEPOPS_CONFIG_DIR}" ]; then
     config_dir="${DEEPOPS_CONFIG_DIR}"
 elif [ -d "$(pwd)/config" ] ; then
@@ -13,10 +13,7 @@ fi
 # Get IP of first master
 master_ip=$(kubectl get nodes -l node-role.kubernetes.io/master= --no-headers -o custom-columns=IP:.status.addresses.*.address | cut -f1 -d, | head -1)
 
-# Install/initialize Helm client
-if ! type helm >/dev/null 2>&1 ; then
-    ./scripts/install_helm.sh
-fi
+./scripts/install_helm.sh
 
 # Add repo for Prometheus charts
 if ! helm repo list | grep coreos >/dev/null 2>&1 ; then

--- a/scripts/k8s_deploy_monitoring.sh
+++ b/scripts/k8s_deploy_monitoring.sh
@@ -2,35 +2,32 @@
 
 HELM_COREOS_CHART_REPO="${HELM_COREOS_CHART_REPO:-https://s3-eu-west-1.amazonaws.com/coreos-charts/stable/}"
 
-# Get IP of first master
-master_ip=$(kubectl get nodes -l node-role.kubernetes.io/master= --no-headers -o custom-columns=IP:.status.addresses.*.address | cut -f1 -d, | head -1)
-
-type helm >/dev/null 2>&1
-if [ $? -ne 0 ] ; then
-    ./scripts/install_helm.sh
-fi
-
-# Add repo for prometheus charts
-helm repo list | grep coreos >/dev/null 2>&1
-if [ $? -ne 0 ] ; then
-    helm repo add coreos "${HELM_COREOS_CHART_REPO}"
-fi
-
 # Determine DeepOps config dir
 config_dir="$(pwd)/config.example"
 if [ "${DEEPOPS_CONFIG_DIR}" ]; then
     config_dir="${DEEPOPS_CONFIG_DIR}"
 fi
 
+# Get IP of first master
+master_ip=$(kubectl get nodes -l node-role.kubernetes.io/master= --no-headers -o custom-columns=IP:.status.addresses.*.address | cut -f1 -d, | head -1)
+
+# Install/initialize Helm client
+if ! type helm >/dev/null 2>&1 ; then
+    ./scripts/install_helm.sh
+fi
+
+# Add repo for Prometheus charts
+if ! helm repo list | grep coreos >/dev/null 2>&1 ; then
+    helm repo add coreos "${HELM_COREOS_CHART_REPO}"
+fi
+
 # Install Prometheus Operator
-helm status prometheus-operator >/dev/null 2>&1
-if [ $? -ne 0 ] ; then
+if ! helm status prometheus-operator >/dev/null 2>&1 ; then
     helm install coreos/prometheus-operator --name prometheus-operator --namespace monitoring --values ${config_dir}/helm/prometheus-operator.yml
 fi
 
 # Create GPU Dashboard config map
-kubectl -n monitoring get configmap kube-prometheus-grafana-gpu >/dev/null 2>&1
-if [ $? -ne 0 ] ; then
+if ! kubectl -n monitoring get configmap kube-prometheus-grafana-gpu >/dev/null 2>&1 ; then
     kubectl create configmap kube-prometheus-grafana-gpu --from-file=${config_dir}/gpu-dashboard.json -n monitoring
 fi
 
@@ -38,9 +35,9 @@ fi
 if ! helm status nginx-ingress >/dev/null 2>&1; then
 	helm install --name nginx-ingress --values "${config_dir}/helm/ingress.yml" stable/nginx-ingress
 fi
+
 # Deploy Monitoring stack
-helm status kube-prometheus >/dev/null 2>&1
-if [ $? -ne 0 ] ; then
+if ! helm status kube-prometheus >/dev/null 2>&1 ; then
     helm install coreos/kube-prometheus --name kube-prometheus --namespace monitoring --values ${config_dir}/helm/kube-prometheus.yml \
         --set alertmanager.ingress.hosts[0]=alertmanager-$(echo ${master_ip} | tr '.' '-').nip.io \
         --set prometheus.ingress.hosts[0]=prometheus-$(echo ${master_ip} | tr '.' '-').nip.io \
@@ -52,8 +49,8 @@ for node in $(kubectl get node --no-headers -o custom-columns=NAME:.metadata.nam
     kubectl label nodes ${node} hardware-type=NVIDIAGPU --overwrite >/dev/null
 done
 
-kubectl -n monitoring get pod -l app=dcgm-exporter 2>&1 | grep "No resources found." >/dev/null 2>&1
-if [ $? -eq 0 ] ; then
+# Deploy DCGM node exporter
+if ! kubectl -n monitoring get pod -l app=dcgm-exporter 2>&1 | grep "No resources found." >/dev/null 2>&1 ; then
     kubectl create -f services/dcgm-exporter.yml
 fi
 

--- a/scripts/k8s_deploy_monitoring.sh
+++ b/scripts/k8s_deploy_monitoring.sh
@@ -6,6 +6,8 @@ HELM_COREOS_CHART_REPO="${HELM_COREOS_CHART_REPO:-https://s3-eu-west-1.amazonaws
 config_dir="$(pwd)/config.example"
 if [ "${DEEPOPS_CONFIG_DIR}" ]; then
     config_dir="${DEEPOPS_CONFIG_DIR}"
+elif [ -d "$(pwd)/config" ] ; then
+    config_dir="$(pwd)/config"
 fi
 
 # Get IP of first master

--- a/scripts/k8s_deploy_monitoring.sh
+++ b/scripts/k8s_deploy_monitoring.sh
@@ -10,6 +10,15 @@ elif [ -d "$(pwd)/config" ] ; then
     config_dir="$(pwd)/config"
 fi
 
+case "$1" in
+    delete)
+        helm del --purge prometheus-operator
+        helm del --purge kube-prometheus
+        kubectl delete ns monitoring
+        exit 0
+        ;;
+esac
+
 # Get IP of first master
 master_ip=$(kubectl get nodes -l node-role.kubernetes.io/master= --no-headers -o custom-columns=IP:.status.addresses.*.address | cut -f1 -d, | head -1)
 

--- a/scripts/k8s_deploy_monitoring.sh
+++ b/scripts/k8s_deploy_monitoring.sh
@@ -49,7 +49,7 @@ for node in $(kubectl get node --no-headers -o custom-columns=NAME:.metadata.nam
 done
 
 # Deploy DCGM node exporter
-if ! kubectl -n monitoring get pod -l app=dcgm-exporter 2>&1 | grep "No resources found." >/dev/null 2>&1 ; then
+if kubectl -n monitoring get pod -l app=dcgm-exporter 2>&1 | grep "No resources found." >/dev/null 2>&1 ; then
     kubectl create -f services/dcgm-exporter.yml
 fi
 

--- a/scripts/k8s_deploy_monitoring.sh
+++ b/scripts/k8s_deploy_monitoring.sh
@@ -19,6 +19,12 @@ case "$1" in
         ;;
 esac
 
+kubectl version
+if [ $? -ne 0 ] ; then
+    echo "Unable to talk to Kubernetes API"
+    exit 1
+fi
+
 # Get IP of first master
 master_ip=$(kubectl get nodes -l node-role.kubernetes.io/master= --no-headers -o custom-columns=IP:.status.addresses.*.address | cut -f1 -d, | head -1)
 

--- a/scripts/k8s_deploy_monitoring.sh
+++ b/scripts/k8s_deploy_monitoring.sh
@@ -44,7 +44,7 @@ if ! helm status kube-prometheus >/dev/null 2>&1 ; then
 fi
 
 # Label GPU nodes
-for node in $(kubectl get node --no-headers -o custom-columns=NAME:.metadata.name,GPU:.status.allocatable.nvidia\\.com\\/gpu | awk '{print $1}') ; do
+for node in $(kubectl get node --no-headers -o custom-columns=NAME:.metadata.name,GPU:.status.allocatable.nvidia\\.com\\/gpu | grep -v none | awk '{print $1}') ; do
     kubectl label nodes ${node} hardware-type=NVIDIAGPU --overwrite >/dev/null
 done
 

--- a/scripts/k8s_deploy_rook.sh
+++ b/scripts/k8s_deploy_rook.sh
@@ -7,10 +7,7 @@
 
 HELM_ROOK_CHART_REPO="${HELM_ROOK_CHART_REPO:-https://charts.rook.io/master}"
 
-type helm >/dev/null 2>&1
-if [ $? -ne 0 ] ; then
-    ./scripts/install_helm.sh
-fi
+./scripts/install_helm.sh
 
 helm repo list | grep rook-master >/dev/null 2>&1
 if [ $? -ne 0 ] ; then

--- a/virtual/Vagrantfile
+++ b/virtual/Vagrantfile
@@ -32,4 +32,9 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     gpu.vm.box = BOX_IMAGE
     gpu.vm.network :private_network, ip: "10.0.0.11"
   end
+
+  config.vm.provision "shell", inline: <<-SHELL
+	sed -i -e 's/4\.2\.2\.1/8.8.8.8/g' -e 's/4\.2\.2\.2/8.8.4.4/g' /etc/netplan/01-netcfg.yaml
+	netplan apply
+  SHELL
 end

--- a/virtual/Vagrantfile-ubuntu
+++ b/virtual/Vagrantfile-ubuntu
@@ -32,4 +32,9 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     gpu.vm.box = BOX_IMAGE
     gpu.vm.network :private_network, ip: "10.0.0.11"
   end
+
+  config.vm.provision "shell", inline: <<-SHELL
+	sed -i -e 's/4\.2\.2\.1/8.8.8.8/g' -e 's/4\.2\.2\.2/8.8.4.4/g' /etc/netplan/01-netcfg.yaml
+	netplan apply
+  SHELL
 end

--- a/virtual/scripts/setup_k8s.sh
+++ b/virtual/scripts/setup_k8s.sh
@@ -38,8 +38,9 @@ kubectl get nodes
 # Deploy rook (optional, but highly recommended)
 "${ROOT_DIR}/scripts/k8s_deploy_rook.sh"
 
+# Deploy load balancer and ingress (optional but recommended)
+"${ROOT_DIR}/scripts/k8s_deploy_loadbalancer.sh"
+"${ROOT_DIR}/scripts/k8s_deploy_ingress.sh"
+
 # Deploy monitoring (optional)
 "${ROOT_DIR}/scripts/k8s_deploy_monitoring.sh"
-
-# Deploy load balancer and ingress (optional but recommended)
-"${ROOT_DIR}/scripts/k8s_deploy_ingress_metallb.sh"


### PR DESCRIPTION
Modify monitoring services to use ingress routes instead of NodePorts without requiring a load balancer or external DNS configuration.