### PR TITLE
Use DeepOps versions of chrony and users roles

### DIFF
--- a/playbooks/chrony-client.yml
+++ b/playbooks/chrony-client.yml
@@ -5,7 +5,7 @@
   tasks:
     - name: Configure Chrony client
       include_role:
-        name: unxnn.chrony
+        name: DeepOps.chrony
 
     - name: Set timezone
       shell: "timedatectl set-timezone {{ chrony_timezone }}"

--- a/playbooks/user-password.yml
+++ b/playbooks/user-password.yml
@@ -27,7 +27,7 @@
         ssh_max_auth_retries: 10
     - name: Set user password
       include_role:
-        name: unxnn.users
+        name: DeepOps.users
       vars:
         # User Configuration
         users:

--- a/playbooks/users.yml
+++ b/playbooks/users.yml
@@ -13,4 +13,4 @@
         ssh_max_auth_retries: 10
     - name: Set user password
       include_role:
-        name: unxnn.users
+        name: DeepOps.users

--- a/requirements.yml
+++ b/requirements.yml
@@ -3,8 +3,9 @@
 - src: dev-sec.ssh-hardening
   version: "6.1.3"
 
-- src: unxnn.users
-  version: '78fd08ca86678d00da376eaac909d22e1022a020'
+- src: https://github.com/DeepOps/ansible-role-users
+  name: DeepOps.users
+  version: 'e67df1db28bf099aa06d0ab250478963532b4d29'
 
 - src: https://github.com/DeepOps/ansible-role-hosts.git
   version: '8311d6ecfe39b665a06d1fc55502c6916e9ab5ce'
@@ -43,8 +44,9 @@
 - src: https://github.com/DeepOps/ansible-maas.git
   name: ansible-maas
 
-- src: unxnn.chrony
-  version: 'c95f84431c8c3ed693e88b35c87edf792fcf152f'
+- src: https://github.com/DeepOps/ansible-role-chrony
+  name: DeepOps.chrony
+  version: 'c9022153036dfdde4e2b313aecde4a46cd6f6687'
 
 - src: https://github.com/OSC/ood-ansible.git
   version: 'a56783750d5e61f0d099a2b294d9f050d194f293'


### PR DESCRIPTION
Github user unxnn appears to have unpublished their repos and Ansible Galaxy roles, but we had local copies so we could mirror. Let's use the DeepOps versions we control instead.

Please don't merge until this passes Jenkins.