### PR TITLE
Update yum.conf to fix DGX repos mirroring

### DIFF
--- a/roles/offline-repo-mirrors/files/yum.conf
+++ b/roles/offline-repo-mirrors/files/yum.conf
@@ -21,20 +21,20 @@ distroverpkg=centos-release
 # geographically close to the client.  You should use this for CentOS updates
 # unless you are manually picking other mirrors.
 #
-# If the mirrorlist= does not work for you, as a fall back you can try the 
+# If the mirrorlist= does not work for you, as a fall back you can try the
 # remarked out baseurl= line instead.
 #
 #
 
-[base]
+[centos-base]
 name=CentOS-7 - Base
 mirrorlist=http://mirrorlist.centos.org/?release=7&arch=x86_64&repo=os&infra=$infra
 #baseurl=http://mirror.centos.org/centos/7/os/x86_64/
 gpgcheck=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
 
-#released updates 
-[updates]
+#released updates
+[centos-updates]
 name=CentOS-7 - Updates
 mirrorlist=http://mirrorlist.centos.org/?release=7&arch=x86_64&repo=updates&infra=$infra
 #baseurl=http://mirror.centos.org/centos/7/updates/x86_64/
@@ -42,7 +42,7 @@ gpgcheck=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
 
 #additional packages that may be useful
-[extras]
+[centos-extras]
 name=CentOS-7 - Extras
 mirrorlist=http://mirrorlist.centos.org/?release=7&arch=x86_64&repo=extras&infra=$infra
 #baseurl=http://mirror.centos.org/centos/7/extras/x86_64/
@@ -72,11 +72,11 @@ gpgkey=https://download.docker.com/linux/centos/gpg
 
 [docker-engine]
 name=Docker-Engine Repository
-baseurl=https://yum.dockerproject.org/repo/main/centos/7
+baseurl=https://download.docker.com/linux/centos/7/$basearch/stable
 enabled=1
 gpgcheck=1
 keepcache=0
-gpgkey=https://yum.dockerproject.org/gpg
+gpgkey=https://download.docker.com/linux/centos/gpg
 
 [epel]
 baseurl = https://download.fedoraproject.org/pub/epel/7/x86_64/
@@ -108,3 +108,15 @@ gpgkey=https://nvidia.github.io/nvidia-docker/gpgkey
 baseurl = https://developer.download.nvidia.com/compute/machine-learning/repos/rhel7/x86_64/
 gpgkey = https://developer.download.nvidia.com/compute/machine-learning/repos/rhel7/x86_64/7fa2af80.pub
 name = NVIDIA Machine Learning Repo
+
+[nvidia-dgx-7]
+name=NVIDIA DGX EL7 Repo
+baseurl=https://international.download.nvidia.com/dgx/repos/rhel7/
+enabled=1
+gpgcheck=1 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-dgx-cosmos-support
+
+[nvidia-dgx-7-updates]
+name=NVIDIA DGX EL7 Updates
+baseurl=https://international.download.nvidia.com/dgx/repos/rhel7-updates/
+enabled=1
+gpgcheck=1 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-dgx-cosmos-support


### PR DESCRIPTION
Was missing nvidia-dgx-7 repo and nvidia-dgx-7-updates repo, and centos-base,  centos-updates and centos-extras were in originally as base, updates, and extras causing the task to fail.

Lifted the nvidia-dgx-7 and nvidia-dgx-7-updates repo from https://docs.nvidia.com/dgx/pdf/dgx-rhel-install-guide.pdf for reference.

Fixed.