### PR TITLE
Bash fixes for managing arguments correctly

### DIFF
--- a/scripts/install_helm.sh
+++ b/scripts/install_helm.sh
@@ -43,13 +43,14 @@ if ! type helm >/dev/null 2>&1 ; then
     HELM_INSTALL_DIR=${HELM_INSTALL_DIR} DESIRED_VERSION=v2.14.3 /tmp/get_helm.sh
 fi
 
-helm_extra_args=""
+# We need to dynamically set up Helm args, so let's use an array
+helm_init_args=("--client-only")
 if [ "${DEEPOPS_HELM_REPO}" ]; then
-	helm_extra_args="--stable-repo-url ${DEEPOPS_HELM_REPO}"
+	helm_init_args+=("--stable-repo-url" "${DEEPOPS_HELM_REPO}")
 fi
 
 if type helm >/dev/null 2>&1 ; then
-    helm init --client-only ${helm_extra_args}
+    helm init "${helm_init_args[@]}"
     helm repo update
 else
     echo "Helm client not installed"

--- a/scripts/k8s_deploy_ingress.sh
+++ b/scripts/k8s_deploy_ingress.sh
@@ -25,22 +25,23 @@ if ! kubectl version ; then
     exit 1
 fi
 
-# Check for environment vars overriding image names
-helm_extra_args=""
+# We need to dynamically set up Helm args, so let's use an array
+helm_arguments=("--name" "${app_name}"
+                "--version" "${CHART_VERSION}"
+		"--values" "${config_dir}/helm/ingress.yml"
+)
+
+
 if [ "${NGINX_INGRESS_CONTROLLER_REPO}" ]; then
-	helm_extra_args="${helm_extra_args} --set-string controller.image.repository=${NGINX_INGRESS_CONTROLLER_REPO}"
+	helm_arguments+=("--set-string" "controller.image.repository=${NGINX_INGRESS_CONTROLLER_REPO}")
 fi
 if [ "${NGINX_INGRESS_BACKEND_REPO}" ]; then
-	helm_extra_args="${helm_extra_args} --set-string defaultBackend.image.repository=${NGINX_INGRESS_BACKEND_REPO}"
+	helm_arguments+=("--set-string" "defaultBackend.image.repository=${NGINX_INGRESS_BACKEND_REPO}")
 fi
 
 # Set up the ingress controller
 if ! helm status "${app_name}" >/dev/null 2>&1; then
-	helm install \
-		--name "${app_name}" \
-		--version "${CHART_VERSION}" \
-		--values "${config_dir}/helm/ingress.yml" ${helm_extra_args} \
-		stable/nginx-ingress
+	helm install "${helm_arguments[@]}" stable/nginx-ingress
 fi
 
 kubectl wait --for=condition=Ready -l "app=${app_name},component=controller" --timeout=90s pod

--- a/scripts/k8s_deploy_rook.sh
+++ b/scripts/k8s_deploy_rook.sh
@@ -13,15 +13,20 @@ HELM_ROOK_CHART_VERSION="${HELM_ROOK_CHART_VERSION:-v1.1.1}"
 # https://github.com/rook/rook/blob/master/Documentation/helm-operator.md
 helm repo add rook-release "${HELM_ROOK_CHART_REPO}"
 
+# We need to dynamically set up Helm args, so let's use an array
+helm_install_args=("--namespace" "rook-ceph"
+                   "--name" "rook-ceph"
+		   "--version" "${HELM_ROOK_CHART_VERSION}"
+)
+
 # Use an alternate image if set
-helm_install_extra_flags=""
 if [ "${ROOK_CEPH_IMAGE_REPO}" ]; then
-	helm_install_extra_flags="--set image.repository=${ROOK_CEPH_IMAGE_REPO}"
+	helm_install_args+=("--set" "image.repository=${ROOK_CEPH_IMAGE_REPO}")
 fi
 
 # Install rook-ceph
 if ! helm status rook-ceph >/dev/null 2>&1 ; then
-    helm install --namespace rook-ceph --name rook-ceph rook-release/rook-ceph --version "${HELM_ROOK_CHART_VERSION}" ${helm_install_extra_flags}
+    helm install "${helm_install_args[@]}" rook-release/rook-ceph
 fi
 
 if kubectl -n rook-ceph get pod -l app=rook-ceph-tools 2>&1 | grep "No resources found." >/dev/null 2>&1; then


### PR DESCRIPTION
tl;dr: This is basically a cleanup commit to make a particular bash pattern a little more correct and less dangerous.

While working on other scripting changes, the I found that the linter didn't like a particular pattern I was using to add extra arguments to some commands:

```
 $ shellcheck -x ./k8s_deploy_ingress.sh

In ./k8s_deploy_ingress.sh line 42:
                --values "${config_dir}/helm/ingress.yml" ${helm_extra_args} \
                                                          ^-- SC2086: Double quote to prevent globbing and word splitting.
```

But just adding quotes broke things differently! So that led me into a rabbit hole of figuring out [the best way to dynamically manage command arguments in bash](http://mywiki.wooledge.org/BashFAQ/050#I.27m_constructing_a_command_based_on_information_that_is_only_known_at_run_time), and finding that I had done this incorrectly in multiple scripts.

None of this actually impacts functionality, it just makes the bash a little nicer and safer. So I'm separating these fixes out into their own PR.