### PR TITLE
kube-cluster to k8s-cluster, because that exists

### DIFF
--- a/playbooks/k8s-cluster.yml
+++ b/playbooks/k8s-cluster.yml
@@ -122,7 +122,7 @@
       run_once: yes
   tags:
     - local
-- hosts: kube-cluster
+- hosts: k8s-cluster
   gather_facts: false
   vars:
     config_dir: "../config"


### PR DESCRIPTION
I missed this in the last PR because all the testing setups already have `kubectl` in /usr/local/bin in the admin node.