### PR TITLE
Ensure EPEL repo is enabled for k8s-gpu-plugin, plus some refactoring

### DIFF
--- a/roles/epel/defaults/main.yml
+++ b/roles/epel/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+epel_baseurl: "https://download.fedoraproject.org/pub/epel/$releasever/$basearch/"
+epel_gpgkey: "https://epel.mirror.constant.com/RPM-GPG-KEY-EPEL-{{ ansible_distribution_major_version }}"

--- a/roles/epel/tasks/main.yml
+++ b/roles/epel/tasks/main.yml
@@ -1,0 +1,8 @@
+---
+- name: add epel repository
+  yum_repository:
+    name: epel
+    description: EPEL YUM repo
+    baseurl: "{{ epel_baseurl }}"
+    gpgkey: "{{ epel_gpgkey }}"
+  when: ansible_os_family == "RedHat"

--- a/roles/k8s-gpu-plugin/meta/main.yml
+++ b/roles/k8s-gpu-plugin/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - role: epel

--- a/roles/nvidia-dgx/defaults/main.yml
+++ b/roles/nvidia-dgx/defaults/main.yml
@@ -1,5 +1,3 @@
-epel_baseurl: "https://download.fedoraproject.org/pub/epel/$releasever/$basearch/"
-epel_gpgkey: "https://epel.mirror.constant.com//RPM-GPG-KEY-EPEL-{{ ansible_distribution_major_version }}"
 nvidia_dgx_rhel_baseurl: "https://international.download.nvidia.com/dgx/repos/{{ dgx_repo_dir }}/"
 nvidia_dgx_rhel_gpgkey: "https://international.download.nvidia.com/dgx/repos/rhel-files/RPM-GPG-KEY-dgx-cosmos-support"
 

--- a/roles/nvidia-dgx/meta/main.yml
+++ b/roles/nvidia-dgx/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - role: epel

--- a/roles/nvidia-dgx/tasks/redhat.yml
+++ b/roles/nvidia-dgx/tasks/redhat.yml
@@ -2,13 +2,6 @@
 - name: include os specific variables
   include_vars: redhat.yml
 
-- name: Add epel repo
-  yum_repository:
-    name: epel
-    description: EPEL YUM repo
-    baseurl: "{{ epel_baseurl }}"
-    gpgkey: "{{ epel_gpgkey }}"
-
 - name: Add DGX repo
   yum_repository:
     name: nvidia-dgx-7

--- a/roles/nvidia-ml/defaults/main.yml
+++ b/roles/nvidia-ml/defaults/main.yml
@@ -1,8 +1,6 @@
 nvidia_ml_package_state: present
 nvidia_cudnn_package_version: ''
 nvidia_nccl_package_version: ''
-epel_baseurl: "https://download.fedoraproject.org/pub/epel/$releasever/$basearch/"
-epel_gpgkey: "https://epel.mirror.constant.com//RPM-GPG-KEY-EPEL-{{ ansible_distribution_major_version }}"
 rhel_nvidiaml_gpgkey: "https://developer.download.nvidia.com/compute/machine-learning/repos/{{ rhel_repo_dir }}/7fa2af80.pub"
 rhel_nvidiaml_baseurl: "https://developer.download.nvidia.com/compute/machine-learning/repos/{{ rhel_repo_dir }}/"
 ubuntu_nvidiaml_gpgkey: "https://developer.download.nvidia.com/compute/machine-learning/repos/{{ ubuntu_repo_dir }}/7fa2af80.pub"

--- a/roles/nvidia-ml/meta/main.yml
+++ b/roles/nvidia-ml/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - role: epel

--- a/roles/nvidia-ml/tasks/redhat-pre-install.yml
+++ b/roles/nvidia-ml/tasks/redhat-pre-install.yml
@@ -1,11 +1,4 @@
 ---
-- name: add epel repo
-  yum_repository:
-    name: epel
-    description: EPEL YUM repo
-    baseurl: "{{ epel_baseurl }}"
-    gpgkey: "{{ epel_gpgkey }}"
-
 - name: add repo
   yum_repository:
     name: machine-learning

--- a/roles/slurm/defaults/main.yml
+++ b/roles/slurm/defaults/main.yml
@@ -1,5 +1,3 @@
-epel_baseurl: "https://download.fedoraproject.org/pub/epel/$releasever/$basearch/"
-epel_gpgkey: "https://epel.mirror.constant.com//RPM-GPG-KEY-EPEL-{{ ansible_distribution_major_version }}"
 
 slurm_pkg_url: "https://github.com/DeepOps/slurm/releases/download/"
 slurm_xenial_deb: slurm_19.05.0-xenial_amd64.deb

--- a/roles/slurm/meta/main.yml
+++ b/roles/slurm/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - role: epel

--- a/roles/slurm/tasks/main.yml
+++ b/roles/slurm/tasks/main.yml
@@ -1,13 +1,4 @@
 ---
-
-- name: add epel repo
-  yum_repository:
-    name: epel
-    description: EPEL YUM repo
-    baseurl: "{{ epel_baseurl }}"
-    gpgkey: "{{ epel_gpgkey }}"
-  when: ansible_os_family == "RedHat"
-
 - include: munge.yml
 
 - name: install slurm (xenial)


### PR DESCRIPTION
Addresses #393, where the `k8s-gpu-plugin` role is failing on CentOS because the EPEL repo is not yet installed when we try to install `python2-openshift`.

Actual changes:

1. Create a new role `epel` for installing EPEL repo
1. Make the `k8s-gpu-plugin` role dependent on the `epel` role
1. (Refactor) Remove EPEL installation from other roles, instead making them dependent on `epel` role

The refactor is optional, but I think it's helpful to keep the EPEL code in one place.