### PR TITLE
Fix notify syntax in nvidia-dgx role

### DIFF
--- a/roles/nvidia-dgx/tasks/redhat.yml
+++ b/roles/nvidia-dgx/tasks/redhat.yml
@@ -89,7 +89,7 @@
     - docker
     - "@NVIDIA container runtime"
   notify:
-    - name: restart docker
+    - restart docker
 
 - name: Install DGX System Management Tools
   yum:

--- a/roles/nvidia-dgx/tasks/ubuntu.yml
+++ b/roles/nvidia-dgx/tasks/ubuntu.yml
@@ -31,7 +31,7 @@
     - ansible_product_name is search("DGX-1")
     - not dgx_full_upgrade
   notify:
-    - name: restart docker
+    - restart docker
 
 - name: install dgx packages
   apt:
@@ -44,7 +44,7 @@
     - ansible_product_name is search("DGX-2")
     - not dgx_full_upgrade
   notify:
-    - name: restart docker
+    - restart docker
 
 - name: install dgx cuda 10.1 repo
   apt:


### PR DESCRIPTION
Fixes:

```
ERROR! Unexpected Exception, this is probably a bug: unhashable type: 'dict'
the full traceback was:

Traceback (most recent call last):
  File "/usr/local/bin/ansible-playbook", line 118, in <module>
    exit_code = cli.run()
  File "/usr/local/lib/python2.7/dist-packages/ansible/cli/playbook.py", line 122, in run
    results = pbex.run()
  File "/usr/local/lib/python2.7/dist-packages/ansible/executor/playbook_executor.py", line 156, in run
    result = self._tqm.run(play=play)
  File "/usr/local/lib/python2.7/dist-packages/ansible/executor/task_queue_manager.py", line 291, in run
    play_return = strategy.run(iterator, play_context)
  File "/usr/local/lib/python2.7/dist-packages/ansible/plugins/strategy/linear.py", line 325, in run
    results += self._wait_on_pending_results(iterator)
  File "/usr/local/lib/python2.7/dist-packages/ansible/plugins/strategy/__init__.py", line 714, in _wait_on_pending_results
    results = self._process_pending_results(iterator)
  File "/usr/local/lib/python2.7/dist-packages/ansible/plugins/strategy/__init__.py", line 117, in inner
    results = func(self, iterator, one_pass=one_pass, max_passes=max_passes)
  File "/usr/local/lib/python2.7/dist-packages/ansible/plugins/strategy/__init__.py", line 570, in _process_pending_results
    if handler_name in self._listening_handlers:
TypeError: unhashable type: 'dict'
```