### PR TITLE
Pin ansible version in setup.sh, and fail if invalid version present

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -28,7 +28,7 @@ case "$ID" in
 	    current_version=$(ansible --version | head -n1 | awk '{print $2}')
 	    if ! echo "${current_version}" | grep "${ANSIBLE_OK}" >/dev/null 2>&1; then
 	        echo "Unsupported version of Ansible: ${current_version}"
-		echo "Version must match ${ANSIBLE_OK}"
+		echo "Version must match ${ANSIBLE_OK}.x"
 		exit 1
 	    fi
 	fi
@@ -90,7 +90,7 @@ case "$ID" in
 	    current_version=$(ansible --version | head -n1 | awk '{print $2}')
 	    if ! echo "${current_version}" | grep "${ANSIBLE_OK}" >/dev/null 2>&1; then
 	        echo "Unsupported version of Ansible: ${current_version}"
-		echo "Version must match ${ANSIBLE_OK}"
+		echo "Version must match ${ANSIBLE_OK}.x"
 		exit 1
 	    fi
 	fi


### PR DESCRIPTION
This is needed because our current version of Kubespray is unsupported in Ansible 2.8.

Installing Ansible via `pip` because CentOS distro repos don't maintain packages in 2.7 series.