### PR TITLE
[slurm] cleanup slurm.conf template

### DIFF
--- a/roles/slurm/templates/slurm.conf
+++ b/roles/slurm/templates/slurm.conf
@@ -100,13 +100,15 @@ AccountingStorageUser={{ slurm_db_username }}
 AccountingStoragePass=/var/run/munge/munge.socket.2
 #
 # COMPUTE NODES
-{% if slurm_manage_gpus == 'yes' %} GresTypes=gpu {% endif %}
+{% if slurm_manage_gpus %}
+GresTypes=gpu
+{% endif %}
 {% for node_name in groups['slurm-node'] %}
 {% set memory =  hostvars[node_name]["ansible_local"]["memory"] -%}
 {% set cpu_topology =  hostvars[node_name]["ansible_local"]["topology"]["cpu_topology"] -%}
 {% set gpu_topology =  hostvars[node_name]["ansible_local"]["topology"]["gpu_topology"] -%}
     NodeName={{ node_name }}{{ " " -}}
-    {% if slurm_manage_gpus == 'yes' %} {%- if gpu_topology|count %} Gres=gpu:{{ gpu_topology|count }} {% endif -%} {% endif %}
+    {% if slurm_manage_gpus %} {%- if gpu_topology|count %} Gres=gpu:{{ gpu_topology|count }} {% endif -%} {% endif %}
     CPUs={{ cpu_topology.logical_cpus|int }}{{ " " -}}
     Sockets={{ cpu_topology.sockets|int }}{{ " " -}}
     CoresPerSocket={{ cpu_topology.cores_per_socket|int }}{{ " " -}}


### PR DESCRIPTION
* Fix whitespace issues with "Gres=" line.
* Allow slurm_manage_gpus=yes (bool, not string)

Verified working:
```
$ srun --gres=gpu sh -c 'nvidia-smi -L | wc -l'
1

$ srun --gres=gpu:8 sh -c 'nvidia-smi -L | wc -l'
8
```