### PR TITLE
[slurm] In epilog, user may not be in docker group

### DIFF
--- a/roles/slurm/files/epilog-parts.d/22-lastuserjob-docker
+++ b/roles/slurm/files/epilog-parts.d/22-lastuserjob-docker
@@ -3,4 +3,4 @@ set -ex
 
 getent group docker || exit 0  # docker not installed
 
-gpasswd -d "$SLURM_JOB_USER" docker
+gpasswd -d "$SLURM_JOB_USER" docker || true


### PR DESCRIPTION
It is possible to trigger an epilog without ever triggering a prolog. e.g.
```console
$ salloc -n1
$ sbcast /tmp/foo /tmp/foo
$ exit  # triggers an epilog
```