### PR TITLE
Add CPU-only job for testing non-GPU environments

### DIFF
--- a/tests/cpu-test-job.yml
+++ b/tests/cpu-test-job.yml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: gpu-pod
+spec:
+  containers:
+    - name: cpu-tf-mnist-train
+      image: tensorflow/tensorflow:latest
+      command: ["python", "-c", "(lambda __g: [[[[[(model.compile(optimizer='adam', loss='sparse_categorical_crossentropy', metrics=['accuracy']), (model.fit(x_train, y_train, epochs=5), (model.evaluate(x_test, y_test), None)[1])[1])[1] for __g['model'] in [(tf.keras.models.Sequential([tf.keras.layers.Flatten(input_shape=(28, 28)), tf.keras.layers.Dense(512, activation=tf.nn.relu), tf.keras.layers.Dropout(0.2), tf.keras.layers.Dense(10, activation=tf.nn.softmax)]))]][0] for (__g['x_train'], __g['x_test']) in [(((x_train / 255.0), (x_test / 255.0)))]][0] for ((__g['x_train'], __g['y_train']), (__g['x_test'], __g['y_test'])) in [(mnist.load_data())]][0] for __g['mnist'] in [(tf.keras.datasets.mnist)]][0] for __g['tf'] in [(__import__('tensorflow', __g, __g))]][0])(globals())"]
+      args:
+      resources:
+        limits:
+          nvidia.com/gpu: 0
+  restartPolicy: Never
+


### PR DESCRIPTION
Short TensorFlow example that trains MNIST on a CPU-only node.  Useful in a Virtual deployment to have a ready-made job that can run on virtual-gpu01 w/o a GPU, or presumably any other non-GPU environment.

(Code taken from https://www.tensorflow.org/tutorials for simplicity)

Only tested that it launches in a Virtual environment, not that it completes.  Tested that it completes in ~30s in a Docker (non-K8S) environment.  Needs somebody with DeepOps setup handy to test for real.