### PR TITLE
Add support for hwloc and PMIx

### DIFF
--- a/roles/slurm/defaults/main.yml
+++ b/roles/slurm/defaults/main.yml
@@ -7,6 +7,9 @@ slurm_build_dir: /tmp/slurm-build
 slurm_config_dir: /etc/slurm
 slurm_install_prefix: /usr
 
+slurm_include_hwloc: yes
+slurm_include_pmix: yes
+
 slurm_cluster_name: deepops
 slurm_username: slurm
 slurm_password: ReplaceWithASecurePasswordInTheVault
@@ -54,3 +57,16 @@ slurm_clear_old_prolog_epilog: false
 slurm_fix_shm: true
 
 slurm_force_rebuild: no
+
+pmix_version: 3.1.5
+pmix_src_url: "https://github.com/openpmix/openpmix/releases/download/v{{ pmix_version }}/pmix-{{ pmix_version }}.tar.bz2"
+pmix_build_dir: /tmp/pmix-build
+pmix_install_prefix: '{{ slurm_install_prefix }}'
+pmix_force_rebuild: no
+
+hwloc_version: 2.2.0
+hwloc_tag: v2.2
+hwloc_src_url: "https://download.open-mpi.org/release/hwloc/{{ hwloc_tag }}/hwloc-{{ hwloc_version }}.tar.bz2"
+hwloc_build_dir: /tmp/hwloc-build
+hwloc_install_prefix: '{{ slurm_install_prefix }}'
+hwloc_force_rebuild: no

--- a/roles/slurm/tasks/hwloc.yml
+++ b/roles/slurm/tasks/hwloc.yml
@@ -1,0 +1,98 @@
+---
+- name: default to building hwloc
+  set_fact:
+    hwloc_build: yes
+
+- name: check installed hwloc version
+  shell: "{{ hwloc_install_prefix }}/bin/hwloc-info --version | awk '{print $2}'"
+  register: hwloc_info_version
+  ignore_errors: yes
+
+- name: don't build hwloc if it's already installed, unless forced
+  set_fact:
+    hwloc_build: no
+  when: hwloc_info_version.stdout == hwloc_version and not hwloc_force_rebuild
+
+- name: install hwloc build dependencies
+  apt:
+    name: "{{ item }}"
+  with_items: "{{ slurm_hwloc_deps }}"
+  when: ansible_distribution == 'Ubuntu'
+
+- name: install hwloc build dependencies
+  yum:
+    name: "{{ item }}"
+    state: present
+  with_items: "{{ slurm_hwloc_deps }}"
+  when: ansible_os_family == 'RedHat'
+
+- name: remove hwloc packages
+  apt:
+    name: "{{ item }}"
+    state: absent
+  with_items:
+    - hwloc
+    - libhwloc-dev
+    - libhwloc5
+  when: ansible_distribution == 'Ubuntu'
+  ignore_errors: yes
+
+- name: remove hwloc packages
+  yum:
+    name: "{{ item }}"
+    state: present
+  with_items:
+    - hwloc-devel
+    - hwloc-libs
+    - hwloc
+  when: ansible_os_family == 'RedHat'
+  ignore_errors: yes
+
+- name: make hwloc build directory
+  file:
+    path: "{{ hwloc_build_dir }}"
+    state: directory
+  when: hwloc_build
+
+- name: download hwloc source
+  unarchive:
+    src: "{{ hwloc_src_url }}"
+    remote_src: yes
+    dest: "{{ hwloc_build_dir }}"
+    extra_opts:
+      - --strip-components=1
+  when: hwloc_build
+
+- name: uninstall old hwloc version
+  command: make -j uninstall
+  args:
+    chdir: "{{ hwloc_build_dir }}"
+  ignore_errors: yes
+  when: hwloc_build
+  tags:
+    - uninstall
+
+- name: clean hwloc src dir
+  command: make distclean
+  args:
+    chdir: "{{ hwloc_build_dir }}"
+  ignore_errors: yes
+  when: hwloc_build
+
+- name: configure hwloc
+  command: "./configure --prefix={{ hwloc_install_prefix }}"
+  args:
+    chdir: "{{ hwloc_build_dir }}"
+  when: hwloc_build
+
+- name: build hwloc
+  shell: "make -j$(nproc) > build.log 2>&1"
+  args:
+    chdir: "{{ hwloc_build_dir }}"
+  when: hwloc_build
+
+- name: install hwloc
+  shell: "make -j$(nproc) install >> build.log 2>&1"
+  args:
+    chdir: "{{ hwloc_build_dir }}"
+  when: hwloc_build

--- a/roles/slurm/tasks/main.yml
+++ b/roles/slurm/tasks/main.yml
@@ -21,6 +21,14 @@
 
 - include: munge.yml
 
+- include: hwloc.yml
+  tags: hwloc
+  when: slurm_include_hwloc
+
+- include: pmix.yml
+  tags: pmix
+  when: slurm_include_pmix
+
 - include: build.yml
   tags: build
 

--- a/roles/slurm/tasks/pmix.yml
+++ b/roles/slurm/tasks/pmix.yml
@@ -1,0 +1,98 @@
+---
+- name: default to building pmix
+  set_fact:
+    pmix_build: yes
+
+- name: check installed pmix version
+  shell: "{{ pmix_install_prefix }}/bin/pmix_info --version | grep PMIX: | awk '{print $2}'"
+  register: pmix_info_version
+  ignore_errors: yes
+
+- name: don't build pmix if it's already installed, unless forced
+  set_fact:
+    pmix_build: no
+  when: pmix_info_version.stdout == pmix_version and not pmix_force_rebuild
+
+- name: install pmix build dependencies
+  apt:
+    name: "{{ item }}"
+  with_items: "{{ slurm_pmix_deps }}"
+  when: ansible_distribution == 'Ubuntu'
+
+- name: install pmix build dependencies
+  yum:
+    name: "{{ item }}"
+    state: present
+  with_items: "{{ slurm_pmix_deps }}"
+  when: ansible_os_family == 'RedHat'
+
+- name: remove pmix packages
+  apt:
+    name: "{{ item }}"
+    state: absent
+  with_items:
+    - pmix
+    - libpmix-dev
+    - libpmix5
+  when: ansible_distribution == 'Ubuntu'
+  ignore_errors: yes
+
+- name: remove pmix packages
+  yum:
+    name: "{{ item }}"
+    state: present
+  with_items:
+    - pmix-devel
+    - pmix-libs
+    - pmix
+  when: ansible_os_family == 'RedHat'
+  ignore_errors: yes
+
+- name: make pmix build directory
+  file:
+    path: "{{ pmix_build_dir }}"
+    state: directory
+  when: pmix_build
+
+- name: download pmix source
+  unarchive:
+    src: "{{ pmix_src_url }}"
+    remote_src: yes
+    dest: "{{ pmix_build_dir }}"
+    extra_opts:
+      - --strip-components=1
+  when: pmix_build
+
+- name: uninstall old pmix version
+  command: make -j uninstall
+  args:
+    chdir: "{{ pmix_build_dir }}"
+  ignore_errors: yes
+  when: pmix_build
+  tags:
+    - uninstall
+
+- name: clean pmix src dir
+  command: make distclean
+  args:
+    chdir: "{{ pmix_build_dir }}"
+  ignore_errors: yes
+  when: pmix_build
+
+- name: configure pmix
+  command: "./configure --prefix={{ pmix_install_prefix }}"
+  args:
+    chdir: "{{ pmix_build_dir }}"
+  when: pmix_build
+
+- name: build pmix
+  shell: "make -j$(nproc) > build.log 2>&1"
+  args:
+    chdir: "{{ pmix_build_dir }}"
+  when: pmix_build
+
+- name: install pmix
+  shell: "make -j$(nproc) install >> build.log 2>&1"
+  args:
+    chdir: "{{ pmix_build_dir }}"
+  when: pmix_build

--- a/roles/slurm/vars/redhat.yml
+++ b/roles/slurm/vars/redhat.yml
@@ -29,3 +29,9 @@ slurm_build_deps:
   - python3
   - ruby-devel
   - wget
+
+slurm_pmix_deps:
+  - libev-devel
+  - libevent-devel
+
+slurm_hwloc_deps: []

--- a/roles/slurm/vars/ubuntu.yml
+++ b/roles/slurm/vars/ubuntu.yml
@@ -10,3 +10,9 @@ slurm_build_deps:
   - python-minimal
   - ruby-dev
   - wget
+
+slurm_pmix_deps:
+  - libev-dev
+  - libevent-dev
+
+slurm_hwloc_deps: []


### PR DESCRIPTION
Has options to upgrade, downgrade, change install prefix. Included by default and automatically picked up by the Slurm build.

With and without PMIx:

```
ubuntu@polite-tapir:~$ srun --mpi=list
srun: MPI types are...
srun: none
srun: openmpi
srun: pmi2
ubuntu@polite-tapir:~$ srun --mpi=list
srun: MPI types are...
srun: none
srun: openmpi
srun: pmi2
srun: pmix_v3
srun: pmix
```