### PR TITLE
add tag to SSH Public key task to optionally skip it for AWS instances

### DIFF
--- a/playbooks/bootstrap-ssh.yml
+++ b/playbooks/bootstrap-ssh.yml
@@ -28,6 +28,7 @@
         user: "{{ ansible_env.SUDO_USER | default(ansible_env.USER) }}"
         state: present
         key: "{{ lookup('file', private_key + '.pub') }}"
+      tags: ssh-public
 
     - debug:
         msg: Now, you shouldn't need to use -k/--ask-pass for these hosts anymore.


### PR DESCRIPTION
SSH'ing into an AWS Instance should only require the private `.pem` key file for the standard workflow, but DeepOps (via `bootstrap-ssh.yml`) enforces having a private/public keypair. This PR adds an optional tag to skip if you only have a private key.

Previously hitting an error on trying to use standard AWS SSH key workflow with only a private `.pem` key file and no `.pub` key to pair with it:
```
$ ansible-playbook -l k8s-cluster playbooks/k8s-cluster.yml
...
TASK [Add SSH public key to ansible user user authorized keys] ****************************************************************************************************************************************************
 [WARNING]: Unable to find '~/.ssh/key.pem.pub' in expected paths (use -vvvvv to see paths)
fatal: [gpu01]: FAILED! => 
  msg: 'An unhandled exception occurred while running the lookup plugin ''file''. Error was a <class ''ansible.errors.AnsibleError''>, original message: could not locate file in lookup: ~/.ssh/key.pem.pub'

PLAY RECAP ********************************************************************************************************************************************************************************************************
gpu01                      : ok=5    changed=1    unreachable=0    failed=1    skipped=0    rescued=0    ignored=0   
```

Enable easier setup of single node AWS instance with optional `ssh-public` tag to skip (tag name subject to change)
```
$ ansible-playbook -l k8s-cluster playbooks/k8s-cluster.yml --skip-tags "ssh-public"
...
PLAY RECAP ********************************************************************************************************************************************************************************************************
gpu01                      : ok=799  changed=153  unreachable=0    failed=0    skipped=986  rescued=0    ignored=1   
```

CC @michael-balint @ajdecon 