### PR TITLE
Option to OTA upgrade DGX OS 4

### DIFF
--- a/roles/nvidia-dgx/defaults/main.yml
+++ b/roles/nvidia-dgx/defaults/main.yml
@@ -9,3 +9,5 @@ nvidia_dgx_ubuntu_gpgkey: "https://international.download.nvidia.com/dgx/repos/b
 dgx_configure_raid_array: false
 nvidia_driver_skip_reboot: false
 dgx_raid_mount_path: /raid
+
+dgx_full_upgrade: false

--- a/roles/nvidia-dgx/tasks/ubuntu.yml
+++ b/roles/nvidia-dgx/tasks/ubuntu.yml
@@ -6,16 +6,19 @@
   apt_repository:
     repo: ppa:graphics-drivers/ppa
     state: absent
+  when: not dgx_full_upgrade
 
 - name: add repo keys
   apt:
     deb: "{{ nvidia_dgx_ubuntu_gpgkey }}"
+  when: not dgx_full_upgrade
 
 - name: add repo
   template:
     src: dgx.list.j2
     dest: /etc/apt/sources.list.d/dgx.list
     mode: 0644
+  when: not dgx_full_upgrade
 
 - name: install dgx packages
   apt:
@@ -24,7 +27,9 @@
     update_cache: yes
   with_items:
     - "{{ PKGS_DGX1_ALL }}"
-  when: ansible_product_name is search("DGX-1")
+  when:
+    - ansible_product_name is search("DGX-1")
+    - not dgx_full_upgrade
   notify:
     - name: restart docker
 
@@ -35,6 +40,26 @@
     update_cache: yes
   with_items:
     - "{{ PKGS_DGX2_ALL }}"
-  when: ansible_product_name is search("DGX-2")
+  when:
+    - ansible_product_name is search("DGX-2")
+    - not dgx_full_upgrade
   notify:
     - name: restart docker
+
+- name: install dgx cuda 10.1 repo
+  apt:
+    name: dgx-bionic-r418+cuda10.1-repo
+    update_cache: yes
+    dpkg_options: "force-confdef,force-confold"
+  when: dgx_full_upgrade
+
+- name: perform OTA upgrade to latest release (this takes a while)
+  apt:
+    upgrade: full
+    update_cache: yes
+    dpkg_options: "force-confdef,force-confold"
+  when: dgx_full_upgrade
+
+- name: reboot after full OTA upgrade
+  reboot:
+  when: dgx_full_upgrade


### PR DESCRIPTION
Not run by default, pass `-e dgx_full_upgrade=true` on the command line to upgrade the DGX OS. 

Works on v4.0.1 and later.

Ubuntu only