### PR TITLE
Ensure correct Jinja2 version on CentOS prov host

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -40,6 +40,15 @@ case "$ID_LIKE" in
             sudo yum -y install ipmitool >/dev/null
         fi
         ipmitool -V
+
+	# Install pip and ensure Jinja2 is updated
+	if ! which pip >/dev/null 2>&1; then
+	    echo "Installing pip..."
+	    sudo yum -y install python-pip >/dev/null
+	fi
+	pip --version
+        echo "Upgrading jinja2"
+        sudo pip install --upgrade Jinja2
         ;;
     debian*)
         # Update apt cache


### PR DESCRIPTION
The default version of Jinja2 provided in the CentOS repos is 2.7.2, but
this version doesn't support the `equalto` comparison for `selectattr`.
This causes the following error in the `nvidia-driver` role, among
others:

```
TASK [nvidia-driver : register installed kernel version]
*************************************************************An
exception occurred during task execution. To see the full traceback, use
-vvv. The error was: TemplateRuntimeError: no test named 'equalto'
```

This error occurs on the host running Ansible, rather than the
destination hosts, so we need to make sure Jinja2 version is >=2.8
before starting the Ansible run.

This PR adds a step to `pip install --upgrade Jinja2` to
`scripts/setup.sh` to address this.