### PR TITLE
Fix an issue where gpu_topology become empty.

### DIFF
--- a/roles/facts/files/topology.fact
+++ b/roles/facts/files/topology.fact
@@ -10,7 +10,7 @@ echo "    \"threads_per_core\": \"$THREADSPERCORE\"",
 echo "    \"logical_cpus\": \"$(expr $SOCKETS \* $CORESPERSOCKET \* $THREADSPERCORE)\""
 echo "  },"
 echo "  \"gpu_topology\": ["
-gpus=$(for i in `lspci | grep -i nvidia | grep 3D | awk '{print $1}' | cut -d : -f 1`; do \
+gpus=$(for i in `lspci | grep -E "(3D|VGA compatible) controller: NVIDIA" | awk '{print $1}' | cut -d : -f 1`; do \
     echo -n \"$(cat /sys/class/pci_bus/0000:$i/cpulistaffinity)\",; done | sed 's/,$//')
 echo "    $gpus"
 echo "  ]"


### PR DESCRIPTION
The current code generates an empty list if "3D controller" is not included in the output of lspci(1).
This pull request will fix #388.