### PR TITLE
deepops namespace

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -73,14 +73,14 @@ pipeline {
             chmod 755 $K8S_CONFIG_DIR/artifacts/kubectl
             cat config/helm/metallb.yml
             cat config/helm/ingress.yml
-            kubectl describe service nginx-ingress-controller
-            kubectl describe pod -l app=metallb,component=controller
+            kubectl -n deepops describe service nginx-ingress-controller
+            kubectl -n deepops describe pod -l app=metallb,component=controller
             kubectl get pods
             kubectl get services --all-namespaces
             sleep 30
             kubectl get pods
             kubectl get services
-            nginx_external_ip=$(kubectl get services -l app=nginx-ingress,component=controller --no-headers | awk '{print $4}')
+            nginx_external_ip=$(kubectl -n deepops get services -l app=nginx-ingress,component=controller --no-headers | awk '{print $4}')
             curl "http://${nginx_external_ip}/" 
           '''
 

--- a/scripts/k8s_deploy_ingress.sh
+++ b/scripts/k8s_deploy_ingress.sh
@@ -25,7 +25,7 @@ fi
 
 # Set up the ingress controller
 if ! helm status "${app_name}" >/dev/null 2>&1; then
-	helm install --name "${app_name}" --values "${config_dir}/helm/ingress.yml" stable/nginx-ingress
+	helm install --name "${app_name}" --namespace deepops --values "${config_dir}/helm/ingress.yml" stable/nginx-ingress
 fi
 
-kubectl wait --for=condition=Ready -l "app=${app_name},component=controller" --timeout=90s pod
+kubectl -n deepops wait --for=condition=Ready -l "app=${app_name},component=controller" --timeout=90s pod

--- a/scripts/k8s_deploy_loadbalancer.sh
+++ b/scripts/k8s_deploy_loadbalancer.sh
@@ -21,7 +21,7 @@ fi
 
 # Set up the MetalLB load balancer
 if ! helm status metallb >/dev/null 2>&1; then
-	helm install --values "${config_dir}/helm/metallb.yml" --name metallb stable/metallb
+	helm install --values "${config_dir}/helm/metallb.yml" --name metallb --namespace deepops stable/metallb
 fi
 
-kubectl wait --for=condition=Ready -l app=metallb,component=controller pod
+kubectl -n deepops wait --for=condition=Ready -l app=metallb,component=controller pod


### PR DESCRIPTION
Move DeepOps services that were previously installed under `default` to `deepops`.

TODOs
[ ] ENV override for `deepops` if you wish to customize the namespace used.
[ ] add other services that previously got deployed under default