### PR TITLE
Enable chrony by default on slurm and k8s clusters

### DIFF
--- a/config.example/group_vars/all.yml
+++ b/config.example/group_vars/all.yml
@@ -29,6 +29,8 @@
 
 # NTP configuration
 # Playbook: chrony-client
+chrony_service_state: "started"
+chrony_service_enabled: "yes"
 chrony_timezone: "Etc/UTC"
 chrony_config_server:
   - 0.pool.ntp.org

--- a/config.example/group_vars/all.yml
+++ b/config.example/group_vars/all.yml
@@ -28,10 +28,13 @@
 #dns_config_search: [example.com]
 
 # NTP configuration
-# Playbook: ntp-client
-#chrony_timezone: "America/Los_Angeles"
-#chrony_config_server:
-#  - 0.pool.ntp.org
+# Playbook: chrony-client
+chrony_timezone: "Etc/UTC"
+chrony_config_server:
+  - 0.pool.ntp.org
+  - 1.pool.ntp.org
+  - 2.pool.ntp.org
+  - 3.pool.ntp.org
 
 
 ################################################################################

--- a/playbooks/k8s-cluster.yml
+++ b/playbooks/k8s-cluster.yml
@@ -29,6 +29,9 @@
   tags:
     - bootstrap
 
+# Configure Chrony (NTP) sync
+- include: chrony-client.yml
+
 # Install the OpenShift API libraries required by the GPU plugin
 - include: bootstrap-openshift.yml
 

--- a/playbooks/slurm-cluster.yml
+++ b/playbooks/slurm-cluster.yml
@@ -21,6 +21,9 @@
 # Configure hostnames, /etc/hosts
 - include: hosts.yml
 
+# Configure Chrony (NTP) sync
+- include: chrony-client.yml
+
 # Install NVIDIA driver
 - include: nvidia-driver.yml
 


### PR DESCRIPTION
- Default to enabling Chrony on all nodes for time sync.
- Use regular NTP pool servers as default time source on all nodes so they use the same upstream.
- Default to UTC as the time zone.

TODO in a later PR: Add a default configuration for offline mode which uses the k8s master or the slurm login node as the time source for other nodes. But getting this set up by default is a good first step.