### PR TITLE
Restart docker after installing nvidia-docker in DGX role

### DIFF
--- a/roles/nvidia-dgx/handlers/main.yml
+++ b/roles/nvidia-dgx/handlers/main.yml
@@ -13,3 +13,7 @@
   reboot:
   when: install_driver.changed and not nvidia_driver_skip_reboot
 
+- name: restart docker
+  service:
+    name: docker
+    state: restarted

--- a/roles/nvidia-dgx/tasks/redhat.yml
+++ b/roles/nvidia-dgx/tasks/redhat.yml
@@ -88,6 +88,8 @@
   with_items:
     - docker
     - "@NVIDIA container runtime"
+  notify:
+    - name: restart docker
 
 - name: Install DGX System Management Tools
   yum:

--- a/roles/nvidia-dgx/tasks/ubuntu.yml
+++ b/roles/nvidia-dgx/tasks/ubuntu.yml
@@ -25,6 +25,8 @@
   with_items:
     - "{{ PKGS_DGX1_ALL }}"
   when: ansible_product_name == "DGX-1"
+  notify:
+    - name: restart docker
 
 - name: install dgx packages
   apt:
@@ -34,3 +36,5 @@
   with_items:
     - "{{ PKGS_DGX2_ALL }}"
   when: ansible_product_name == "DGX-2"
+  notify:
+    - name: restart docker


### PR DESCRIPTION
A restart of docker is required after installing nvidia-docker.