### PR TITLE
Use nvcr.io version of CUDA container 

### DIFF
--- a/tests/gpu-test-job.yml
+++ b/tests/gpu-test-job.yml
@@ -5,7 +5,7 @@ metadata:
 spec:
   containers:
     - name: cuda-container
-      image: nvidia/cuda:10.0-devel
+      image: nvcr.io/nvidia/cuda:10.0-devel
       command: ["sleep", "6000"]
       args:
       resources:

--- a/tests/gpu-test-job.yml
+++ b/tests/gpu-test-job.yml
@@ -10,6 +10,6 @@ spec:
       args:
       resources:
         limits:
-          nvidia.com/gpu: 8
+          nvidia.com/gpu: 1
   restartPolicy: Never
 


### PR DESCRIPTION
Consistency with the other tests (and because that's where we want everyone to go).