### PR TITLE
Add explicit statement of Linux distributions supported to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,14 @@ For detailed help or guidance, read through our [Getting Started Guide](docs/get
 
 ## Deployment Options
 
+### Supported distributions
+
+DeepOps currently supports the following Linux distributions:
+
+* NVIDIA DGX OS 4
+* Ubuntu 18.04 LTS
+* CentOS 7
+
 ### Kubernetes
 
 Kubernetes (K8s) is an open-source system for automating deployment, scaling, and management of containerized applications.


### PR DESCRIPTION
Make it clearer which Linux distributions are supported by DeepOps.

Current list is my current best guess, @dholt should comment if I'm missing anything here.