### PR TITLE
Remove localhost from inventory as cache_builder

### DIFF
--- a/config.example/inventory
+++ b/config.example/inventory
@@ -64,12 +64,6 @@ slurm-node
 #slurm-node
 
 ######
-# OFFLINE CACHE BUILDER
-######
-[cache_builder]
-localhost	ansible_connection=local
-
-######
 # SSH connection configuration
 ######
 [all:vars]

--- a/playbooks/build-offline-cache.yml
+++ b/playbooks/build-offline-cache.yml
@@ -6,7 +6,8 @@
 # to be run on an admin's laptop or some other non-DeepOps host, and there
 # are many ways to install Docker that a user may otherwise prefer on their
 # own system. So let's just make sure it's present.
-- hosts: cache_builder
+- hosts: 127.0.0.1
+  connection: local
   become: no
   tasks:
   - name: check for docker
@@ -15,7 +16,8 @@
     - skip_ansible_lint
 
 # Install prerequisite tools
-- hosts: cache_builder
+- hosts: 127.0.0.1
+  connection: local
   become: yes
   tasks:
   - name: install necessary system packages
@@ -46,7 +48,8 @@
     - "docker-py"
 
 # Download everything
-- hosts: cache_builder
+- hosts: 127.0.0.1
+  connection: local
   become: no
   tasks:
   - name: build an online cache

--- a/scripts/build_offline_cache.sh
+++ b/scripts/build_offline_cache.sh
@@ -39,13 +39,13 @@ fi
 get_all_helm_tgzs() {
     local repo_url="$1"
     rm -f index.yaml
-    wget $repo_url/index.yaml
+    wget "$repo_url/index.yaml"
     tgzs="$(ruby -ryaml -e \
         "YAML.load_file('index.yaml')['entries'].each do |k,e|;for c in e;puts c['urls'][0];end;end")"
     pushd mirror/
     for tgz in $tgzs; do
         if [ ! -f "${tgz##*/}" ]; then
-            wget $tgz >/dev/null 2>&1 || echo "Couldn't download ${tgz}, skipping..."
+            wget "$tgz" >/dev/null 2>&1 || echo "Couldn't download ${tgz}, skipping..."
         fi
     done
     popd
@@ -92,7 +92,6 @@ ansible-playbook -b \
 echo "Downloading other DeepOps dependencies"
 cd "${ROOT_DIR}" || exit 1
 ansible-playbook \
-	-i "${DEEPOPS_CONFIG_DIR}/inventory" \
 	-e offline_cache_dir="${DEST_DIR}" \
 	playbooks/build-offline-cache.yml
 


### PR DESCRIPTION
Addresses #265.

Instead of putting localhost in inventory, specify local connection explicitly for the `build-offline-cache.yml` playbook.

I had used a name in inventory previously so that the user could build the cache on a separate host, but realistically this will be run from localhost directly most of the time. If they want to use a separate host workflow the user should be able to edit the playbook themselves.

PR also includes a couple of minor lint fixes.