### PR TITLE
Make use of setup.sh clearer

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -2,6 +2,9 @@
 
 . /etc/os-release
 
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+cd "${SCRIPT_DIR}/.." || echo "Could not cd to repository root"
+
 # Install Software
 case "$ID_LIKE" in
     rhel*)

--- a/virtual/README.md
+++ b/virtual/README.md
@@ -16,18 +16,16 @@ Also, using VMs and optionally GPU passthrough assumes that the host machine has
 enable virtualization in the BIOS. For instructions on how to accomplish this, refer to the sections
 at the bottom of this README: `Enabling virtualization and GPU passthrough`.
 
-## Bootstrap virtualization dependencies
+## Bootstrap dependencies
 
-This project leverages vagrant and libvirt to spin up the appropriate VMs to model a DeepOps
-cluster. To install the necessary dependencies, such as ansible, vagrant, libvirt, etc, run the
-included `setup.sh` on the host machine...
+To install basic dependencies for running Ansible and managing a DeepOps cluster,
+run the `setup.sh` found in the `scripts` directory of the repository root.
 
 ```
-$ ./setup.sh
+$ <deepops repo>/scripts/setup.sh
 ```
 
-After you've run this, it's a good idea to start a fresh login shell to ensure your environment is up to date.
-For example, you will need to be in the "libvirt" group to mangage VMs, but your current session won't include this group if libvirt was just installed.
+Virtualization-related dependencies will be installed if needed by the `vagrant_startup.sh` script.
 
 ## Select the Vagrant file for your Linux distro
 


### PR DESCRIPTION
* Fix `setup.sh` so that it can be run from any directory (not just the repo root)
* Fix the instructions in `virtual/README.md` that refer to the wrong `setup.sh`