### PR TITLE
Add Example NGC Dockerfiles

### DIFF
--- a/containers/ngc/README.md
+++ b/containers/ngc/README.md
@@ -1,0 +1,23 @@
+# NGC-based Docker Containers
+
+This directory contains several Dockerfiles for common Deep Learning and Machine Learning frameworks. These serve as an example for extending NGC Docker images.
+
+By default, most NGC containers start a shell prompt. These Dockerfiles are designed to start JupyterLab by default, allowing for easier integration into interactive notebook platforms such as Kubeflow.
+
+They also build ontop of the base NGC containers by including additional packages for demos, monitoring, generating graphs, Kubernetes integration, and rendering interactive html5 elements.
+
+Where possible, the package versions in these Dockerfiles are hard-coded to ensure repeatable builds.
+
+Additional details about NGC can be found [here](http://ngc.nvidia.com/).
+
+## Misc. Notes
+
+* JupyterLab is exposed at port 8888
+* Tensorboard is exposed at port 6006
+* The `WORKDIR` contains the built-in NGC tutorials and example code. This is /workspace in most cases.
+
+## Included Frameworks
+
+* PyTorch
+* TensorFlow
+* RAPIDS

--- a/containers/ngc/pytorch/Dockerfile
+++ b/containers/ngc/pytorch/Dockerfile
@@ -1,0 +1,35 @@
+# https://ngc.nvidia.com/catalog/containers/nvidia:pytorch
+FROM nvcr.io/nvidia/pytorch:20.01-py3
+
+# Install some extra packages to ease development
+RUN apt-get update && \
+    apt-get install -y screen unzip git vim htop font-manager && \
+    rm -rf /var/lib/apt/*
+
+# Install nodejs, it is a dependency for Jupyter labextensions
+RUN conda install nodejs
+
+# Install the NVIDIA Jupyter Dashboard
+RUN pip install jupyterlab-nvdashboard && \
+    jupyter labextension install jupyterlab-nvdashboard
+
+# Install ipyvolume for clean HTML5 visualizations
+RUN pip install ipyvolume && \
+    jupyter labextension install ipyvolume
+
+# Install graphviz for clean graph/node/edge rendering
+RUN apt-get update && \
+    apt-get install -y graphviz && \
+    pip install graphviz && \
+    rm -rf /var/lib/apt/*
+
+# Expose Jupyter & Tensorboard
+EXPOSE 8888
+EXPOSE 6006
+
+# /workspace contains NVIDIA tutorials and example code
+WORKDIR /workspace
+
+# Start Jupyter up by default rather than a shell
+ENTRYPOINT ["/bin/sh"]
+CMD ["-c", "jupyter lab  --notebook-dir=/workspace --ip=0.0.0.0 --no-browser --allow-root --port=8888 --NotebookApp.token='' --NotebookApp.password='' --NotebookApp.allow_origin='*' --NotebookApp.base_url=${NB_PREFIX}"]

--- a/containers/ngc/pytorch/Dockerfile
+++ b/containers/ngc/pytorch/Dockerfile
@@ -7,21 +7,18 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/*
 
 # Install nodejs, it is a dependency for Jupyter labextensions
-RUN conda install nodejs
+RUN conda install nodejs=10.13.0 && conda clean -yac *
 
 # Install the NVIDIA Jupyter Dashboard
-RUN pip install jupyterlab-nvdashboard && \
+RUN conda install -y -c conda-forge jupyterlab-nvdashboard==0.1.11 && conda clean -yac * && \
     jupyter labextension install jupyterlab-nvdashboard
 
 # Install ipyvolume for clean HTML5 visualizations
-RUN pip install ipyvolume && \
-    jupyter labextension install ipyvolume
+RUN  conda install -y -c conda-forge ipyvolume==0.5.2 && conda clean -yac * && \
+     jupyter labextension install ipyvolume
 
 # Install graphviz for clean graph/node/edge rendering
-RUN apt-get update && \
-    apt-get install -y graphviz && \
-    pip install graphviz && \
-    rm -rf /var/lib/apt/*
+RUN  conda install -c conda-forge python-graphviz=0.13.2 graphviz=2.42.3 && conda clean -yac *
 
 # Expose Jupyter & Tensorboard
 EXPOSE 8888

--- a/containers/ngc/rapids/Dockerfile
+++ b/containers/ngc/rapids/Dockerfile
@@ -1,0 +1,40 @@
+# https://ngc.nvidia.com/catalog/containers/nvidia:rapidsai:rapidsai
+FROM nvcr.io/nvidia/rapidsai/rapidsai:cuda10.1-runtime-ubuntu18.04 
+
+# RAPIDS is installed using conda and we need to work from this environment
+ENV CONDA_ENV rapids
+
+# Install some extra packages to ease development
+RUN source activate ${CONDA_ENV} && \
+    apt-get update && \
+    apt-get install -y screen unzip git vim htop font-manager && \
+    rm -rf /var/lib/apt/*
+
+# Install the NVIDIA Jupyter Dashboard
+RUN source activate ${CONDA_ENV} && \
+    pip install jupyterlab-nvdashboard && \
+    jupyter labextension install jupyterlab-nvdashboard
+
+# Install ipyvolume for clean HTML5 visualizations
+RUN source activate ${CONDA_ENV} && \
+    conda install -y -c conda-forge ipyvolume && conda clean -yac * && \
+    jupyter labextension install ipyvolume
+
+# Install graphviz for clean graph/node/edge rendering
+RUN source activate ${CONDA_ENV} && \
+    conda install -c conda-forge python-graphviz graphviz && conda clean -yac *
+
+# Install dask_kubernetes for deploying works through K8S and monitoring through Jupyter
+RUN source activate ${CONDA_ENV} && \
+    pip install dask-kubernetes
+
+# Expose Jupyter and Dask ports
+EXPOSE 8888
+EXPOSE 8787
+
+# /rapids contains NVIDIA & contrib tutorials and example code
+WORKDIR /rapids
+
+# Start using the built in RAPIDS conda environment
+ENTRYPOINT ["/bin/sh"]
+CMD ["-c", "/opt/conda/envs/${CONDA_ENV}/bin/jupyter lab  --notebook-dir=/rapids --ip=0.0.0.0 --no-browser --allow-root --port=8888 --NotebookApp.token='' --NotebookApp.password='' --NotebookApp.allow_origin='*' --NotebookApp.base_url=${NB_PREFIX}"]

--- a/containers/ngc/rapids/Dockerfile
+++ b/containers/ngc/rapids/Dockerfile
@@ -12,21 +12,21 @@ RUN source activate ${CONDA_ENV} && \
 
 # Install the NVIDIA Jupyter Dashboard
 RUN source activate ${CONDA_ENV} && \
-    pip install jupyterlab-nvdashboard && \
+    conda install -y -c conda-forge jupyterlab-nvdashboard==0.1.11 && conda clean -yac * && \
     jupyter labextension install jupyterlab-nvdashboard
 
 # Install ipyvolume for clean HTML5 visualizations
 RUN source activate ${CONDA_ENV} && \
-    conda install -y -c conda-forge ipyvolume && conda clean -yac * && \
+    conda install -y -c conda-forge ipyvolume==0.5.2 && conda clean -yac * && \
     jupyter labextension install ipyvolume
 
 # Install graphviz for clean graph/node/edge rendering
 RUN source activate ${CONDA_ENV} && \
-    conda install -c conda-forge python-graphviz graphviz && conda clean -yac *
+    conda install -c conda-forge python-graphviz=0.13.2 graphviz=2.42.3 && conda clean -yac *
 
 # Install dask_kubernetes for deploying works through K8S and monitoring through Jupyter
 RUN source activate ${CONDA_ENV} && \
-    pip install dask-kubernetes
+    conda install -c conda-forge dask-kubernetes==0.10.1 && conda clean -yac *
 
 # Expose Jupyter and Dask ports
 EXPOSE 8888

--- a/containers/ngc/tensorflow/Dockerfile
+++ b/containers/ngc/tensorflow/Dockerfile
@@ -1,0 +1,42 @@
+# https://ngc.nvidia.com/catalog/containers/nvidia:tensorflow
+FROM nvcr.io/nvidia/tensorflow:20.01-tf1-py3
+
+# Install some extra packages to ease development
+RUN apt-get update && \
+    apt-get install -y screen unzip git vim htop font-manager && \
+    rm -rf /var/lib/apt/*
+
+# Install nodejs and npm, which are dependencies for labextensions
+RUN apt-get update && \
+    apt-get install -y nodejs=8.10.0~dfsg-2ubuntu0.4 \
+                       npm=3.5.2-0ubuntu4 && \
+    rm -rf /var/lib/apt/*
+
+# Cleanup old python2 install that interferes with pip
+RUN rm /usr/bin/python && \
+    ln -s $(which python3) /usr/bin/python
+
+# Install the NVIDIA Jupyter Dashboard
+RUN  pip install jupyterlab-nvdashboard==0.2.0 && \
+     jupyter labextension install jupyterlab-nvdashboard
+
+# Install ipyvolume for clean HTML5 visualizations
+RUN pip install ipyvolume==0.5.2 && \
+    jupyter labextension install ipyvolume
+
+# Install graphviz for clean graph/node/edge rendering
+RUN apt-get update && \
+    apt-get install -s graphviz=2.40.1-2 && \
+    pip install graphviz==0.13.2 && \
+    rm -rf /var/lib/apt/*
+
+# Expose Jupyter & Tensorboard
+EXPOSE 8888
+EXPOSE 6006
+
+# /workspace contains NVIDIA tutorials and example code
+WORKDIR /workspace
+
+# Start Jupyter up by default rather than a shell
+ENTRYPOINT ["/bin/sh"]
+CMD ["-c", "jupyter lab  --notebook-dir=/workspace --ip=0.0.0.0 --no-browser --allow-root --port=8888 --NotebookApp.token='' --NotebookApp.password='' --NotebookApp.allow_origin='*' --NotebookApp.base_url=${NB_PREFIX}"]


### PR DESCRIPTION
Add example notebooks that extend NGC. These launch Jupyterlab by default and will work in Kubeflow and other platforms.

I've also added a few common packages and extensions (nvdashboard, dask, graphviz, etc.).

For all critical packages I pegged the version so they work consistently.

* RAPIDS
* PyTorch
* Tensorflow