### PR TITLE
Kubeflow 6 2

### DIFF
--- a/docs/kubeflow.md
+++ b/docs/kubeflow.md
@@ -1,0 +1,30 @@
+# Kubeflow
+
+[Kubeflow](https://www.kubeflow.org/docs/) is a K8S native tool that eases the Deep Learning and Machine learning lifecycle.
+
+Kubeflow allows users to request specific resources (such as number of GPUs and CPUs), specify Docker images, and easily launch and develop through Jupyter models. Kubeflow makes it easy to create persistent home directories, mount data volumes, and share notebooks within a team.
+
+Kubeflow also offers a full deep learning [pipeline](https://www.kubeflow.org/docs/pipelines/overview/pipelines-overview/) platform that allows you to run, track, and version experiments. Pipelines can be used to deploy code to production and can include all steps in the training process (data prep, training, tuning, etc.) each done through different Docker images.
+
+Additionally Kubeflow offers [hyper-parameter tuning](https://github.com/kubeflow/katib) options.
+
+Kubeflow is an [open source project](https://github.com/kubeflow/kubeflow) and is regularly evolving and adding [new features](https://github.com/kubeflow/kubeflow/blob/master/ROADMAP.md).
+
+## Installation
+
+Deploy Kubernetes by following the [Kubernetes GPU Cluster Deployment Guide](kubernetes-cluster.md)
+
+Deploy [Ceph](kubernetes-cluster.md#persistent-storage)
+
+Deploy the [LoadBalancer](ingress.md#on-prem-loadbalancer). This step is not required if you specify the `-x` option, however doing so will not include built-in multi-user support.
+
+
+Deploy Kubeflow:
+
+```sh
+# Deploy
+./scripts/k8s_deploy_kubeflow.sh
+
+```
+
+See the [install docs](https://www.kubeflow.org/docs/started/k8s/overview/) for additional install configuration options.

--- a/docs/kubeflow.md
+++ b/docs/kubeflow.md
@@ -28,3 +28,9 @@ Deploy Kubeflow:
 ```
 
 See the [install docs](https://www.kubeflow.org/docs/started/k8s/overview/) for additional install configuration options.
+
+Deploy older version of Kubeflow with built-in NGC support:
+
+```sh
+./scripts/k8s_deploy_kubeflow.v0.5.1.sh
+```

--- a/roles/nvidia-dgx/tasks/main.yml
+++ b/roles/nvidia-dgx/tasks/main.yml
@@ -2,7 +2,7 @@
 - name: Check for DGX
   fail:
     msg: "Role supports DGX-1 and DGX-2 systems only"
-  when: ansible_product_name != "DGX-1" and ansible_product_name != "DGX-2"
+  when: ansible_product_name is not search("DGX-1") and ansible_product_name is not search("DGX-2")
 
 - name: ubuntu tasks
   include_tasks: ubuntu.yml

--- a/roles/nvidia-dgx/tasks/redhat.yml
+++ b/roles/nvidia-dgx/tasks/redhat.yml
@@ -21,14 +21,14 @@
     name: "@DGX-1 Configurations"
     state: present
     update_cache: yes
-  when: ansible_product_name == "DGX-1"
+  when: ansible_product_name is search("DGX-1")
 
 - name: Install packages
   yum:
     name: "@DGX-2 Configurations"
     state: present
     update_cache: yes
-  when: ansible_product_name == "DGX-2"
+  when: ansible_product_name is search("DGX-2")
 
 - name: Install extra packages
   yum:

--- a/roles/nvidia-dgx/tasks/ubuntu.yml
+++ b/roles/nvidia-dgx/tasks/ubuntu.yml
@@ -24,7 +24,7 @@
     update_cache: yes
   with_items:
     - "{{ PKGS_DGX1_ALL }}"
-  when: ansible_product_name == "DGX-1"
+  when: ansible_product_name is search("DGX-1")
   notify:
     - name: restart docker
 
@@ -35,6 +35,6 @@
     update_cache: yes
   with_items:
     - "{{ PKGS_DGX2_ALL }}"
-  when: ansible_product_name == "DGX-2"
+  when: ansible_product_name is search("DGX-2")
   notify:
     - name: restart docker

--- a/scripts/k8s_deploy_kubeflow.sh
+++ b/scripts/k8s_deploy_kubeflow.sh
@@ -122,8 +122,8 @@ function stand_up() {
   ${KFCTL} generate all -V
   ${KFCTL} apply all -V
 
-  echo 'cd ${KFAPP} && ${KFCTL} delete -V k8s; cd && sudo rm -rf ${KFAPP}; sudo rm ${KFCTL}' > ${KUBEFLOW_DEL_SCRIPT}
-  echo 'cd ${KFAPP} && ${KFCTL} delete -V all; cd && sudo rm -rf ${KFAPP}; sudo rm ${KFCTL}' > ${KUBEFLOW_DEL_SCRIPT}_full.sh
+  echo "cd ${KFAPP} && ${KFCTL} delete -V k8s; cd && sudo rm -rf ${KFAPP}; sudo rm ${KFCTL}" > ${KUBEFLOW_DEL_SCRIPT}
+  echo "cd ${KFAPP} && ${KFCTL} delete -V all; cd && sudo rm -rf ${KFAPP}; sudo rm ${KFCTL}" > ${KUBEFLOW_DEL_SCRIPT}_full.sh
   chmod +x ${KUBEFLOW_DEL_SCRIPT}
 }
 

--- a/scripts/k8s_deploy_kubeflow.sh
+++ b/scripts/k8s_deploy_kubeflow.sh
@@ -1,19 +1,16 @@
 #!/usr/bin/env bash
 
-export KS_VER=0.13.1
-export KS_PKG=ks_${KS_VER}_linux_amd64
-export KS_INSTALL_DIR=/usr/local/bin
+export KFAPP=~/kubeflow
+export KFCTL=~/kfctl
+export KUBEFLOW_TAG=v0.6.2
+export KFCTL_URL=https://github.com/kubeflow/kubeflow/releases/download/${KUBEFLOW_TAG}/kfctl_${KUBEFLOW_TAG}_linux.tar.gz
+export CONFIG="https://raw.githubusercontent.com/kubeflow/kubeflow/v0.6-branch/bootstrap/config/kfctl_existing_arrikto.0.6.2.yaml"
+export CONFIG="https://raw.githubusercontent.com/kubeflow/kubeflow/v0.6-branch/bootstrap/config/kfctl_k8s_istio.0.6.2.yaml"
 
-export KUBEFLOW_TAG=v0.5.1
-export KFAPP=kubeflow
-export KUBEFLOW_SRC=/opt/kubeflow
 
-export DEEPOPS_DIR=$(dirname $(dirname  $(readlink -f $0)))
-
-KSONNET_URL="${KSONNET_URL:-https://github.com/ksonnet/ksonnet/releases/download/v${KS_VER}/${KS_PKG}.tar.gz}"
-KUBEFLOW_URL="${KUBEFLOW_URL:-https://raw.githubusercontent.com/kubeflow/kubeflow/${KUBEFLOW_TAG}/scripts/download.sh}"
-
-###
+# Specify credentials for the default user.
+export KUBEFLOW_USER_EMAIL="admin@kubeflow.org"
+export KUBEFLOW_PASSWORD="12341234"
 
 # Install dependencies
 . /etc/os-release
@@ -27,7 +24,7 @@ case "$ID_LIKE" in
     debian*)
         type curl >/dev/null 2>&1
         if [ $? -ne 0 ] ; then
-            sudo apt-get -y install curl wget
+            sudo apt -y install curl wget
         fi
         ;;
     *)
@@ -44,77 +41,35 @@ if [ $? -eq 0 ] ; then
     exit 1
 fi
 
-# Ksonnet
-wget -O /tmp/${KS_PKG}.tar.gz "${KSONNET_URL}" \
-      --no-check-certificate
-mkdir -p ${KS_INSTALL_DIR}
-tempd=$(mktemp -d)
-tar -xvf /tmp/${KS_PKG}.tar.gz -C ${tempd}
-sudo mv ${tempd}/${KS_PKG}/ks ${KS_INSTALL_DIR}
-rm -rf ${tempd} /tmp/${KS_PKG}.tar.gz
+# Download the kfctl binary and move it to the default location
+pushd .
+mkdir /tmp/kf-download
+cd /tmp/kf-download
+curl -O -L ${KFCTL_URL}
+tar -xvf kfctl_${KUBEFLOW_TAG}_linux.tar.gz
+mv kfctl ${KFCTL}
+popd
+rm -rf /tmp/kf-download
 
-# Kubeflow
-if [ ! -d ${KUBEFLOW_SRC} ] ; then
-    tempd=$(mktemp -d)
-    cd ${tempd}
-    curl "${KUBEFLOW_URL}" | bash
-    cd -
-    sudo mv ${tempd} ${KUBEFLOW_SRC}
-fi
-
-# Get master ip
-master_ip=$(kubectl get nodes -l node-role.kubernetes.io/master= --no-headers -o custom-columns=IP:.status.addresses.*.address | cut -f1 -d, | head -1)
-
-# Check for ingress controller
-ingress_name="nginx-ingress"
-ingress_ip_string="$(echo ${master_ip} | tr '.' '-')"
-if kubectl describe service -l "app=${ingress_name},component=controller" | grep 'LoadBalancer Ingress' >/dev/null 2>&1; then
-    lb_ip="$(kubectl describe service -l "app=${ingress_name},component=controller" | grep 'LoadBalancer Ingress' | awk '{print $3}')"
-    ingress_ip_string="$(echo ${lb_ip} | tr '.' '-').nip.io"
-    echo "Using load balancer url: ${ingress_ip_string}"
-fi
-
-# Initialize and generate kubeflow
-set -e # XXX: Fail if anything in the initialization or configuration fail
-pushd ${HOME}
-${KUBEFLOW_SRC}/scripts/kfctl.sh init ${KFAPP} --platform none
+# Initialize and apply the Kubeflow project using the specified config
+${KFCTL} init ${KFAPP} --config=${CONFIG} -V
 cd ${KFAPP}
+${KFCTL} generate all -V
+${KFCTL} apply all -V
 
-# Update the Kubeflow Jupyter UI
-export KSAPP_DIR="$(pwd)/ks_app"
-export KUBEFLOW_SRC
-${DEEPOPS_DIR}/scripts/update_kubeflow_config.py
-
-${KUBEFLOW_SRC}/scripts/kfctl.sh generate k8s
-pushd ${KSAPP_DIR}
-set +e
-
-# NOTE: temporarily using a custom image, to add custom command functionality
-ks param set jupyter-web-app image deepops/kubeflow-jupyter-web-app:v0.5-custom-command
-
-# Use NodePort directly if the IP string uses the master IP, otherwise use Ingress URL
-if echo "${ingress_ip_string}" | grep "${master_ip}" >/dev/null 2>&1; then
-    ks param set ambassador ambassadorServiceType NodePort
-    popd
-    ${KUBEFLOW_SRC}/scripts/kfctl.sh apply k8s
-    popd
-    kf_ip=$master_ip
-    kf_port=$(kubectl -n kubeflow get svc ambassador --no-headers -o custom-columns=:.spec.ports.*.nodePort)
-    kf_url="http://${kf_ip}:${kf_port}"
-else
-    ks param set ambassador ambassadorServiceType LoadBalancer
-    popd
-    ${KUBEFLOW_SRC}/scripts/kfctl.sh apply k8s
-    popd
-    kf_ip=$(kubectl -n kubeflow get svc ambassador --no-headers -o custom-columns=:.status.loadBalancer.ingress[0].ip)
-    kf_url="http://${kf_ip}"
-fi
+# Get LoadBalancer and NodePorts
+master_ip=$(kubectl get nodes -l node-role.kubernetes.io/master= --no-headers -o custom-columns=IP:.status.addresses.*.address | cut -f1 -d, | head -1)
+nodePort="$(kubectl get svc -n istio-system istio-ingressgateway --no-headers -o custom-columns=PORT:.spec.ports[2].nodePort)
+lb_ip="$(kubectl get svc -n istio-system istio-ingressgateway --no-headers -o -o custom-columns=:.status.loadBalancer.ingress[0].ip)
+kf_url="http://${master_ip}:${nodePort}"
 
 echo
-echo "Kubeflow app installed to: ${HOME}/${KFAPP}"
-echo "To remove, run: cd ${HOME}/${KFAPP} && ${KUBEFLOW_SRC}/scripts/kfctl.sh delete k8s"
-echo "To fully remove all source and application code run: cd ${HOME} && rm -rf ${KFAPP}; rm -rf ${KUBEFLOW_SRC}"
-echo "To fully remove everything: cd ${HOME}/${KFAPP} && ${KUBEFLOW_SRC}/scripts/kfctl.sh delete k8s; cd ${DEEPOPS_DIR} && sudo rm -rf ${KFAPP}; sudo rm -rf ${KUBEFLOW_SRC}"
-echo
+echo "Kubeflow app installed to: ${KFAPP}"
+echo "To remove, run: cd ${KFAPP} && ${KFCTL} delete k8s"
+echo "To fully remove all source and application code run: cd ${HOME} && rm -rf ${KFAPP}; rm ${KFCTL}"
+echo "To fully remove everything:"
+echo "cd ${KFAPP} && ${KFCTL} delete k8s; cd && sudo rm -rf ${KFAPP}; sudo rm ${KFCTL}"
+echo 
 echo "Kubeflow Dashboard: ${kf_url}"
-echo
+echo ${lb_ip}
+echo 

--- a/scripts/k8s_deploy_kubeflow.sh
+++ b/scripts/k8s_deploy_kubeflow.sh
@@ -1,83 +1,223 @@
 #!/usr/bin/env bash
 
-export KFAPP=~/kubeflow
-export KFCTL=~/kfctl
+# Local files/directories to create and place scripts
+export KFAPP=${KFAPP:-~/kubeflow}
+export KFCTL=${KFCTL:-~/kfctl}
+export KUBEFLOW_DEL_SCRIPT="${KFAPP}/deepops-delete-kubeflow.sh"
+
+# Download URLs and versions
 export KUBEFLOW_TAG=v0.6.2
 export KFCTL_URL=https://github.com/kubeflow/kubeflow/releases/download/${KUBEFLOW_TAG}/kfctl_${KUBEFLOW_TAG}_linux.tar.gz
 export CONFIG="https://raw.githubusercontent.com/kubeflow/kubeflow/v0.6-branch/bootstrap/config/kfctl_existing_arrikto.0.6.2.yaml"
-# export CONFIG="https://raw.githubusercontent.com/kubeflow/kubeflow/v0.6-branch/bootstrap/config/kfctl_k8s_istio.0.6.2.yaml"
+export NO_AUTH_CONFIG="https://raw.githubusercontent.com/kubeflow/kubeflow/v0.6-branch/bootstrap/config/kfctl_k8s_istio.0.6.2.yaml"
 
 
 # Specify credentials for the default user.
-export KUBEFLOW_USER_EMAIL="admin@kubeflow.org"
-export KUBEFLOW_PASSWORD="12341234"
+export KUBEFLOW_USER_EMAIL="${KUBEFLOW_USER_EMAIL:-admin@kubeflow.org}"
+export KUBEFLOW_PASSWORD="${KUBEFLOW_PASSWORD:-12341234}"
 
-# Install dependencies
-. /etc/os-release
-case "$ID_LIKE" in
-    rhel*)
-        type curl >/dev/null 2>&1
-        if [ $? -ne 0 ] ; then
-            sudo yum -y install curl wget
-        fi
+
+function help_me() {
+  echo "Usage:"
+  echo "-h    This message."
+  echo "-p    Print out the connection info for Kubeflow"
+  echo "-d    Delete Kubeflow from your system (skipping the istio-system namespace that may have been installed with Kubeflow"
+  echo "-D    Delete Kubeflow from your system along with the istio-system namespace. WARNING, do not use this option if other components depend on istio."
+  echo "-x    Install Kubeflow without multi-user auth (this does not require loadbalancing"
+  echo "-c    Specify a different Kubeflow config to install with"
+}
+
+
+function get_opts() {
+  while getopts "hpc:xdD" option; do
+    case $option in
+      p)
+        KUBEFLOW_PRINT=true
         ;;
-    debian*)
-        type curl >/dev/null 2>&1
-        if [ $? -ne 0 ] ; then
-            sudo apt -y install curl wget
-        fi
+      c)
+	CONFIG=$OPTARG
         ;;
-    *)
-        echo "Unsupported Operating System $ID_LIKE"
+      x)
+	CONFIG=${NO_AUTH_CONFIG}
+	SKIP_LB=true
+        ;;
+      d)
+        KUBEFLOW_DELETE=true
+        ;;
+      D)
+        KUBEFLOW_DELETE=true
+        KUBEFLOW_FULL_DELETE=true
+        ;;
+      h)
+        help_me
         exit 1
         ;;
-esac
+      * )
+        help_me
+        exit 1
+        ;;
+    esac
+  done
+}
 
-# Rook
-kubectl get storageclass 2>&1 | grep "No resources found." >/dev/null 2>&1
-if [ $? -eq 0 ] ; then
-    echo "No storageclass found"
-    echo "To provision Ceph storage, run: ./scripts/k8s_deploy_rook.sh"
-    exit 1
+function install_dependencies() {
+  # Install dependencies
+  . /etc/os-release
+  case "$ID_LIKE" in
+      rhel*)
+          type curl >/dev/null 2>&1
+          if [ $? -ne 0 ] ; then
+              sudo yum -y install curl wget
+          fi
+          ;;
+      debian*)
+          type curl >/dev/null 2>&1
+          if [ $? -ne 0 ] ; then
+              sudo apt -y install curl wget
+          fi
+          ;;
+      *)
+          echo "Unsupported Operating System $ID_LIKE"
+          exit 1
+          ;;
+  esac
+
+  # Rook
+  kubectl get storageclass 2>&1 | grep "No resources found." >/dev/null 2>&1
+  if [ $? -eq 0 ] ; then
+      echo "No storageclass found"
+      echo "To provision Ceph storage, run: ./scripts/k8s_deploy_rook.sh"
+      exit 1
+  fi
+
+  # MetalLB
+  helm list  | grep metallb >/dev/null 2>&1
+  if [ $? -ne 0 ]; then
+      echo "LoadBalancer not found (MetalLB)"
+      if [ ${SKIP_LB} ]; then
+        echo "LoadBalancer not required for alternative install"
+      else
+        echo "To support Kubeflow on-prem with multi-user-auth please install a load balancer by running"
+        echo "./scripts/k8s_deploy_loadbalancer.sh"
+        exit 2
+      fi
+  fi
+}
+
+
+function stand_up() {
+  # Download the kfctl binary and move it to the default location
+  pushd .
+  mkdir /tmp/kf-download
+  cd /tmp/kf-download
+  curl -O -L ${KFCTL_URL}
+  tar -xvf kfctl_${KUBEFLOW_TAG}_linux.tar.gz
+  mv kfctl ${KFCTL}
+  popd
+  rm -rf /tmp/kf-download
+
+  # Initialize and apply the Kubeflow project using the specified config
+  ${KFCTL} init ${KFAPP} --config=${CONFIG} -V
+  cd ${KFAPP}
+  ${KFCTL} generate all -V
+  ${KFCTL} apply all -V
+
+  echo 'cd ${KFAPP} && ${KFCTL} delete -V k8s; cd && sudo rm -rf ${KFAPP}; sudo rm ${KFCTL}' > ${KUBEFLOW_DEL_SCRIPT}
+  echo 'cd ${KFAPP} && ${KFCTL} delete -V all; cd && sudo rm -rf ${KFAPP}; sudo rm ${KFCTL}' > ${KUBEFLOW_DEL_SCRIPT}_full.sh
+  chmod +x ${KUBEFLOW_DEL_SCRIPT}
+}
+
+
+function tear_down() {
+  if [ ${KUBEFLOW_FULL_DELETE} ]; then
+    bash ${KUBEFLOW_DEL_SCRIPT}_full.sh
+
+    # Kubeflow use leads to some user created namespaces that are not torn down during kfctl delete
+    additional_namespaces="kubeflow-anonymous ${KUBEFLOW_EXTRA_NS}"
+    echo "Deleting additional namespaces ${additional_namespaces}, this may take several minutes"
+    kubectl delete ns ${additional_namespaces}
+  else
+    bash ${KUBEFLOW_DEL_SCRIPT}
+  fi
+  rm ${KFCTL}
+}
+
+
+function get_url() {
+  # Get LoadBalancer and NodePorts
+  master_ip=$(kubectl get nodes -l node-role.kubernetes.io/master= --no-headers -o custom-columns=IP:.status.addresses.*.address | cut -f1 -d, | head -1)
+  nodePort="$(kubectl get svc -n istio-system istio-ingressgateway --no-headers -o custom-columns=PORT:.spec.ports[2].nodePort)
+  lb_ip="$(kubectl get svc -n istio-system istio-ingressgateway --no-headers -o -o custom-columns=:.status.loadBalancer.ingress[0].ip)
+  kf_url="http://${master_ip}:${nodePort}"
+}
+
+
+function print_info() {
+  echo
+  echo "Kubeflow app installed to: ${KFAPP}"
+  echo "To remove, run: cd ${KFAPP} && ${KFCTL} delete -V k8s"
+  echo "To remove the kfctl binary: rm ${KFCTL}"
+  echo "To fully remove everything:"
+  echo "bash ${KUBEFLOW_DEL_SCRIPT}"
+  echo 
+  echo "Kubeflow Dashboard: ${kf_url}"
+  echo ${lb_ip}
+  echo
+}
+
+
+function test_script() {
+  # Don't test recursively
+  if [ ${KUBEFLOW_TEST} ]; then
+    export KUBEFLOW_TEST=""
+  else
+    return
+  fi
+
+  ./${0} -dp
+  if [ ${?} -eq 0 ]; then
+    exit 10
+  fi
+  ./${0} -h
+  if [ ${?} -eq 0 ]; then
+    exit 11
+  fi
+  
+  ./${0}
+  if [ ${?} -ne 0 ]; then
+    exit 12 # we should really test with a curl
+  fi
+  ./${0} -D
+  if [ ${?} -ne 0 ]; then
+    exit 13
+  fi
+  ./${0} -x
+  if [ ${?} -ne 0 ]; then
+    exit 14
+  fi
+  ./${0} -e
+  if [ ${?} -ne 0 ]; then
+    exit 15
+  fi
+
+  exit 0
+}
+
+test_script
+
+get_opts ${@}
+
+if [ ${KUBEFLOW_PRINT} ] && [ ${KUBEFLOW_DELETE} ]; then
+  echo "Cannot specify print flag and delete flag"
+  exit 2
+elif [ ${KUBEFLOW_PRINT} ]; then
+  get_url
+  print_info
+elif [ ${KUBEFLOW_DELETE} ]; then
+  tear_down
+else
+  install_dependencies
+  stand_up
+  get_url
+  print_info
 fi
-
-helm list  | grep metallb >/dev/null 2>&1
-if [ $? -ne 0 ]; then
-    echo "LoadBalancer not found (MetalLB)"
-    echo "To support Kubeflow on-prem with multi-user-auth please install a load balancer by running"
-    echo "./scripts/k8s_deploy_loadbalancer.sh"
-    exit 2
-fi
-
-# Download the kfctl binary and move it to the default location
-pushd .
-mkdir /tmp/kf-download
-cd /tmp/kf-download
-curl -O -L ${KFCTL_URL}
-tar -xvf kfctl_${KUBEFLOW_TAG}_linux.tar.gz
-mv kfctl ${KFCTL}
-popd
-rm -rf /tmp/kf-download
-
-# Initialize and apply the Kubeflow project using the specified config
-${KFCTL} init ${KFAPP} --config=${CONFIG} -V
-cd ${KFAPP}
-${KFCTL} generate all -V
-${KFCTL} apply all -V
-
-# Get LoadBalancer and NodePorts
-master_ip=$(kubectl get nodes -l node-role.kubernetes.io/master= --no-headers -o custom-columns=IP:.status.addresses.*.address | cut -f1 -d, | head -1)
-nodePort="$(kubectl get svc -n istio-system istio-ingressgateway --no-headers -o custom-columns=PORT:.spec.ports[2].nodePort)
-lb_ip="$(kubectl get svc -n istio-system istio-ingressgateway --no-headers -o -o custom-columns=:.status.loadBalancer.ingress[0].ip)
-kf_url="http://${master_ip}:${nodePort}"
-
-echo
-echo "Kubeflow app installed to: ${KFAPP}"
-echo "To remove, run: cd ${KFAPP} && ${KFCTL} delete k8s"
-echo "To fully remove all source and application code run: cd ${HOME} && rm -rf ${KFAPP}; rm ${KFCTL}"
-echo "To fully remove everything:"
-echo "cd ${KFAPP} && ${KFCTL} delete k8s; cd && sudo rm -rf ${KFAPP}; sudo rm ${KFCTL}"
-echo 
-echo "Kubeflow Dashboard: ${kf_url}"
-echo ${lb_ip}
-echo 

--- a/scripts/k8s_deploy_kubeflow.sh
+++ b/scripts/k8s_deploy_kubeflow.sh
@@ -146,8 +146,8 @@ function tear_down() {
 function get_url() {
   # Get LoadBalancer and NodePorts
   master_ip=$(kubectl get nodes -l node-role.kubernetes.io/master= --no-headers -o custom-columns=IP:.status.addresses.*.address | cut -f1 -d, | head -1)
-  nodePort="$(kubectl get svc -n istio-system istio-ingressgateway --no-headers -o custom-columns=PORT:.spec.ports[2].nodePort)
-  lb_ip="$(kubectl get svc -n istio-system istio-ingressgateway --no-headers -o -o custom-columns=:.status.loadBalancer.ingress[0].ip)
+  nodePort="$(kubectl get svc -n istio-system istio-ingressgateway --no-headers -o custom-columns=PORT:.spec.ports[2].nodePort)"
+  lb_ip="$(kubectl get svc -n istio-system istio-ingressgateway --no-headers -o custom-columns=:.status.loadBalancer.ingress[0].ip)"
   kf_url="http://${master_ip}:${nodePort}"
 }
 
@@ -160,8 +160,8 @@ function print_info() {
   echo "To fully remove everything:"
   echo "bash ${KUBEFLOW_DEL_SCRIPT}"
   echo 
-  echo "Kubeflow Dashboard: ${kf_url}"
-  echo ${lb_ip}
+  echo "Kubeflow Dashboard (NodePort): ${kf_url}"
+  echo "Kubeflow Dashboard (LoadBalancer): ${lb_ip}"
   echo
 }
 

--- a/scripts/k8s_deploy_kubeflow.sh
+++ b/scripts/k8s_deploy_kubeflow.sh
@@ -42,7 +42,7 @@ if [ $? -eq 0 ] ; then
 fi
 
 helm list  | grep metallb >/dev/null 2>&1
-if [ $? -ne 0 ]l then
+if [ $? -ne 0 ]; then
     echo "LoadBalancer not found (MetalLB)"
     echo "To support Kubeflow on-prem with multi-user-auth please install a load balancer by running"
     echo "./scripts/k8s_deploy_loadbalancer.sh"

--- a/scripts/k8s_deploy_kubeflow.sh
+++ b/scripts/k8s_deploy_kubeflow.sh
@@ -5,7 +5,7 @@ export KFCTL=~/kfctl
 export KUBEFLOW_TAG=v0.6.2
 export KFCTL_URL=https://github.com/kubeflow/kubeflow/releases/download/${KUBEFLOW_TAG}/kfctl_${KUBEFLOW_TAG}_linux.tar.gz
 export CONFIG="https://raw.githubusercontent.com/kubeflow/kubeflow/v0.6-branch/bootstrap/config/kfctl_existing_arrikto.0.6.2.yaml"
-export CONFIG="https://raw.githubusercontent.com/kubeflow/kubeflow/v0.6-branch/bootstrap/config/kfctl_k8s_istio.0.6.2.yaml"
+# export CONFIG="https://raw.githubusercontent.com/kubeflow/kubeflow/v0.6-branch/bootstrap/config/kfctl_k8s_istio.0.6.2.yaml"
 
 
 # Specify credentials for the default user.
@@ -39,6 +39,14 @@ if [ $? -eq 0 ] ; then
     echo "No storageclass found"
     echo "To provision Ceph storage, run: ./scripts/k8s_deploy_rook.sh"
     exit 1
+fi
+
+helm list  | grep metallb >/dev/null 2>&1
+if [ $? -ne 0 ]l then
+    echo "LoadBalancer not found (MetalLB)"
+    echo "To support Kubeflow on-prem with multi-user-auth please install a load balancer by running"
+    echo "./scripts/k8s_deploy_loadbalancer.sh"
+    exit 2
 fi
 
 # Download the kfctl binary and move it to the default location

--- a/scripts/k8s_deploy_kubeflow.v0.5.1.sh
+++ b/scripts/k8s_deploy_kubeflow.v0.5.1.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+
+export KS_VER=0.13.1
+export KS_PKG=ks_${KS_VER}_linux_amd64
+export KS_INSTALL_DIR=/usr/local/bin
+
+export KUBEFLOW_TAG=v0.5.1
+export KFAPP=kubeflow
+export KUBEFLOW_SRC=/opt/kubeflow
+
+export DEEPOPS_DIR=$(dirname $(dirname  $(readlink -f $0)))
+
+KSONNET_URL="${KSONNET_URL:-https://github.com/ksonnet/ksonnet/releases/download/v${KS_VER}/${KS_PKG}.tar.gz}"
+KUBEFLOW_URL="${KUBEFLOW_URL:-https://raw.githubusercontent.com/kubeflow/kubeflow/${KUBEFLOW_TAG}/scripts/download.sh}"
+
+###
+
+# Install dependencies
+. /etc/os-release
+case "$ID_LIKE" in
+    rhel*)
+        type curl >/dev/null 2>&1
+        if [ $? -ne 0 ] ; then
+            sudo yum -y install curl wget
+        fi
+        ;;
+    debian*)
+        type curl >/dev/null 2>&1
+        if [ $? -ne 0 ] ; then
+            sudo apt-get -y install curl wget
+        fi
+        ;;
+    *)
+        echo "Unsupported Operating System $ID_LIKE"
+        exit 1
+        ;;
+esac
+
+# Rook
+kubectl get storageclass 2>&1 | grep "No resources found." >/dev/null 2>&1
+if [ $? -eq 0 ] ; then
+    echo "No storageclass found"
+    echo "To provision Ceph storage, run: ./scripts/k8s_deploy_rook.sh"
+    exit 1
+fi
+
+# Ksonnet
+wget -O /tmp/${KS_PKG}.tar.gz "${KSONNET_URL}" \
+      --no-check-certificate
+mkdir -p ${KS_INSTALL_DIR}
+tempd=$(mktemp -d)
+tar -xvf /tmp/${KS_PKG}.tar.gz -C ${tempd}
+sudo mv ${tempd}/${KS_PKG}/ks ${KS_INSTALL_DIR}
+rm -rf ${tempd} /tmp/${KS_PKG}.tar.gz
+
+# Kubeflow
+if [ ! -d ${KUBEFLOW_SRC} ] ; then
+    tempd=$(mktemp -d)
+    cd ${tempd}
+    curl "${KUBEFLOW_URL}" | bash
+    cd -
+    sudo mv ${tempd} ${KUBEFLOW_SRC}
+fi
+
+# Get master ip
+master_ip=$(kubectl get nodes -l node-role.kubernetes.io/master= --no-headers -o custom-columns=IP:.status.addresses.*.address | cut -f1 -d, | head -1)
+
+# Check for ingress controller
+ingress_name="nginx-ingress"
+ingress_ip_string="$(echo ${master_ip} | tr '.' '-')"
+if kubectl describe service -l "app=${ingress_name},component=controller" | grep 'LoadBalancer Ingress' >/dev/null 2>&1; then
+    lb_ip="$(kubectl describe service -l "app=${ingress_name},component=controller" | grep 'LoadBalancer Ingress' | awk '{print $3}')"
+    ingress_ip_string="$(echo ${lb_ip} | tr '.' '-').nip.io"
+    echo "Using load balancer url: ${ingress_ip_string}"
+fi
+
+# Initialize and generate kubeflow
+set -e # XXX: Fail if anything in the initialization or configuration fail
+pushd ${HOME}
+${KUBEFLOW_SRC}/scripts/kfctl.sh init ${KFAPP} --platform none
+cd ${KFAPP}
+
+# Update the Kubeflow Jupyter UI
+export KSAPP_DIR="$(pwd)/ks_app"
+export KUBEFLOW_SRC
+${DEEPOPS_DIR}/scripts/update_kubeflow_config.py
+
+${KUBEFLOW_SRC}/scripts/kfctl.sh generate k8s
+pushd ${KSAPP_DIR}
+set +e
+
+# NOTE: temporarily using a custom image, to add custom command functionality
+ks param set jupyter-web-app image deepops/kubeflow-jupyter-web-app:v0.5-custom-command
+
+# Use NodePort directly if the IP string uses the master IP, otherwise use Ingress URL
+if echo "${ingress_ip_string}" | grep "${master_ip}" >/dev/null 2>&1; then
+    ks param set ambassador ambassadorServiceType NodePort
+    popd
+    ${KUBEFLOW_SRC}/scripts/kfctl.sh apply k8s
+    popd
+    kf_ip=$master_ip
+    kf_port=$(kubectl -n kubeflow get svc ambassador --no-headers -o custom-columns=:.spec.ports.*.nodePort)
+    kf_url="http://${kf_ip}:${kf_port}"
+else
+    ks param set ambassador ambassadorServiceType LoadBalancer
+    popd
+    ${KUBEFLOW_SRC}/scripts/kfctl.sh apply k8s
+    popd
+    kf_ip=$(kubectl -n kubeflow get svc ambassador --no-headers -o custom-columns=:.status.loadBalancer.ingress[0].ip)
+    kf_url="http://${kf_ip}"
+fi
+
+echo
+echo "Kubeflow app installed to: ${HOME}/${KFAPP}"
+echo "To remove, run: cd ${HOME}/${KFAPP} && ${KUBEFLOW_SRC}/scripts/kfctl.sh delete k8s"
+echo "To fully remove all source and application code run: cd ${HOME} && rm -rf ${KFAPP}; rm -rf ${KUBEFLOW_SRC}"
+echo "To fully remove everything: cd ${HOME}/${KFAPP} && ${KUBEFLOW_SRC}/scripts/kfctl.sh delete k8s; cd ${DEEPOPS_DIR} && sudo rm -rf ${KFAPP}; sudo rm -rf ${KUBEFLOW_SRC}"
+echo
+echo "Kubeflow Dashboard: ${kf_url}"
+echo
+echo "This script is deprecated and will be removed in a future release in favor of v0.6"


### PR DESCRIPTION
* Add Kubeflow Readme
* Bump Kubeflow up to version v0.6.2
* Cleanup Kubeflow deployment script with cmd line arguments for delete, install, config override, and print_url
* Add deployment option for "community version" and vendor version with Dex pre-installed
* Add minimal testing harness
* Fix for nvidia-dgx role

**Note:** Upgrading to this version of Kubeflow breaks NGC compatability. Until we have revisity the custom jupyter-web-app and kubeflow_update python script NGC images will not display in the image selection drop down, there will be no custom run commands to support NGC containers, and the default custom resource field will not have the nvidia gpu config added by default.

**Note:** The -D delete flag may leave around a few configmaps or persistant volumes created through Kubeflow use.