### PR TITLE
Configure monitoring ingress with loadbalancer if present

### DIFF
--- a/config.example/helm/ingress.yml
+++ b/config.example/helm/ingress.yml
@@ -10,8 +10,6 @@ controller:
   # Service type LoadBalancer requires a load balancer to be configured, e.g.
   # MetalLB in an on-prem cluster. See metallb.yml for a sample definition.
   # NodePort can be used instead where we don't have a load balancer.
-  # Since we're using the host network, the ingress controller can be reached
-  # on an IP of any master node
   service:
     type: LoadBalancer
   # Always run on master nodes

--- a/docs/ingress.md
+++ b/docs/ingress.md
@@ -10,19 +10,6 @@ Two key concepts for routing traffic to your services are:
 
 DeepOps provides scripts you can run to configure a simple Load Balancer and/or Ingress setup:
 
-### Ingress controller
-
-By default the Ingress controller will use host networking and can be accessed at the IP of any master node.
-
-To expose the Ingress controller on an external IP managed by the Load Balancer, modify `config/helm/ingress.yml` and set the service type to `LoadBalancer`.
-
-Run the script to deploy the Ingress controller:
-
-```
-./scripts/k8s_deploy_ingress.sh
-```
-This script will set up an Ingress controller based on [NGINX](https://github.com/kubernetes/ingress-nginx).
-
 ### Load Balancer
 
 Modify `config/helm/metallb.yml` to configure the IP range that the load balancer will hand out.
@@ -34,6 +21,22 @@ Run the script to deploy the load balancer:
 ```
 
 This script will set up a software-based L2 Load Balancer using [MetalLb](https://metallb.universe.tf/)
+
+### Ingress controller
+
+By default the Ingress controller will be assigned an external IP managed by the Load Balancer.
+
+If you do not have control over your subnet to assign IPs to the load balancer, you can expose
+ingress routes on specific ports and access them via the IP of any management node. To do this, 
+modify `config/helm/ingress.yml` and set the service type to `NodePort`.
+
+Run the script to deploy the Ingress controller:
+
+```
+./scripts/k8s_deploy_ingress.sh
+```
+
+This script will set up an Ingress controller based on [NGINX](https://github.com/kubernetes/ingress-nginx).
 
 ----------------------
 

--- a/scripts/k8s_deploy_ingress.sh
+++ b/scripts/k8s_deploy_ingress.sh
@@ -5,8 +5,12 @@ set -x
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 ROOT_DIR="${SCRIPT_DIR}/.."
 
+# Allow overriding the app name with an env var
+app_name="${NGINX_INGRESS_APP_NAME:-nginx-ingress}"
+
 # Allow overriding config dir to look in
 config_dir=${DEEPOPS_CONFIG_DIR:-"${ROOT_DIR}/config"}
+
 if [ ! -d "${config_dir}" ]; then
 	echo "Can't find configuration in ${config_dir}"
 	echo "Please set DEEPOPS_CONFIG_DIR env variable to point to config location"
@@ -20,8 +24,8 @@ if [ $? -ne 0 ] ; then
 fi
 
 # Set up the ingress controller
-if ! helm status nginx-ingress >/dev/null 2>&1; then
-	helm install --name nginx-ingress --values "${config_dir}/helm/ingress.yml" stable/nginx-ingress
+if ! helm status "${app_name}" >/dev/null 2>&1; then
+	helm install --name "${app_name}" --values "${config_dir}/helm/ingress.yml" stable/nginx-ingress
 fi
 
-kubectl wait --for=condition=Ready -l app=nginx-ingress,component=controller --timeout=90s pod
+kubectl wait --for=condition=Ready -l "app=${app_name},component=controller" --timeout=90s pod

--- a/virtual/scripts/setup_k8s.sh
+++ b/virtual/scripts/setup_k8s.sh
@@ -39,7 +39,7 @@ kubectl get nodes
 "${ROOT_DIR}/scripts/k8s_deploy_rook.sh"
 
 # Deploy load balancer and ingress (optional but recommended)
-"${ROOT_DIR}/scripts/k8s_deploy_loadbalancer.sh"
+#"${ROOT_DIR}/scripts/k8s_deploy_loadbalancer.sh"
 "${ROOT_DIR}/scripts/k8s_deploy_ingress.sh"
 
 # Deploy monitoring (optional)

--- a/virtual/scripts/setup_k8s.sh
+++ b/virtual/scripts/setup_k8s.sh
@@ -39,7 +39,7 @@ kubectl get nodes
 "${ROOT_DIR}/scripts/k8s_deploy_rook.sh"
 
 # Deploy load balancer and ingress (optional but recommended)
-#"${ROOT_DIR}/scripts/k8s_deploy_loadbalancer.sh"
+"${ROOT_DIR}/scripts/k8s_deploy_loadbalancer.sh"
 "${ROOT_DIR}/scripts/k8s_deploy_ingress.sh"
 
 # Deploy monitoring (optional)


### PR DESCRIPTION
During monitoring setup, check for the presence of a LoadBalancer
Ingress on the nginx-controller service. If it exists, use the IP
address for the LoadBalancer to generate the ingress URL for the
monitoring services. If not, just use the master node IP.