### PR TITLE
Increase timeout waiting for ingress controller

### DIFF
--- a/scripts/k8s_deploy_ingress.sh
+++ b/scripts/k8s_deploy_ingress.sh
@@ -43,4 +43,4 @@ if ! helm status "${app_name}" >/dev/null 2>&1; then
 		stable/nginx-ingress
 fi
 
-kubectl wait --for=condition=Ready -l "app=${app_name},component=controller" --timeout=90s pod
+kubectl wait --for=condition=Ready -l "app=${app_name},component=controller" --timeout=180s pod


### PR DESCRIPTION
In my local tests, I've seen the `kubectl wait` command for the ingress controller time out several times by 10-30 seconds. So I'm proposing we double this timeout to avoid failures. :)