### PR TITLE
Update docker-registry version

### DIFF
--- a/roles/container-registry/defaults/main.yml
+++ b/roles/container-registry/defaults/main.yml
@@ -2,7 +2,7 @@ tiller_host: localhost
 helm_chart_location: "https://kubernetes-charts.storage.googleapis.com"
 container_registry_name: docker-registry
 container_registry_namespace: default
-container_registry_version: 1.7.0
+container_registry_version: 1.9.2
 container_registry_hostname: registry.local
 container_registry_ingress_enabled: true
 container_registry_ingress_size: 4096m


### PR DESCRIPTION
Fixes issues with 'no matches for kind "Deployment" in version "extensions/v1beta1"' errors on deployment of local registry