### PR TITLE
Standardize on DeepOps <project> Deployment Guide across docs to diffe…

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ DeepOps currently supports the following Linux distributions:
 
 Kubernetes (K8s) is an open-source system for automating deployment, scaling, and management of containerized applications.
 
-Consult the [Kubernetes Guide](docs/kubernetes-cluster.md) for instructions on building a GPU-enabled Kubernetes cluster using DeepOps.
+Consult the [DeepOps Kubernetes Deployment Guide](docs/kubernetes-cluster.md) for instructions on building a GPU-enabled Kubernetes cluster using DeepOps.
 
 For more information on Kubernetes in general, refer to the [official Kubernetes docs](https://kubernetes.io/docs/concepts/overview/what-is-kubernetes/).
 
@@ -47,7 +47,7 @@ For more information on Kubernetes in general, refer to the [official Kubernetes
 
 Slurm is an open source, fault-tolerant, and highly scalable cluster management and job scheduling system for large and small Linux clusters.
 
-Consult the [Slurm Guide](docs/slurm-cluster.md) for instructions on building a GPU-enabled Slurm cluster using DeepOps.
+Consult the [DeepOps Slurm Deployment Guide](docs/slurm-cluster.md) for instructions on building a GPU-enabled Slurm cluster using DeepOps.
 
 For more information on Slurm in general, refer to the [official Slurm docs](https://slurm.schedmd.com/overview.html).
 
@@ -55,17 +55,17 @@ For more information on Slurm in general, refer to the [official Slurm docs](htt
 
 A hybrid cluster with both Kubernetes and Slurm can also be deployed. This is recommended for [DGX POD](https://www.nvidia.com/en-us/data-center/dgx-pod-reference-architecture/) and other setups that wish to make maximal use of the cluster.
 
-Consult the [DGX POD Guide](docs/dgx-pod.md) for step-by-step instructions on building a GPU-enabled hybrid cluster using DeepOps.
+Consult the [DeepOps DGX POD Deployment Guide](docs/dgx-pod.md) for step-by-step instructions on building a GPU-enabled hybrid cluster using DeepOps.
 
 ### Virtual
 
 To try DeepOps before deploying it on an actual cluster, a virtualized version of DeepOps may be deployed on a single node using Vagrant. This can be used for testing, adding new features, or configuring DeepOps to meet deployment-specific needs.
 
-Consult the [Virtual Guide](virtual/README.md) to build a GPU-enabled virtual cluster with DeepOps.
+Consult the [Virtual DeepOps Deployment Guide](virtual/README.md) to build a GPU-enabled virtual cluster with DeepOps.
 
 ## Updating DeepOps
 
-To update from a previous version of DeepOps to a newer release, please consult the [Update Guide](docs/update-deepops.md).
+To update from a previous version of DeepOps to a newer release, please consult the [DeepOps Update Guide](docs/update-deepops.md).
 
 ## Copyright and License
 

--- a/docs/binderhub.md
+++ b/docs/binderhub.md
@@ -9,7 +9,7 @@ The default installation works on a single node. Multi-node installations are su
 
 ## Installation
 
-Deploy Kubernetes by following the [Kubernetes GPU Cluster Deployment Guide](kubernetes-cluster.md)
+Deploy Kubernetes by following the [DeepOps Kubernetes Deployment Guide](kubernetes-cluster.md)
 
 Deploy the [LoadBalancer](ingress.md#on-prem-loadbalancer)
 

--- a/docs/dgx-pod.md
+++ b/docs/dgx-pod.md
@@ -1,4 +1,4 @@
-Deployment Guide
+DGX POD Deployment Guide
 ===
 
 ## Contents

--- a/docs/kubeflow.md
+++ b/docs/kubeflow.md
@@ -12,7 +12,7 @@ Kubeflow is an [open source project](https://github.com/kubeflow/kubeflow) and i
 
 ## Installation
 
-Deploy Kubernetes by following the [Kubernetes GPU Cluster Deployment Guide](kubernetes-cluster.md)
+Deploy Kubernetes by following the [DeepOps Kubernetes Deployment Guide](kubernetes-cluster.md)
 
 Deploy [Ceph](kubernetes-cluster.md#persistent-storage)
 

--- a/docs/rapids-dask.md
+++ b/docs/rapids-dask.md
@@ -11,13 +11,13 @@ Dask has tight kubernetes integration that allows you to scale up/down your Dask
 
 ### Kubeflow
 
-If Kubeflow has already been installed using the [Kubeflow Deployment Guide](kubeflow.md) there are no additional K8S setup steps required.
+If Kubeflow has already been installed using the [DeepOps Kubeflow Deployment Guide](kubeflow.md) there are no additional K8S setup steps required.
 
 When deploying through Kubeflow, it is necessary to ensure that a proper Docker image, entrypoint, and cmd have been specified; or Kubeflow will not properly start Jupyter and the service will immediately fail. See the [Dask Kubernetes](../examples/k8s-dask-rapids/docker/Dockerfile) Dockerfile for an example.
 
 ### Stand-alone
 
-Deploy Kubernetes by following the [Kubernetes GPU Cluster Deployment Guide](kubernetes-cluster.md)
+Deploy Kubernetes by following the [DeepOps Kubernetes Deployment Guide](kubernetes-cluster.md)
 
 Deploy the [LoadBalancer](ingress.md#on-prem-loadbalancer)
 

--- a/docs/slurm-perf-cluster.md
+++ b/docs/slurm-perf-cluster.md
@@ -5,7 +5,7 @@ High-Performance Multi-Node Cluster Deployment Guide
 
    This guide utilizes a collection of playbooks to configure a cluster, deploy a workload manager, and verify performance.
 
-   It leverages open source tools such as Pyxis and Enroot to optimize Slurm for multi-node Deep Learning jobs beyond the cluster configuration described in the [Slurm Deployment Guide](/docs/slurm-cluster.md). Additional details can be found [here](https://docs.nvidia.com/ngc/multi-node-bert-user-guide).
+   It leverages open source tools such as Pyxis and Enroot to optimize Slurm for multi-node Deep Learning jobs beyond the cluster configuration described in the [DeepOps Slurm Deployment Guide](/docs/slurm-cluster.md). Additional details can be found [here](https://docs.nvidia.com/ngc/multi-node-bert-user-guide).
 
 ## Supported Distributions
 


### PR DESCRIPTION
* We've encountered several people who have a hard time finding the Kubernetes Deployment guide on the README. I added some more clear wording "DeepOps Kubernetes Deployment Guide" to make it clear that this is a "deployment guide", not a "usage guide". It should also make it clear that this is a DeepOps guide, not an official community Kubernetes guide.

* I went through all the other docs that reference a cluster deployment guide and updated them to the same format
