### PR TITLE
Split Jenkinsfile into function-specific scripts

### DIFF
--- a/.jenkins-scripts/munge-files.sh
+++ b/.jenkins-scripts/munge-files.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+if [ -z "${GPUDATA+x}" ]; then
+	echo "GPUDATA variable is not set, are we running in Jenkins?"
+	echo "Bailing!"
+	exit 1
+fi
+
+GPU="$(echo "${GPUDATA}" | cut -d"-" -f1)"
+export GPU
+BUS="$(echo "${GPUDATA}" | cut -d"-" -f2)"
+export BUS
+
+echo "modify GPU passthrough to point to this resource's GPU"
+sed -i -e "s/#v.pci :bus => '0x08', :slot => '0x00', :function => '0x0'/v.pci :bus => '$BUS', :slot => '0x00', :function => '0x0'/g" virtual/Vagrant*
+
+echo "modify CPU and RAM requirements"
+git grep -lz "v.cpus = 2" virtual/ | xargs -0 sed -i -e "s/v.cpus = 2/v.cpus = 4/g"
+git grep -lz "v.memory = 2048" virtual/ | xargs -0 sed -i -e "s/v.memory = 2048/v.memory = 16384/g"
+
+echo "modify machine names and IPs"
+git grep -lz virtual-mgmt virtual/ | xargs -0 sed -i -e "s/virtual-mgmt/virtual-mgmt-${GPU}/g"
+git grep -lz virtual-login virtual/ | xargs -0 sed -i -e "s/virtual-login/virtual-login-${GPU}/g"
+git grep -lz virtual-gpu01 virtual/ | xargs -0 sed -i -e "s/virtual-gpu01/virtual-gpu01-${GPU}/g"
+git grep -lz 10.0.0.2 virtual/ | xargs -0 sed -i -e "s/10.0.0.2/10.0.0.2${GPU}/g"
+git grep -lz 10.0.0.4 virtual/ | xargs -0 sed -i -e "s/10.0.0.4/10.0.0.4${GPU}/g"
+git grep -lz 10.0.0.11 virtual/ | xargs -0 sed -i -e "s/10.0.0.11/10.0.0.11${GPU}/g"
+
+echo "Also fix IPs in the load balancer config"
+sed -i -e  "s/10\\.0\\.0\\.100-10\\.0\\.0\\.110$/10.0.0.1${GPU}0-10.0.0.1${GPU}9/g" config.example/helm/metallb.yml
+
+echo "Increase debug scope for ansible-playbook commands"
+sed -i -e "s/ansible-playbook/ansible-playbook -v/g" virtual/scripts/*

--- a/.jenkins-scripts/run-gpu-job.sh
+++ b/.jenkins-scripts/run-gpu-job.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+pwd
+cd virtual || exit 1
+
+K8S_CONFIG_DIR=$(pwd)/config
+export KUBECONFIG="${K8S_CONFIG_DIR}/artifacts/admin.conf"
+export PATH="${K8S_CONFIG_DIR}/artifacts:${PATH}"
+
+chmod 755 "$K8S_CONFIG_DIR/artifacts/kubectl"
+kubectl get nodes
+kubectl run gpu-test --rm -t -i --restart=Never --image=nvidia/cuda --limits=nvidia.com/gpu=1 -- nvidia-smi

--- a/.jenkins-scripts/test-cluster-up.sh
+++ b/.jenkins-scripts/test-cluster-up.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+pwd
+cd virtual || exit 1
+bash ./vagrant_startup.sh
+bash ./cluster_up.sh

--- a/.jenkins-scripts/test-slurm-job.sh
+++ b/.jenkins-scripts/test-slurm-job.sh
@@ -5,5 +5,6 @@ ssh -v \
 	-o "StrictHostKeyChecking no" \
 	-o "UserKnownHostsFile /dev/null" \
 	-l vagrant \
-	-i "${HOME}/.ssh/id_rsa 10.0.0.4${GPU}" \
+	-i "${HOME}/.ssh/id_rsa" \
+	"10.0.0.4${GPU}" \
 	srun -n1 hostname

--- a/.jenkins-scripts/test-slurm-job.sh
+++ b/.jenkins-scripts/test-slurm-job.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+pwd
+GPU="$(echo "${GPUDATA}" | cut -d"-" -f1)"
+ssh -v \
+	-o "StrictHostKeyChecking no" \
+	-o "UserKnownHostsFile /dev/null" \
+	-l vagrant \
+	-i "${HOME}/.ssh/id_rsa 10.0.0.4${GPU}" \
+	srun -n1 hostname

--- a/.jenkins-scripts/verify-ingress-config.sh
+++ b/.jenkins-scripts/verify-ingress-config.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+pwd
+cd virtual || exit 1
+
+K8S_CONFIG_DIR="$(pwd)/config"
+export KUBECONFIG="${K8S_CONFIG_DIR}/artifacts/admin.conf"
+export PATH="${K8S_CONFIG_DIR}/artifacts:${PATH}"
+
+chmod 755 "$K8S_CONFIG_DIR/artifacts/kubectl"
+nginx_external_ip=$(kubectl get services -l app=nginx-ingress,component=controller --no-headers | awk '{print $4}')
+curl "http://${nginx_external_ip}/" 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,77 +11,24 @@ pipeline {
       steps {
         // TODO: ideally lock should work with declared stages
         lock(resource: null, label: 'gpu', quantity: 1, variable: 'GPUDATA') {
-          echo "Modifying Vagrantfiles"
+          echo "Munge files for testing"
           sh '''
-            pwd
-            export GPU="$(echo ${GPUDATA} | cut -d"-" -f1)"
-            export BUS="$(echo ${GPUDATA} | cut -d"-" -f2)"
-            # modify GPU passthrough to point to this resource's GPU
-            sed -i -e "s/#v.pci :bus => '0x08', :slot => '0x00', :function => '0x0'/v.pci :bus => '$BUS', :slot => '0x00', :function => '0x0'/g" virtual/Vagrant*
-            # modify CPU and RAM requirements
-            git grep -lz "v.cpus = 2" virtual/ | xargs -0 sed -i -e "s/v.cpus = 2/v.cpus = 4/g"
-            git grep -lz "v.memory = 2048" virtual/ | xargs -0 sed -i -e "s/v.memory = 2048/v.memory = 16384/g"
-            # modify machine names and IPs
-            git grep -lz virtual-mgmt virtual/ | xargs -0 sed -i -e "s/virtual-mgmt/virtual-mgmt-$GPU/g"
-            git grep -lz virtual-login virtual/ | xargs -0 sed -i -e "s/virtual-login/virtual-login-$GPU/g"
-            git grep -lz virtual-gpu01 virtual/ | xargs -0 sed -i -e "s/virtual-gpu01/virtual-gpu01-$GPU/g"
-            git grep -lz 10.0.0.2 virtual/ | xargs -0 sed -i -e "s/10.0.0.2/10.0.0.2$GPU/g"
-            git grep -lz 10.0.0.4 virtual/ | xargs -0 sed -i -e "s/10.0.0.4/10.0.0.4$GPU/g"
-            git grep -lz 10.0.0.11 virtual/ | xargs -0 sed -i -e "s/10.0.0.11/10.0.0.11$GPU/g"
-          '''
-
-          echo "Modifying loadbalancer config to use unique IPs"
-          sh '''
-            pwd
-            export GPU="$(echo ${GPUDATA} | cut -d"-" -f1)"
-            cat config.example/helm/metallb.yml
-            sed -i -e  "s/10\\.0\\.0\\.100-10\\.0\\.0\\.110$/10.0.0.1${GPU}0-10.0.0.1${GPU}9/g" config.example/helm/metallb.yml
-            cat config.example/helm/metallb.yml
-          '''
-
-          echo "Increase debug scope for ansible-playbook commands"
-          sh '''
-            sed -i -e "s/ansible-playbook/ansible-playbook -v/g" virtual/scripts/*
+            bash -x ./.jenkins-scripts/munge-files.sh
           '''
 
           echo "Cluster Up"
           sh '''
-            pwd
-            cd virtual
-            ./vagrant_startup.sh
-            ./cluster_up.sh
+            bash -x ./.jenkins-scripts/test-cluster-up.sh
           '''
 
-          // TODO: Use junit-style tests
           echo "Verify we can run a GPU job"
           sh '''
-            cd virtual
-            export K8S_CONFIG_DIR=$(pwd)/config
-            export KUBECONFIG="${K8S_CONFIG_DIR}/artifacts/admin.conf"
-            export PATH="${K8S_CONFIG_DIR}/artifacts:${PATH}"
-            chmod 755 $K8S_CONFIG_DIR/artifacts/kubectl
-            kubectl get nodes
-            kubectl run gpu-test --rm -t -i --restart=Never --image=nvidia/cuda --limits=nvidia.com/gpu=1 -- nvidia-smi
+            bash -x ./.jenkins-scripts/run-gpu-job.sh
           '''
 
           echo "Verify ingress config"
           sh '''
-            cd virtual
-            export K8S_CONFIG_DIR="$(pwd)/config"
-            export KUBECONFIG="${K8S_CONFIG_DIR}/artifacts/admin.conf"
-            export PATH="${K8S_CONFIG_DIR}/artifacts:${PATH}"
-            chmod 755 $K8S_CONFIG_DIR/artifacts/kubectl
-            cat config/helm/metallb.yml
-            cat config/helm/ingress.yml
-            kubectl describe service nginx-ingress-controller
-            kubectl describe pod -l app=metallb,component=controller
-            kubectl get pods
-            kubectl get services --all-namespaces
-            sleep 30
-            kubectl get pods
-            kubectl get services
-            nginx_external_ip=$(kubectl get services -l app=nginx-ingress,component=controller --no-headers | awk '{print $4}')
-            curl "http://${nginx_external_ip}/" 
+             bash -x ./.jenkins-scripts/verify-ingress-config.sh
           '''
 
           echo "Set up Slurm"
@@ -93,9 +40,7 @@ pipeline {
 
           echo "Test Slurm"
           sh '''
-            pwd
-            export GPU="$(echo ${GPUDATA} | cut -d"-" -f1)"
-            ssh -v -o "StrictHostKeyChecking no" -o "UserKnownHostsFile /dev/null" -l vagrant -i $HOME/.ssh/id_rsa 10.0.0.4$GPU srun -n1 hostname
+            bash -x ./.jenkins-scripts/test-slurm-job.sh
           '''
         }
       }


### PR DESCRIPTION
Take most shell commands out of the Jenkinsfile and split into function-specific scripts.

This has the dual purpose of making the Jenkinsfile more readable, and eventually making it easier to write tests in nicer languages.

Note: this is a WIP because it can only be tested by opening a PR. ;-P Will ping reviewers directly once it passes tests and is ready to go.