### PR TITLE
Fix script usage of `apt` to use `apt-get`

### DIFF
--- a/scripts/install_dgxie_prereqs.sh
+++ b/scripts/install_dgxie_prereqs.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
 # install required software
-sudo apt update
-sudo apt install -y git ipmitool vim software-properties-common sshpass
+sudo apt-get update
+sudo apt-get install -y git ipmitool vim software-properties-common sshpass
 
 # install docker
 type docker >/dev/null 2>&1
@@ -10,8 +10,8 @@ if [ $? -ne 0 ] ; then
     sudo apt-get install -y apt-transport-https ca-certificates curl software-properties-common
     curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
     sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
-    sudo apt update
-    sudo apt install -y docker-ce
+    sudo apt-get update
+    sudo apt-get install -y docker-ce
     docker --version
 fi
 

--- a/scripts/install_helm.sh
+++ b/scripts/install_helm.sh
@@ -27,7 +27,7 @@ case "$ID_LIKE" in
         ;;
     debian*)
         if ! type curl >/dev/null 2>&1 ; then
-            sudo apt -y install curl
+            sudo apt-get -y install curl
         fi
         ;;
     *)

--- a/scripts/k8s_deploy_kubeflow.sh
+++ b/scripts/k8s_deploy_kubeflow.sh
@@ -27,7 +27,7 @@ case "$ID_LIKE" in
     debian*)
         type curl >/dev/null 2>&1
         if [ $? -ne 0 ] ; then
-            sudo apt -y install curl wget
+            sudo apt-get -y install curl wget
         fi
         ;;
     *)

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -127,7 +127,7 @@ case "$ID" in
         type git >/dev/null 2>&1
         if [ $? -ne 0 ] ; then
             echo "Installing git..."
-            sudo apt -y install git >/dev/null
+            sudo apt-get -y install git >/dev/null
         fi
         git --version
 
@@ -135,14 +135,14 @@ case "$ID" in
         type ipmitool >/dev/null 2>&1
         if [ $? -ne 0 ] ; then
             echo "Installing IPMITool..."
-            sudo apt -y install ipmitool >/dev/null
+            sudo apt-get -y install ipmitool >/dev/null
         fi
         ipmitool -V
 
         # Install wget
         if ! which wget >/dev/null 2>&1; then
         echo "Installing wget..."
-            sudo apt -y install wget >/dev/null
+            sudo apt-get -y install wget >/dev/null
         fi
         wget --version | head -1
         ;;

--- a/scripts/setup_remote_k8s.sh
+++ b/scripts/setup_remote_k8s.sh
@@ -14,7 +14,7 @@ case "$ID_LIKE" in
     debian*)
         type curl >/dev/null 2>&1
         if [ $? -ne 0 ] ; then
-            sudo apt -y install curl
+            sudo apt-get -y install curl
         fi
         ;;
     *)

--- a/virtual/vagrant_startup.sh
+++ b/virtual/vagrant_startup.sh
@@ -76,11 +76,11 @@ case "$ID" in
       echo "Installing apt dependencies..."
 
       # Update apt
-      sudo apt update -y
+      sudo apt-get update -y
 
       # Install build-essential tools
       # shellcheck disable=SC2086
-      sudo apt install -y $APT_DEPENDENCIES
+      sudo apt-get install -y $APT_DEPENDENCIES
     fi
 
     # Ensure we have permissions to manage VMs


### PR DESCRIPTION
`apt` is a user-facing tool which does not guarantee a stable command
line API. `apt-get` is the recommended tool for use in scripts.

This is a minor issue, but it bugs me every time I watch `apt` print
that warning, and it does provide a little future-proofing for the
scripts. :-)