### PR TITLE
Support Docker in Docker in BinderHub script

### DIFF
--- a/config.example/helm/binderhub-config.yml
+++ b/config.example/helm/binderhub-config.yml
@@ -1,6 +1,7 @@
 config:
   BinderHub:
     use_registry: false
+    # image_prefix: <docker-id|organization-name>/<prefix>- # Used to name docker images if use_registry is true
     # hub_url: 
 
 # Require 1 GPU for each Notebook deployment

--- a/config.example/helm/binderhub-config.yml
+++ b/config.example/helm/binderhub-config.yml
@@ -16,5 +16,7 @@ jupyterhub:
     timeout: 3600 # Delete Pods that have been inactive for over n seconds
     every: 600 # Check for inactive Pods ever n seconds
 
+# Depending on how you have your Docker networking setup, Docker in Docker may be required to reach the Internet during Docker builds.
+# It is recommended to enable this. Doing so will launch an additional dind pod to help in this process.
 dind:
   enabled: true

--- a/config.example/helm/binderhub-config.yml
+++ b/config.example/helm/binderhub-config.yml
@@ -15,3 +15,6 @@ jupyterhub:
     enabled: true
     timeout: 3600 # Delete Pods that have been inactive for over n seconds
     every: 600 # Check for inactive Pods ever n seconds
+
+dind:
+  enabled: true

--- a/config.example/helm/binderhub-secret.yml
+++ b/config.example/helm/binderhub-secret.yml
@@ -6,7 +6,12 @@ jupyterhub:
   proxy:
     secretToken:
 
+# Uncomment to and enter GitHub token to avoid hitting API limits
 #config:
 #  GitHubRepoProvider:
 #    access_token: <insert_token_value_here>
 
+# Enter credentials to push/pull images from DockerHub
+#registry:
+#  username:
+#  password:

--- a/docs/binderhub.md
+++ b/docs/binderhub.md
@@ -1,0 +1,25 @@
+# BinderHub
+
+[BinderHub](https://github.com/jupyterhub/binderhub/) allows automatic builds and deployments of Docker containers utilizing JupyterHub and built from git repos.
+
+BinderHub is coupled with JupyterHub. It allows users to build a GitHub repo that specifies requirements for a Docker image based on Dockerfiles, requirements.txt, and other formats. Docker containers are deployed using pieces of the JupyterHub infrastructure and users have a shareable, repeatable, and deployable Jupyter notebook instance to do their DL/ML workloads through. There is tight integration into Kubernetes, but all interactions are done through a GUI and end-users do not need to have any Kubernetes experience.
+
+The default installation works on a single node. Multi-node installations are supported with additional Docker registry configurations as specified in the [BinderHub docs](https://binderhub.readthedocs.io/en/latest/setup-binderhub.html). This can be done using DockerHub or a private registry such as the registry included with the DeepOps install (registry.local by default).
+
+
+## Installation
+
+Deploy Kubernetes by following the [Kubernetes GPU Cluster Deployment Guide](kubernetes-cluster.md)
+
+Deploy the [LoadBalancer](ingress.md#on-prem-loadbalancer)
+
+Deploy [Ceph](kubernetes-cluster.md#persistent-storage)
+
+
+Deploy Binderhub:
+
+```sh
+# Deploy
+./scripts/k8s_deploy_binderhub.sh
+
+```

--- a/scripts/k8s_deploy_binderhub.sh
+++ b/scripts/k8s_deploy_binderhub.sh
@@ -8,10 +8,10 @@
 
 # Define K8s/helm params
 BINDERHUB_NAMESPACE=binderhub
-BINDERHUB_VERSION=0.2.0-3b53fce
+BINDERHUB_VERSION=0.2.0-1eac3a0
 JUPYTERHUB_CHART_REPO=https://jupyterhub.github.io/helm-chart
 BINDERHUB_CHART_NAME=jupyterhub/binderhub
-pod_count=4 # Currently we need 4 pods to be running for BinderHub, this may change in the future
+pod_count=5 # Currently we need 5 pods to be running for BinderHub, this may change in the future
 
 
 # Define the configuration files
@@ -130,7 +130,7 @@ function stand_up() {
 
   # Install Binderhub
   helm install ${BINDERHUB_CHART_NAME} --version=${BINDERHUB_VERSION}  --name=${BINDERHUB_NAMESPACE} --namespace=${BINDERHUB_NAMESPACE} -f ${secret_file} -f ${config_file}
-  while [ `kubectl -n ${BINDERHUB_NAMESPACE} get pods | grep Running | wc -l` != ${pod_count} ]; do
+  while [ `kubectl -n ${BINDERHUB_NAMESPACE} get pods | grep Running | wc -l` -lt ${pod_count} ]; do
     sleep 1
   done
   sleep 1 # Give services time to start after pods are created


### PR DESCRIPTION
Bump up the BinderHub version and enable dind to support Docker in Docker builds in default cloud environments.