### PR TITLE
Only create kubectl config for k8s-cluster to avoid missing variables

### DIFF
--- a/playbooks/k8s-cluster.yml
+++ b/playbooks/k8s-cluster.yml
@@ -50,7 +50,7 @@
     - swap
  
 # Manage Kubernetes cluster access config file
-- hosts: all
+- hosts: k8s-cluster
   gather_facts: false
   vars:
     ansible_become: no


### PR DESCRIPTION
If a user has both Slurm and K8S configured in their inventory file this task get's load balanced between the mgmt, gpu, and login nodes. If the tasks happens to run on a login node that is not a part of the k8s-cluster group then the `artifacts_dir` variable will not be set.

This is just forcing the task to be run in a group that has the variable configured and is relevant to the playbook.