### PR TITLE
Better /etc/hosts file for slurm cluster

### DIFF
--- a/docs/offline.md
+++ b/docs/offline.md
@@ -74,6 +74,11 @@ The primary difference between an "offline" build and an "online" one is what up
 In order to build DeepOps on a network without access to the Internet, you have to ensure that the Ansible playbooks and other scripts used to set up the cluster know where to find the software they need to install.
 We do this by overriding a collection of Ansible variables and environment variables used by DeepOps to control the download locations.
 
+### Considerations for configuring DeepOps
+
+- If building an offline Slurm cluster, please configure `hosts_network_interface` in the DeepOps configuration to specify the primary network interface on your offline hosts.
+    This will ensure that the cluster `/etc/hosts` file uses the correct IP addresses for your nodes.
+
 ### Specifying mirror locations
 
 1. Edit `config/offline_repo_vars.yml` file to specify your repository mirror locations for Ansible.

--- a/playbooks/hosts.yml
+++ b/playbooks/hosts.yml
@@ -7,6 +7,6 @@
         name: "{{ inventory_hostname }}"
     - name: set /etc/hosts
       include_role:
-        name: lukeyeager.hosts
+        name: DeepOps.hosts
       vars:
         hosts_add_ansible_managed_hosts: true

--- a/requirements.yml
+++ b/requirements.yml
@@ -6,9 +6,9 @@
 - src: unxnn.users
   version: '78fd08ca86678d00da376eaac909d22e1022a020'
 
-- src: https://github.com/lukeyeager/ansible-role-hosts.git
-  version: '711ba98571f068a8bc6739fa1055ac38fc931010'
-  name: lukeyeager.hosts
+- src: https://github.com/DeepOps/ansible-role-hosts.git
+  version: '8311d6ecfe39b665a06d1fc55502c6916e9ab5ce'
+  name: DeepOps.hosts
 
 - src: geerlingguy.ntp
   version: "1.6.3"

--- a/virtual/vars_files/virt_slurm.yml
+++ b/virtual/vars_files/virt_slurm.yml
@@ -12,3 +12,10 @@ nfs_exports:
 
 # For virtual cluster, ensure hosts file correctly uses private network
 hosts_network_interface: "eth1"
+hosts_add_ansible_managed_hosts_groups:
+- "slurm-cluster"
+
+# Ensure vagrant user has SSH access after pam_slurm for debugging
+slurm_allow_ssh_user:
+- "vagrant"
+- "root"

--- a/virtual/vars_files/virt_slurm.yml
+++ b/virtual/vars_files/virt_slurm.yml
@@ -11,5 +11,4 @@ nfs_exports:
   options: "*(rw,sync)"
 
 # For virtual cluster, ensure hosts file correctly uses private network
-hosts_add_default_ipv4: false
 hosts_network_interface: "eth1"


### PR DESCRIPTION
See https://github.com/DeepOps/ansible-role-hosts/pull/1 for details of the changes to /etc/hosts file.

This PR:

- Swaps `lukeyeager.hosts` for `DeepOps.hosts` to better manage the hosts role.
- Minor fix to virtual slurm variables for new role.
- Update docs for offline cluster to point out that you may want to specify your default network interface.