### PR TITLE
Configure Slurm to use SelectType=select/cons_tres

### DIFF
--- a/roles/slurm/templates/slurm.conf
+++ b/roles/slurm/templates/slurm.conf
@@ -67,7 +67,7 @@ Waittime=0
 # SCHEDULING
 SchedulerType=sched/backfill
 #SchedulerAuth=
-SelectType=select/cons_res
+SelectType=select/cons_tres
 SelectTypeParameters=CR_Core_Memory,CR_CORE_DEFAULT_DIST_BLOCK,CR_ONE_TASK_PER_CORE
 FastSchedule=1
 #PriorityType=priority/multifactor


### PR DESCRIPTION
Default Slurm configuration in DeepOps should use [trackable resources](https://slurm.schedmd.com/SLUG18/cons_tres.pdf) by default.

In addition to being the more modern option (AFAIK any new features are going into the cons_tres plugin), it enables some handy convenience features for GPUs. See new flags in the [generic resource](https://slurm.schedmd.com/gres.html#Running_Jobs) documentation.

## Testing

With cons_tres enabled, "friendly" GPU options work:

```
vagrant@virtual-login01:~$ srun --gpus 2 -n2 hostname
virtual-gpu01
virtual-gpu02
vagrant@virtual-login01:~$ srun --gpus 2 -n2 nvidia-smi -L
GPU 0: Tesla P4 (UUID: GPU-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx)
GPU 0: Tesla P4 (UUID: GPU-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx)
```

Without cons_tres enabled (SelectType=select/cons_res):

```
vagrant@virtual-login01:~$ srun --gpus 2 -n2 hostname
srun: error: Unable to allocate resources: Requested GRES option unsupported by configured SelectType plugin
```

Though of course the older-style gres options still work:

```
vagrant@virtual-login01:~$ srun --gres=gpu:1 -N2 hostname
virtual-gpu01
virtual-gpu02
vagrant@virtual-login01:~$ srun --gres=gpu:1 -N2 nvidia-smi -L
GPU 0: Tesla P4 (UUID: GPU-09d2c3f1-e54a-055f-c996-601051acf4e9)
GPU 0: Tesla P4 (UUID: GPU-23235a6b-0dfd-7646-2c8c-5160afde63dd)
```