### PR TITLE
Fix localusers for Slurm role SSH access

### DIFF
--- a/roles/slurm/templates/etc-localusers
+++ b/roles/slurm/templates/etc-localusers
@@ -1,5 +1,5 @@
 root
-{{ ansible_env.USER }}
+{{ ansible_ssh_user }}
 {% for user in slurm_allow_ssh_user %}
 {{ user }}
 {% endfor %}


### PR DESCRIPTION
Ensure that the Ansible SSH user always has access to all hosts. This avoids situations where a non-root Ansible user loses access to the compute hosts after a Slurm job runs.

(I run into this often when troubleshooting virtual installs! :P)