### PR TITLE
Virtual fixes for test server

### DIFF
--- a/virtual/README.md
+++ b/virtual/README.md
@@ -66,12 +66,12 @@ $ ./cluster_up.sh
 
 The script should complete without errors.
 
-## Destroy the cluster
+## Shutdown vagrant
 
-To destroy the cluster, run the `cluster_destroy.sh` script...
+To destroy the cluster and shutdown the VMs, run the `vagrant_shutdown.sh` script...
 
 ```
-$ ./cluster_destroy.sh
+$ ./vagrant_shutdown.sh
 ```
 
 Check that there are no running VMs using `virsh list`.
@@ -112,7 +112,7 @@ v.pci :bus => '0x08', :slot => '0x00', :function => '0x0'
 
 ```
 
-Destroy the virtual cluster (if it is running) and run cluster up again.
+Shutdown the virtual cluster (if it is running) and startup vagrant + run cluster up again.
 
 # Enabling virtualization and GPU passthrough
 

--- a/virtual/vagrant_startup.sh
+++ b/virtual/vagrant_startup.sh
@@ -11,26 +11,33 @@ VIRT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
 case "$ID_LIKE" in
   rhel*)
-    # End Install Vagrant & Dependencies for RHEL Systems
+    # Install Vagrant & Dependencies for RHEL Systems
 
-    # Update yum
-    sudo yum update
+    if ! rpm -q wget "Development Tools" centos-release-qemu-ev qem-kvm-ev qemu-kvm libvirt virt-install \
+      bridge-utils libvirt-devel libxslt-devel libxml2-devel libguestfs-tools-c sshpass qemu-kvm libvirt-bin \
+      libvirt-dev bridge-utils libguestfs-tools qemu virt-manager firewalld OVMF 2>&1; then
 
-    # Install essential packages and tools
-    sudo yum -y install wget
-    sudo yum group install -y "Development Tools"
-    sudo yum install -y centos-release-qemu-ev qem-kvm-ev qemu-kvm libvirt virt-install bridge-utils libvirt-devel libxslt-devel libxml2-devel libvirt-devel libguestfs-tools-c
+      echo "Installing yum dependencies..."
 
-    # Optional set up networking for Vagrant VMs. Uncomment and adjust if needed
-    #sudo echo "net.ipv4.ip_forward = 1"|sudo tee /etc/sysctl.d/99-ipforward.conf
-    #sudo sysctl -p /etc/sysctl.d/99-ipforward.conf
+      # Update yum
+      sudo yum update
 
-    # Install other dependencies
-    sudo yum install -y sshpass
+      # Install essential packages and tools
+      sudo yum -y install wget
+      sudo yum group install -y "Development Tools"
+      sudo yum install -y centos-release-qemu-ev qem-kvm-ev qemu-kvm libvirt virt-install bridge-utils libvirt-devel libxslt-devel libxml2-devel libguestfs-tools-c
 
-    # Install KVM packages
-    sudo yum install -y qemu-kvm libvirt-bin libvirt-dev bridge-utils libguestfs-tools
-    sudo yum install -y qemu virt-manager firewalld OVMF
+      # Optional set up networking for Vagrant VMs. Uncomment and adjust if needed
+      #sudo echo "net.ipv4.ip_forward = 1"|sudo tee /etc/sysctl.d/99-ipforward.conf
+      #sudo sysctl -p /etc/sysctl.d/99-ipforward.conf
+
+      # Install other dependencies
+      sudo yum install -y sshpass
+
+      # Install KVM packages
+      sudo yum install -y qemu-kvm libvirt-bin libvirt-dev bridge-utils libguestfs-tools
+      sudo yum install -y qemu virt-manager firewalld OVMF
+    fi
 
     # Ensure we have permissions to manage VMs
     export LIBVIRT_GROUP="libvirt"

--- a/virtual/vagrant_startup.sh
+++ b/virtual/vagrant_startup.sh
@@ -70,18 +70,24 @@ case "$ID_LIKE" in
   debian*)
     # Install Vagrant & Dependencies for Debian Systems
 
-    # Update apt
-    sudo apt update
+    if ! dpkg -l build-essential sshpass qemu-kvm libvirt-bin libvirt-dev bridge-utils libguestfs-tools \
+      qemu ovmf virt-manager firewalld >/dev/null 2>&1; then
 
-    # Install build-essential tools
-    sudo apt install build-essential
+      echo "Installing apt dependencies..."
 
-    # Install other dependencies
-    sudo apt install -y sshpass
+      # Update apt
+      sudo apt update
+
+      # Install build-essential tools
+      sudo apt install build-essential
+
+      # Install other dependencies
+      sudo apt install -y sshpass
     
-    # Install KVM packages
-    sudo apt install -y qemu-kvm libvirt-bin libvirt-dev bridge-utils libguestfs-tools
-    sudo apt install -y qemu ovmf virt-manager firewalld
+      # Install KVM packages
+      sudo apt install -y qemu-kvm libvirt-bin libvirt-dev bridge-utils libguestfs-tools
+      sudo apt install -y qemu ovmf virt-manager firewalld
+    fi
 
     # Ensure we have permissions to manage VMs
     case "${VERSION_ID}" in

--- a/virtual/vagrant_startup.sh
+++ b/virtual/vagrant_startup.sh
@@ -13,31 +13,20 @@ case "$ID_LIKE" in
   rhel*)
     # Install Vagrant & Dependencies for RHEL Systems
 
-    if ! rpm -q wget "Development Tools" centos-release-qemu-ev qem-kvm-ev qemu-kvm libvirt virt-install \
+    export YUM_DEPENDENCIES="centos-release-qemu-ev qem-kvm-ev qemu-kvm libvirt virt-install \
       bridge-utils libvirt-devel libxslt-devel libxml2-devel libguestfs-tools-c sshpass qemu-kvm libvirt-bin \
-      libvirt-dev bridge-utils libguestfs-tools qemu virt-manager firewalld OVMF 2>&1; then
+      libvirt-dev bridge-utils libguestfs-tools qemu virt-manager firewalld OVMF"
 
+    if ! (yum grouplist installed "Development Tools" && rpm -q $YUM_DEPENDENCIES) >/dev/null 2>&1; then
       echo "Installing yum dependencies..."
 
-      # Update yum
-      sudo yum update
-
-      # Install essential packages and tools
-      sudo yum -y install wget
       sudo yum group install -y "Development Tools"
-      sudo yum install -y centos-release-qemu-ev qem-kvm-ev qemu-kvm libvirt virt-install bridge-utils libvirt-devel libxslt-devel libxml2-devel libguestfs-tools-c
-
-      # Optional set up networking for Vagrant VMs. Uncomment and adjust if needed
-      #sudo echo "net.ipv4.ip_forward = 1"|sudo tee /etc/sysctl.d/99-ipforward.conf
-      #sudo sysctl -p /etc/sysctl.d/99-ipforward.conf
-
-      # Install other dependencies
-      sudo yum install -y sshpass
-
-      # Install KVM packages
-      sudo yum install -y qemu-kvm libvirt-bin libvirt-dev bridge-utils libguestfs-tools
-      sudo yum install -y qemu virt-manager firewalld OVMF
+      sudo yum install -y $YUM_DEPENDENCIES
     fi
+
+    # Optional set up networking for Vagrant VMs. Uncomment and adjust if needed
+    #sudo echo "net.ipv4.ip_forward = 1"|sudo tee /etc/sysctl.d/99-ipforward.conf
+    #sudo sysctl -p /etc/sysctl.d/99-ipforward.conf
 
     # Ensure we have permissions to manage VMs
     export LIBVIRT_GROUP="libvirt"
@@ -77,23 +66,17 @@ case "$ID_LIKE" in
   debian*)
     # Install Vagrant & Dependencies for Debian Systems
 
-    if ! dpkg -l build-essential sshpass qemu-kvm libvirt-bin libvirt-dev bridge-utils libguestfs-tools \
-      qemu ovmf virt-manager firewalld >/dev/null 2>&1; then
+    export APT_DEPENDENCIES="build-essential sshpass qemu-kvm libvirt-bin libvirt-dev bridge-utils \
+      libguestfs-tools qemu ovmf virt-manager firewalld"
 
+    if ! (dpkg -l $APT_DEPENDENCIES) >/dev/null 2>&1; then
       echo "Installing apt dependencies..."
 
       # Update apt
-      sudo apt update
+      sudo apt update -y
 
       # Install build-essential tools
-      sudo apt install build-essential
-
-      # Install other dependencies
-      sudo apt install -y sshpass
-    
-      # Install KVM packages
-      sudo apt install -y qemu-kvm libvirt-bin libvirt-dev bridge-utils libguestfs-tools
-      sudo apt install -y qemu ovmf virt-manager firewalld
+      sudo apt install -y $APT_DEPENDENCIES
     fi
 
     # Ensure we have permissions to manage VMs

--- a/virtual/vagrant_startup.sh
+++ b/virtual/vagrant_startup.sh
@@ -17,7 +17,7 @@ case "$ID_LIKE" in
       bridge-utils libvirt-devel libxslt-devel libxml2-devel libguestfs-tools-c sshpass qemu-kvm libvirt-bin \
       libvirt-dev bridge-utils libguestfs-tools qemu virt-manager firewalld OVMF"
 
-    if ! (yum grouplist installed "Development Tools" && rpm -q $YUM_DEPENDENCIES) >/dev/null 2>&1; then
+    if ! (yum grouplist installed | grep "Development Tools" && rpm -q $YUM_DEPENDENCIES) >/dev/null 2>&1; then
       echo "Installing yum dependencies..."
 
       sudo yum group install -y "Development Tools"
@@ -69,7 +69,7 @@ case "$ID_LIKE" in
     export APT_DEPENDENCIES="build-essential sshpass qemu-kvm libvirt-bin libvirt-dev bridge-utils \
       libguestfs-tools qemu ovmf virt-manager firewalld"
 
-    if ! (dpkg -l $APT_DEPENDENCIES) >/dev/null 2>&1; then
+    if ! (dpkg -s $APT_DEPENDENCIES) >/dev/null 2>&1; then
       echo "Installing apt dependencies..."
 
       # Update apt


### PR DESCRIPTION
On the test server, we're periodically encountering errors due to dpkg locking when builds coincide. This PR fixes that and speeds up the setup process if you already have virtual dependencies installed.