### PR TITLE
Add multi-node and CentOS support to BinderHub script

### DIFF
--- a/config.example/helm/binderhub-config.yml
+++ b/config.example/helm/binderhub-config.yml
@@ -1,8 +1,11 @@
 config:
   BinderHub:
-    use_registry: false
-    # image_prefix: <docker-id|organization-name>/<prefix>- # Used to name docker images if use_registry is true
-    # hub_url: 
+    use_registry: true
+    image_prefix: username/binderhub- # Used to name docker images if use_registry is true
+    # hub_url: # Controlled by scripting, do not modify #
+# Used for private Docker registries (the default is DockerHub)
+  # DockerRegistry:
+    # token_url:
 
 # Require 1 GPU for each Notebook deployment
 jupyterhub:
@@ -21,3 +24,5 @@ jupyterhub:
 # It is recommended to enable this. Doing so will launch an additional dind pod to help in this process.
 dind:
   enabled: true
+
+

--- a/config.example/helm/binderhub-secret.yml
+++ b/config.example/helm/binderhub-secret.yml
@@ -11,7 +11,9 @@ jupyterhub:
 #  GitHubRepoProvider:
 #    access_token: <insert_token_value_here>
 
-# Enter credentials to push/pull images from DockerHub
-#registry:
-#  username:
-#  password:
+# Enter credentials to push/pull images from DockerHub, this must be done before running the deployment scripts
+registry:
+  username: username
+  password: password
+# Used for private Docker registries
+  # url:

--- a/docs/binderhub.md
+++ b/docs/binderhub.md
@@ -15,6 +15,7 @@ Deploy the [LoadBalancer](ingress.md#on-prem-loadbalancer)
 
 Deploy [Ceph](kubernetes-cluster.md#persistent-storage)
 
+Update the binderhub-config.yml and binderhub-secret.yml with the proper `username` and `password` values for your DockerHub account. Optionally update the fields for GitHub tokens.
 
 Deploy Binderhub:
 

--- a/scripts/k8s_deploy_binderhub.sh
+++ b/scripts/k8s_deploy_binderhub.sh
@@ -150,11 +150,11 @@ function get_url() {
   binderhub_ip=`kubectl -n ${BINDERHUB_NAMESPACE} get svc binder -ocustom-columns=:.status.loadBalancer.ingress[0].ip | tail -n1`
   binderhub_port=`kubectl -n ${BINDERHUB_NAMESPACE} get svc binder -ocustom-columns=:.spec.ports[0].nodePort | tail -n1`
 
-  aws_ip=`curl --max-time .1 --connect-timeout .1 http://169.254.169.254/latest/meta-data/public-hostname`
-  gcp_ip=`curl --max-time .1 --connect-timeout .1 -H "Metadata-Flavor: Google" http://169.254.169.254/computeMetadata/v1/instance/network-interfaces/0/access-configs/0/external-ip`
+  aws_ip=`curl --max-time 1 --connect-timeout 1 http://169.254.169.254/latest/meta-data/public-hostname`
+  gcp_ip=`curl --max-time 1 --connect-timeout 1 -H "Metadata-Flavor: Google" http://169.254.169.254/computeMetadata/v1/instance/network-interfaces/0/access-configs/0/external-ip`
 
   for local_ip in `ip -br addr  | awk '{print $3}' | awk -F/ '{print $1}'`; do
-    curl --max-time .1 --connect-timeout .1 -L ${local_ip}:${binderhub_port} && break
+    curl --max-time 1 --connect-timeout 1 -L ${local_ip}:${binderhub_port} && break
   done
   if [ "${?}" != "0" ]; then
     echo "WARNING: Could not determine local IP"


### PR DESCRIPTION
Multi-node BinderHub support requires pushing images to a repository. Defaulting to DockerHub.

CentOS does not support curl timeouts of non-integers, so changing that.