### PR TITLE
Disable Open OnDemand by default.

### DIFF
--- a/config.example/group_vars/slurm-cluster.yml
+++ b/config.example/group_vars/slurm-cluster.yml
@@ -34,7 +34,7 @@ nfs_mounts:
 ################################################################################
 # Open OnDemand                                                                #
 ################################################################################
-install_open_ondemand: yes
+install_open_ondemand: no
 ood_install_linuxhost_adapter: yes
 
 servername: '{{ ansible_fqdn }}'


### PR DESCRIPTION
The `rake build` step for ood-ansible is flaky and often causes the CI system to fail. Let's disable this in the default cluster build, and users can enable on their own clusters if desired.