### PR TITLE
Fix vagrant_shutdown.sh in Jenkins teardown

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -28,9 +28,6 @@ pipeline {
             git grep -lz 10.0.0.2 virtual/ | xargs -0 sed -i -e "s/10.0.0.2/10.0.0.2$GPU/g"
             git grep -lz 10.0.0.4 virtual/ | xargs -0 sed -i -e "s/10.0.0.4/10.0.0.4$GPU/g"
             git grep -lz 10.0.0.11 virtual/ | xargs -0 sed -i -e "s/10.0.0.11/10.0.0.11$GPU/g"
-            sed -i -e "s/virtual_virtual-mgmt/virtual_virtual-mgmt-$GPU/g" virtual/vagrant_shutdown.sh
-            sed -i -e "s/virtual_virtual-login/virtual_virtual-login-$GPU/g" virtual/vagrant_shutdown.sh
-            sed -i -e "s/virtual_virtual-gpu01/virtual_virtual-gpu01-$GPU/g" virtual/vagrant_shutdown.sh
           '''
 
           echo "Modifying loadbalancer config to use unique IPs"

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -8,7 +8,7 @@ fact_caching_connection = /var/tmp/ansible_cache
 fact_caching_timeout = 86400
 deprecation_warnings = False
 #vault_password_file = ./config/.vault-pass
-timeout=30
+timeout=60
 
 [ssh_connection]
 pipelining = True


### PR DESCRIPTION
We're still duplicating the GPU replacement in the shutdown script... this should fix that.