### PR TITLE
No interactive prompts from apt in scripts

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -74,6 +74,8 @@ case "$ID" in
         wget --version | head -1
         ;;
     ubuntu*)
+	# No interactive prompts from apt during this process
+	export DEBIAN_FRONTEND=noninteractive
         # Update apt cache
         echo "Updating apt cache..."
         sudo apt-get update >/dev/null

--- a/virtual/vagrant_startup.sh
+++ b/virtual/vagrant_startup.sh
@@ -66,6 +66,8 @@ case "$ID" in
     ;;
 
   ubuntu*)
+    # No interactive prompts from apt during this process
+    export DEBIAN_FRONTEND=noninteractive
     # Install Vagrant & Dependencies for Debian Systems
 
     export APT_DEPENDENCIES="build-essential sshpass qemu-kvm libvirt-bin libvirt-dev bridge-utils \


### PR DESCRIPTION
I often run DeepOps to help set up completely fresh Ubuntu installs, and may not have done any package upgrades before I kick off `setup.sh`.

Unfortunately, the `-y` flag on `apt-get` does not suppress all interactive prompts; it only says "yes" to making the package changes in the first place. I have frequently seen fresh Ubuntu 18.04 installs hang on this script due to interactive prompts for service restarts. This is a *pain*, and means I often end up having to Ctrl-C out of the script to fix things manually.

This PR sets `DEBIAN_FRONTEND=noninteractive` to suppress this prompt and accept the default choice when running `apt-get` in `setup.sh` and the virtual setup script.