### PR TITLE
Set the same user password on all hosts

### DIFF
--- a/playbooks/user-password.yml
+++ b/playbooks/user-password.yml
@@ -2,17 +2,21 @@
 # Generate password for user
 # You can also generate a password with `mkpasswd -m sha-512`
 - hosts: all
-  become: true
   gather_facts: false
   vars:
     pwgen: "{{ lookup('password', '/dev/null length=8 chars=ascii_letters') }}"
   tasks:
     - set_fact:
         passwd: "{{ pwgen }}"
+      delegate_to: localhost
+      delegate_facts: true
+      run_once: true
 
 - hosts: all
   become: true
   tasks:
+    - set_fact:
+        passwd: "{{ hostvars['localhost'].passwd }}"
     - name: Configure SSH to allow login with password
       include_role:
         name: dev-sec.ssh-hardening


### PR DESCRIPTION
Previously you would get a different password on every host, which is kind of annoying. This will generate one password and set it on all hosts.