### PR TITLE
Fix handling of services when downgrading Slurm

### DIFF
--- a/roles/slurm/tasks/build.yml
+++ b/roles/slurm/tasks/build.yml
@@ -45,15 +45,19 @@
     slurm_build: no
   when: sinfo_version.stdout == slurm_version and not slurm_force_rebuild
 
+- name: debug
+  debug:
+    msg: "{{ sinfo_version.stdout }}"
+
 - name: upgrade?
   set_fact:
     slurm_upgrade: yes
-  when: sinfo_version.stdout is version(slurm_version, '<')
+  when: sinfo_version.stdout and sinfo_version.stdout is version(slurm_version, '<')
 
 - name: downgrade?
   set_fact:
     slurm_downgrade: yes
-  when: sinfo_version.stdout is version(slurm_version, '>')
+  when: sinfo_version.stdout and sinfo_version.stdout is version(slurm_version, '>')
 
 - name: going to rebuild slurm?
   debug:

--- a/roles/slurm/tasks/build.yml
+++ b/roles/slurm/tasks/build.yml
@@ -32,6 +32,8 @@
 - name: default to building slurm
   set_fact:
     slurm_build: yes
+    slurm_upgrade: no
+    slurm_downgrade: no
 
 - name: check installed slurm version
   shell: "{{ slurm_install_prefix }}/bin/sinfo --version | awk '{print $2}'"
@@ -42,6 +44,16 @@
   set_fact:
     slurm_build: no
   when: sinfo_version.stdout == slurm_version and not slurm_force_rebuild
+
+- name: upgrade?
+  set_fact:
+    slurm_upgrade: yes
+  when: sinfo_version.stdout is version(slurm_version, '<')
+
+- name: downgrade?
+  set_fact:
+    slurm_downgrade: yes
+  when: sinfo_version.stdout is version(slurm_version, '>')
 
 - name: going to rebuild slurm?
   debug:

--- a/roles/slurm/tasks/build.yml
+++ b/roles/slurm/tasks/build.yml
@@ -45,10 +45,6 @@
     slurm_build: no
   when: sinfo_version.stdout == slurm_version and not slurm_force_rebuild
 
-- name: debug
-  debug:
-    msg: "{{ sinfo_version.stdout }}"
-
 - name: upgrade?
   set_fact:
     slurm_upgrade: yes

--- a/roles/slurm/tasks/compute.yml
+++ b/roles/slurm/tasks/compute.yml
@@ -114,7 +114,7 @@
 - name: start slurmd
   systemd:
     name: slurmd
-    state: started
+    state: restarted
     enabled: yes
     daemon-reload: yes
 

--- a/roles/slurm/tasks/controller.yml
+++ b/roles/slurm/tasks/controller.yml
@@ -79,10 +79,10 @@
   tags:
   - config
 
-- name: start slurmdbd
+- name: restart slurmdbd
   systemd:
     name: slurmdbd
-    state: started
+    state: restarted
     enabled: yes
     daemon-reload: yes
 
@@ -117,9 +117,23 @@
   environment:
     PATH: '{{ slurm_install_prefix }}/bin:{{ ansible_env.PATH }}'
 
-- name: start slurmctld
+- name: clear slurm state when downgrading
+  command: /usr/sbin/slurmctld -i
+  when: slurm_downgrade
+
+- name: wait for slurmctld to start
+  pause:
+    seconds: 20
+  when: slurm_downgrade
+
+- name: kill slurmctld
+  command: killall slurmctld
+  ignore_errors: yes
+  when: slurm_downgrade
+
+- name: restart slurmctld
   systemd:
     name: slurmctld
-    state: started
+    state: restarted
     enabled: yes
     daemon-reload: yes

--- a/roles/slurm/tasks/controller.yml
+++ b/roles/slurm/tasks/controller.yml
@@ -118,8 +118,10 @@
     PATH: '{{ slurm_install_prefix }}/bin:{{ ansible_env.PATH }}'
 
 - name: clear slurm state when downgrading
-  command: /usr/sbin/slurmctld -i
+  command: slurmctld -i
   when: slurm_downgrade
+  environment:
+    PATH: '{{ slurm_install_prefix }}/bin:{{ ansible_env.PATH }}'
 
 - name: wait for slurmctld to start
   pause:


### PR DESCRIPTION
Test Plan:

Test downgrading the Slurm version. Run the `slurm-cluster.yml` playbook with `-e slurm_version=20.02.4` and then a second time with `-e slurm_version=19.05.7` and make sure everything is working correctly.