### PR TITLE
Doubled memory and cpu requirements for dcgm-exporter

### DIFF
--- a/services/dcgm-exporter.yml
+++ b/services/dcgm-exporter.yml
@@ -68,11 +68,11 @@ spec:
           name: metrics
         resources:
           requests:
-            memory: 30Mi
-            cpu: 100m
-          limits:
-            memory: 50Mi
+            memory: 60Mi
             cpu: 200m
+          limits:
+            memory: 100Mi
+            cpu: 400m
         volumeMounts:
         - name: proc
           readOnly:  true


### PR DESCRIPTION
dcgm-exporter crashes repeatedly unless the limits are increased