### PR TITLE
Fix shell script OS detection

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -6,8 +6,8 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 cd "${SCRIPT_DIR}/.." || echo "Could not cd to repository root"
 
 # Install Software
-case "$ID_LIKE" in
-    rhel*)
+case "$ID" in
+    rhel*|centos*)
         # Install Ansible
         type ansible >/dev/null 2>&1
         if [ $? -ne 0 ] ; then
@@ -50,7 +50,7 @@ case "$ID_LIKE" in
         echo "Upgrading jinja2"
         sudo pip install --upgrade Jinja2
         ;;
-    debian*)
+    ubuntu*)
         # Update apt cache
         echo "Updating apt cache..."
         sudo apt-get update >/dev/null

--- a/virtual/vagrant_startup.sh
+++ b/virtual/vagrant_startup.sh
@@ -17,11 +17,13 @@ case "$ID" in
       bridge-utils libvirt-devel libxslt-devel libxml2-devel libguestfs-tools-c sshpass qemu-kvm libvirt-bin \
       libvirt-dev bridge-utils libguestfs-tools qemu virt-manager firewalld OVMF"
 
-    if ! (yum grouplist installed | grep "Development Tools" && rpm -q "$YUM_DEPENDENCIES") >/dev/null 2>&1; then
+    # shellcheck disable=SC2086
+    if ! (yum grouplist installed | grep "Development Tools" && rpm -q $YUM_DEPENDENCIES) >/dev/null 2>&1; then
       echo "Installing yum dependencies..."
 
       sudo yum group install -y "Development Tools"
-      sudo yum install -y "$YUM_DEPENDENCIES"
+      # shellcheck disable=SC2086
+      sudo yum install -y $YUM_DEPENDENCIES
     fi
 
     # Optional set up networking for Vagrant VMs. Uncomment and adjust if needed
@@ -69,14 +71,16 @@ case "$ID" in
     export APT_DEPENDENCIES="build-essential sshpass qemu-kvm libvirt-bin libvirt-dev bridge-utils \
       libguestfs-tools qemu ovmf virt-manager firewalld"
 
-    if ! (dpkg -s "$APT_DEPENDENCIES") >/dev/null 2>&1; then
+    # shellcheck disable=SC2086
+    if ! (dpkg -s $APT_DEPENDENCIES) >/dev/null 2>&1; then
       echo "Installing apt dependencies..."
 
       # Update apt
       sudo apt update -y
 
       # Install build-essential tools
-      sudo apt install -y "$APT_DEPENDENCIES"
+      # shellcheck disable=SC2086
+      sudo apt install -y $APT_DEPENDENCIES
     fi
 
     # Ensure we have permissions to manage VMs

--- a/virtual/vagrant_startup.sh
+++ b/virtual/vagrant_startup.sh
@@ -9,19 +9,19 @@ VIRT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 # Install Vagrant and Dependencies
 #####################################
 
-case "$ID_LIKE" in
-  rhel*)
+case "$ID" in
+  rhel*|centos*)
     # Install Vagrant & Dependencies for RHEL Systems
 
     export YUM_DEPENDENCIES="centos-release-qemu-ev qem-kvm-ev qemu-kvm libvirt virt-install \
       bridge-utils libvirt-devel libxslt-devel libxml2-devel libguestfs-tools-c sshpass qemu-kvm libvirt-bin \
       libvirt-dev bridge-utils libguestfs-tools qemu virt-manager firewalld OVMF"
 
-    if ! (yum grouplist installed | grep "Development Tools" && rpm -q $YUM_DEPENDENCIES) >/dev/null 2>&1; then
+    if ! (yum grouplist installed | grep "Development Tools" && rpm -q "$YUM_DEPENDENCIES") >/dev/null 2>&1; then
       echo "Installing yum dependencies..."
 
       sudo yum group install -y "Development Tools"
-      sudo yum install -y $YUM_DEPENDENCIES
+      sudo yum install -y "$YUM_DEPENDENCIES"
     fi
 
     # Optional set up networking for Vagrant VMs. Uncomment and adjust if needed
@@ -63,20 +63,20 @@ case "$ID_LIKE" in
     # End Install Vagrant & Dependencies for RHEL Systems
     ;;
 
-  debian*)
+  ubuntu*)
     # Install Vagrant & Dependencies for Debian Systems
 
     export APT_DEPENDENCIES="build-essential sshpass qemu-kvm libvirt-bin libvirt-dev bridge-utils \
       libguestfs-tools qemu ovmf virt-manager firewalld"
 
-    if ! (dpkg -s $APT_DEPENDENCIES) >/dev/null 2>&1; then
+    if ! (dpkg -s "$APT_DEPENDENCIES") >/dev/null 2>&1; then
       echo "Installing apt dependencies..."
 
       # Update apt
       sudo apt update -y
 
       # Install build-essential tools
-      sudo apt install -y $APT_DEPENDENCIES
+      sudo apt install -y "$APT_DEPENDENCIES"
     fi
 
     # Ensure we have permissions to manage VMs


### PR DESCRIPTION
Addresses #247.

It turns out that while CentOS sets `ID_LIKE="rhel fedora"`, RHEL itself only sets `ID_LIKE=fedora`. Which kind of makes sense -- `ID_LIKE` is a list of aliases -- but means this script breaks on RHEL right now.

This PR changes to detecting `ID` directly in `/etc/os-release`, and specify CentOS, RHEL, and Ubuntu directly as supported.

Also a few lint fixes.