### PR TITLE
Upgrade to nvidia.nvidia_driver v1.2.1.

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -18,7 +18,7 @@
   version: "v5.2.6"
 
 - src: nvidia.nvidia_driver
-  version: "v1.2.0"
+  version: "v1.2.1"
 
 - src: nvidia.nvidia_docker
   version: "v1.2.1"


### PR DESCRIPTION
Includes fix for specifying version of NVIDIA driver on RHEL. See https://github.com/NVIDIA/ansible-role-nvidia-driver/pull/13