### PR TITLE
Optionally clean up virtual config on cluster_up

### DIFF
--- a/virtual/cluster_up.sh
+++ b/virtual/cluster_up.sh
@@ -15,6 +15,13 @@ cd "${ROOT_DIR}"
 # Ensure Ansible Galaxy dependencies are present
 ./scripts/setup.sh
 
+# Ensure clean config dirs for a new turnup
+DEEPOPS_VIRT_CLEAN_CONFIG="${DEEPOPS_VIRT_CLEAN_CONFIG:-1}"
+if [ "${DEEPOPS_VIRT_CLEAN_CONFIG}" -ne 0 ]; then
+	rm -rf "${VIRT_DIR}/config"
+	rm -rf "${VIRT_DIR}/k8s-config"
+fi
+
 # Create the config for deepops servers (and use the virtual inventory)
 export DEEPOPS_CONFIG_DIR="${VIRT_DIR}/config"
 cp -r "${ROOT_DIR}/config.example/" "${DEEPOPS_CONFIG_DIR}/"


### PR DESCRIPTION
(Note: I'd find this useful, but I'm open to arguments against.)

Continuing to try to make the virtual cluster development experience a
little better... I've had some recent cases where I made changes to
`config.example` or to the k8s config generation process, and had to
manually whack the auto-copied config to get my changes to take place.

The virtual cluster should be in a clean state when we run
`cluster_up.sh`, so let's just explicitly clean up these directories so
we can start with fresh copies.

This is conditional with a `DEEPOPS_VIRT_CLEAN_CONFIG` variable that can
be used to prevent the cleanup if needed.