### PR TITLE
Add NetApp Trident Deployment

### DIFF
--- a/config.example/group_vars/netapp-trident.yml
+++ b/config.example/group_vars/netapp-trident.yml
@@ -1,0 +1,94 @@
+---
+# vars file for netapp-trident playbook
+
+# Kubernetes version
+# Note: Do not include patch version, e.g. provide value of 1.16, not 1.16.7.
+# Note: Versions 1.14 and above are supported when deploying Trident with DeepOps.
+#   If you are using an earlier version, you must deploy Trident manually.
+k8s_version: 1.16
+
+# Denotes whether or not to create new backends after deploying trident
+# For more info, refer to: https://netapp-trident.readthedocs.io/en/stable-v20.04/kubernetes/operator-install.html#creating-a-trident-backend
+create_backends: true
+
+# List of backends to create
+# For more info on parameter values, refer to: https://netapp-trident.readthedocs.io/en/stable-v20.04/kubernetes/operations/tasks/backends/ontap.html
+# Note: Parameters other than those listed below are not avaible when creating a backend via DeepOps
+#   If you wish to use other parameter values, you must create your backend manually.
+backends_to_create:
+  - backendName: ontap-flexvol
+    storageDriverName: ontap-nas # only 'ontap-nas' and 'ontap-nas-flexgroup' are supported when creating a backend via DeepOps
+    managementLIF: 10.61.188.40
+    dataLIF: 192.168.200.41
+    svm: ai221_data
+    username: admin
+    password: NetApp!23
+    storagePrefix: trident
+    limitAggregateUsage: ""
+    limitVolumeSize: ""
+    nfsMountOptions: ""
+    defaults:
+      spaceReserve: none
+      snapshotPolicy: none
+      snapshotReserve: 0
+      splitOnClone: false
+      encryption: false
+      unixPermissions: 777
+      snapshotDir: true
+      exportPolicy: default
+      securityStyle: unix
+      tieringPolicy: none
+  - backendName: ontap-flexgroup
+    storageDriverName: ontap-nas-flexgroup # only 'ontap-nas' and 'ontap-nas-flexgroup' are supported when creating a backend via DeepOps
+    managementLIF: 10.61.188.40
+    dataLIF: 192.168.200.41
+    svm: ai221_data
+    username: admin
+    password: NetApp!23
+    storagePrefix: trident
+    limitAggregateUsage: ""
+    limitVolumeSize: ""
+    nfsMountOptions: ""
+    defaults:
+      spaceReserve: none
+      snapshotPolicy: none
+      snapshotReserve: 0
+      splitOnClone: false
+      encryption: false
+      unixPermissions: 777
+      snapshotDir: true
+      exportPolicy: default
+      securityStyle: unix
+      tieringPolicy: none
+  # Add additional backends as needed
+
+# Denotes whether or not to create new StorageClasses for your NetApp storage
+# For more info, refer to: https://netapp-trident.readthedocs.io/en/stable-v20.04/kubernetes/operator-install.html#creating-a-storage-class
+create_StorageClasses: true
+
+# List of StorageClasses to create
+# Note: Each item in the list should be an actual K8s StorageClass definition in yaml format
+# For more info on StorageClass definitions, refer to https://netapp-trident.readthedocs.io/en/stable-v20.04/kubernetes/concepts/objects.html#kubernetes-storageclass-objects.
+storageClasses_to_create:
+  - apiVersion: storage.k8s.io/v1
+    kind: StorageClass
+    metadata:
+      name: ontap-flexvol
+      annotations:
+        storageclass.kubernetes.io/is-default-class: "true"
+    provisioner: csi.trident.netapp.io
+    parameters:
+      backendType: "ontap-nas"
+  - apiVersion: storage.k8s.io/v1
+    kind: StorageClass
+    metadata:
+      name: ontap-flexgroup
+    provisioner: csi.trident.netapp.io
+    parameters:
+      backendType: "ontap-nas-flexgroup"
+  # Add additional StorageClasses as needed
+
+# Denotes whether or not to copy tridenctl binary to localhost
+copy_tridentctl_to_localhost: true
+# Directory that tridentctl will be copied to on localhost
+tridentctl_copy_to_directory: ../ # will be copied to 'deepops/' directory

--- a/docs/kubernetes-cluster.md
+++ b/docs/kubernetes-cluster.md
@@ -100,6 +100,8 @@ Run the following script to create an administrative user and print out the dash
 
 ### Persistent Storage
 
+#### Ceph Cluster
+
 Deploy a Ceph cluster running on Kubernetes for services that require persistent storage (such as Kubeflow):
 
 ```sh
@@ -110,6 +112,41 @@ Poll the Ceph status by running:
 
 ```sh
 ./scripts/ceph_poll.sh
+```
+
+#### NetApp Trident
+
+Deploy NetApp Trident for services that require persistent storage (such as Kubeflow). Note that you must have a NetApp storage system/instance in order to use Trident to provision persistent storage.
+
+1. Set configuration parameters.
+
+```sh
+vi config/group_vars/netapp-trident.yml
+```
+
+2. Deploy Trident using Ansible.
+
+```sh
+# NOTE: If SSH requires a password, add: `-k`
+# NOTE: If sudo on remote machine requires a password, add: `-K`
+# NOTE: If SSH user is different than current user, add: `-u ubuntu`
+ansible-playbook -l k8s-cluster playbooks/netapp-trident.yml
+```
+
+3. Verify that Trident is running.
+
+```sh
+./tridenctl -n trident version
+```
+
+Output of the above command should be:
+
+```sh
++----------------+----------------+
+| SERVER VERSION | CLIENT VERSION |
++----------------+----------------+
+| 20.04.0        | 20.04.0        |
++----------------+----------------+
 ```
 
 ### Monitoring

--- a/docs/kubernetes-cluster.md
+++ b/docs/kubernetes-cluster.md
@@ -120,34 +120,34 @@ Deploy NetApp Trident for services that require persistent storage (such as Kube
 
 1. Set configuration parameters.
 
-```sh
-vi config/group_vars/netapp-trident.yml
-```
+   ```sh
+   vi config/group_vars/netapp-trident.yml
+   ```
 
 2. Deploy Trident using Ansible.
 
-```sh
-# NOTE: If SSH requires a password, add: `-k`
-# NOTE: If sudo on remote machine requires a password, add: `-K`
-# NOTE: If SSH user is different than current user, add: `-u ubuntu`
-ansible-playbook -l k8s-cluster playbooks/netapp-trident.yml
-```
+   ```sh
+   # NOTE: If SSH requires a password, add: `-k`
+   # NOTE: If sudo on remote machine requires a password, add: `-K`
+   # NOTE: If SSH user is different than current user, add: `-u ubuntu`
+   ansible-playbook -l k8s-cluster playbooks/netapp-trident.yml
+   ```
 
 3. Verify that Trident is running.
 
-```sh
-./tridenctl -n trident version
-```
+   ```sh
+   ./tridenctl -n trident version
+   ```
 
-Output of the above command should be:
+   Output of the above command should be:
 
-```sh
-+----------------+----------------+
-| SERVER VERSION | CLIENT VERSION |
-+----------------+----------------+
-| 20.04.0        | 20.04.0        |
-+----------------+----------------+
-```
+   ```sh
+   +----------------+----------------+
+   | SERVER VERSION | CLIENT VERSION |
+   +----------------+----------------+
+   | 20.04.0        | 20.04.0        |
+   +----------------+----------------+
+   ```
 
 ### Monitoring
 

--- a/docs/kubernetes-cluster.md
+++ b/docs/kubernetes-cluster.md
@@ -136,7 +136,7 @@ Deploy NetApp Trident for services that require persistent storage (such as Kube
 3. Verify that Trident is running.
 
    ```sh
-   ./tridenctl -n trident version
+   ./tridentctl -n trident version
    ```
 
    Output of the above command should be:

--- a/playbooks/netapp-trident.yml
+++ b/playbooks/netapp-trident.yml
@@ -1,0 +1,25 @@
+---
+# Playbook for deploying NetApp Trident
+
+- name: "Install NFS utils on worker nodes"
+  hosts: kube-node
+  become: true
+  become_method: sudo
+  tasks:
+  - name: install nfs utils (Ubuntu)
+    package:
+      name: nfs-common
+    when: ansible_os_family == "Debian"
+  - name: install nfs utils (Red Hat / CentOS)
+    package:
+      name: nfs-utils
+    when: ansible_os_family == "RedHat"
+
+- name: "Deploy NetApp Trident"
+  hosts: kube-master
+  become: true
+  become_method: sudo
+  vars_files:
+    - ../config/group_vars/netapp-trident.yml
+  roles:
+    - role: netapp-trident

--- a/roles/netapp-trident/README.md
+++ b/roles/netapp-trident/README.md
@@ -19,7 +19,7 @@ See defaults/main.yml, vars/main.yml
 Dependencies
 ------------
 
-Python modules: openshift (must be installed on target host)
+Roles: openshift (https://github.com/mboglesby/deepops/tree/master/roles/openshift)
 
 Example Playbooks
 ----------------

--- a/roles/netapp-trident/README.md
+++ b/roles/netapp-trident/README.md
@@ -1,0 +1,100 @@
+netapp-trident
+=========
+
+Ansible role that can be used to deploy NetApp Trident within a Kubernetes cluster.
+
+Requirements
+------------
+
+**Prerequesites:**
+
+1. 'kubectl' must be installed on the target host.
+2. '~/.kube/config' must be configured, on the target host, for access to the cluster that you wish to deploy Trident to.
+
+Role Variables
+--------------
+
+See defaults/main.yml, vars/main.yml
+
+Dependencies
+------------
+
+Python modules: openshift (must be installed on target host)
+
+Example Playbooks
+----------------
+
+Note: Role must be invoked with "become: true", or playbook that invokes role must be executed by root user.
+
+**Example Playbooks:**
+
+Example A:
+
+    - name: "Deploy NetApp Trident"
+      hosts: localhost
+      become: true
+      become_method: sudo
+      roles:
+         - role: netapp-trident
+
+Example B:
+
+    - name: "Deploy NetApp Trident"
+      hosts: kube-master
+      become: true
+      become_method: sudo
+      roles:
+        - role: netapp-trident
+
+Example C:
+
+    - name: "Deploy NetApp Trident"
+      hosts: kube-master
+      become: true
+      become_method: sudo
+      vars_files:
+        - custom-vars.yml
+      roles:
+        - role: netapp-trident
+
+**Example Inventory File:**
+
+```
+all:
+  hosts:
+    mgmt01:
+      ansible_host: 192.168.1.210
+      ip: 192.168.1.210
+      access_ip: 192.168.1.210
+    mgmt02:
+      ansible_host: 192.168.1.211
+      ip: 192.168.1.211
+      access_ip: 192.168.1.211
+    mgmt03:
+      ansible_host: 192.168.1.212
+      ip: 192.168.1.212
+      access_ip: 192.168.1.212
+    app01:
+      ansible_host: 192.168.1.213
+      ip: 192.168.1.213
+      access_ip: 192.168.1.213
+    app02:
+      ansible_host: 192.168.1.214
+      ip: 192.168.1.214
+      access_ip: 192.168.1.214
+    app03:
+      ansible_host: 192.168.1.215
+      ip: 192.168.1.215
+      access_ip: 192.168.1.215
+  children:
+    kube-master:
+      hosts:
+        mgmt01:
+        mgmt02:
+        mgmt03:
+    servers-dgx2:
+      hosts:
+        app01:
+        app02:
+        app03:
+```

--- a/roles/netapp-trident/defaults/main.yml
+++ b/roles/netapp-trident/defaults/main.yml
@@ -1,0 +1,94 @@
+---
+# defaults file for netapp-trident role
+
+# Kubernetes version
+# Note: Do not include patch version, e.g. provide value of 1.16, not 1.16.7.
+# Note: Versions 1.14 and above are supported when deploying Trident with DeepOps.
+#   If you are using an earlier version, you must deploy Trident manually.
+k8s_version: 1.16
+
+# Denotes whether or not to create new backends after deploying trident
+# For more info, refer to: https://netapp-trident.readthedocs.io/en/stable-v20.04/kubernetes/operator-install.html#creating-a-trident-backend
+create_backends: false
+
+# List of backends to create
+# For more info on parameter values, refer to: https://netapp-trident.readthedocs.io/en/stable-v20.04/kubernetes/operations/tasks/backends/ontap.html
+# Note: Parameters other than those listed below are not avaible when creating a backend via DeepOps
+#   If you wish to use other parameter values, you must create your backend manually.
+backends_to_create:
+  - backendName: ontap-flexvol
+    storageDriverName: ontap-nas # only 'ontap-nas' and 'ontap-nas-flexgroup' are supported when creating a backend via DeepOps
+    managementLIF: 10.61.188.40
+    dataLIF: 192.168.200.41
+    svm: ai221_data
+    username: admin
+    password: NetApp!23
+    storagePrefix: trident
+    limitAggregateUsage: ""
+    limitVolumeSize: ""
+    nfsMountOptions: ""
+    defaults:
+      spaceReserve: none
+      snapshotPolicy: none
+      snapshotReserve: 0
+      splitOnClone: false
+      encryption: false
+      unixPermissions: 777
+      snapshotDir: true
+      exportPolicy: default
+      securityStyle: unix
+      tieringPolicy: none
+  - backendName: ontap-flexgroup
+    storageDriverName: ontap-nas-flexgroup # only 'ontap-nas' and 'ontap-nas-flexgroup' are supported when creating a backend via DeepOps
+    managementLIF: 10.61.188.40
+    dataLIF: 192.168.200.41
+    svm: ai221_data
+    username: admin
+    password: NetApp!23
+    storagePrefix: trident
+    limitAggregateUsage: ""
+    limitVolumeSize: ""
+    nfsMountOptions: ""
+    defaults:
+      spaceReserve: none
+      snapshotPolicy: none
+      snapshotReserve: 0
+      splitOnClone: false
+      encryption: false
+      unixPermissions: 777
+      snapshotDir: true
+      exportPolicy: default
+      securityStyle: unix
+      tieringPolicy: none
+  # Add additional backends as needed
+
+# Denotes whether or not to create new StorageClasses for your NetApp storage
+# For more info, refer to: https://netapp-trident.readthedocs.io/en/stable-v20.04/kubernetes/operator-install.html#creating-a-storage-class
+create_StorageClasses: false
+
+# List of StorageClasses to create
+# Note: Each item in the list should be an actual K8s StorageClass definition in yaml format
+# For more info on StorageClass definitions, refer to https://netapp-trident.readthedocs.io/en/stable-v20.04/kubernetes/concepts/objects.html#kubernetes-storageclass-objects.
+storageClasses_to_create:
+  - apiVersion: storage.k8s.io/v1
+    kind: StorageClass
+    metadata:
+      name: ontap-flexvol
+      annotations:
+        storageclass.kubernetes.io/is-default-class: "true"
+    provisioner: csi.trident.netapp.io
+    parameters:
+      backendType: "ontap-nas"
+  - apiVersion: storage.k8s.io/v1
+    kind: StorageClass
+    metadata:
+      name: ontap-flexgroup
+    provisioner: csi.trident.netapp.io
+    parameters:
+      backendType: "ontap-nas-flexgroup"
+  # Add additional StorageClasses as needed
+
+# Denotes whether or not to copy tridenctl binary to localhost
+copy_tridentctl_to_localhost: true
+# Directory that tridentctl will be copied to on localhost
+tridentctl_copy_to_directory: ./

--- a/roles/netapp-trident/meta/main.yml
+++ b/roles/netapp-trident/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - role: openshift

--- a/roles/netapp-trident/tasks/main.yml
+++ b/roles/netapp-trident/tasks/main.yml
@@ -1,42 +1,6 @@
 ---
 # tasks file for netapp-trident role
 
-- name: Install pip (Ubuntu)
-  package:
-    name:
-      - python-pip
-      - python3-pip
-    state: present
-  when: ansible_os_family == "Debian"
-  
-- name: Install epel-release (Red Hat / CentOS)
-  package:
-    name: epel-release
-    state: present
-  when: ansible_os_family == "RedHat"
-
-- name: Install pip (Red Hat / CentOS)
-  package:
-    name:
-      - python2-pip
-      - python3-pip
-    state: present
-  when: ansible_os_family == "RedHat"
-  
-- name: Upgrade pip (Red Hat / CentOS)
-  pip:
-    name:
-      - pip
-      - setuptools
-    state: latest
-  when: ansible_os_family == "RedHat"
-
-- name: Install python dependencies
-  pip:
-    name:
-      - openshift>=0.6
-      - PyYAML>=3.11
-
 - name: Download and extract Trident installer
   unarchive:
     src: https://github.com/NetApp/trident/releases/download/v20.04.0/trident-installer-20.04.0.tar.gz

--- a/roles/netapp-trident/tasks/main.yml
+++ b/roles/netapp-trident/tasks/main.yml
@@ -8,6 +8,12 @@
       - python3-pip
     state: present
   when: ansible_os_family == "Debian"
+  
+- name: Install epel-release (Red Hat / CentOS)
+  package:
+    name: epel-release
+    state: present
+  when: ansible_os_family == "RedHat"
 
 - name: Install pip (Red Hat / CentOS)
   package:

--- a/roles/netapp-trident/tasks/main.yml
+++ b/roles/netapp-trident/tasks/main.yml
@@ -1,0 +1,124 @@
+---
+# tasks file for netapp-trident role
+
+- name: Install pip
+  package:
+    name:
+      - python3
+      - python3-pip
+    state: present
+
+- name: Install python dependencies
+  pip:
+    name:
+      - openshift>=0.6
+      - PyYAML>=3.11
+    executable: pip3
+
+- name: Download and extract Trident installer
+  unarchive:
+    src: https://github.com/NetApp/trident/releases/download/v20.04.0/trident-installer-20.04.0.tar.gz
+    dest: /root
+    remote_src: yes
+
+- name: Create Trident namespace
+  k8s:
+    state: present
+    kind: Namespace
+    name: trident
+    wait: yes
+  run_once: true
+
+- name: Create TridentProvisioner CRD (K8s version >= 1.16)
+  k8s:
+    state: present
+    src: /root/trident-installer/deploy/crds/trident.netapp.io_tridentprovisioners_crd_post1.16.yaml
+    wait: yes
+  when: k8s_version >= 1.16
+  run_once: true
+
+- name: Create TridentProvisioner CRD (K8s version < 1.16)
+  k8s:
+    state: present
+    src: /root/trident-installer/deploy/crds/trident.netapp.io_tridentprovisioners_crd_pre1.16.yaml
+    wait: yes
+  when: k8s_version < 1.16
+  run_once: true
+
+- name: Deploy Trident operator resources
+  k8s:
+    state: present
+    src: /root/trident-installer/deploy/bundle.yaml
+    wait: yes
+  run_once: true
+
+- name: Create TridentProvisioner CR
+  k8s:
+    state: present
+    src: /root/trident-installer/deploy/crds/tridentprovisioner_cr.yaml
+    wait: yes
+  run_once: true
+
+- name: Wait until trident-csi Deployment exists
+  k8s_info:
+    kind: Deployment
+    namespace: trident
+    name: trident-csi
+  register: deployment_trident_csi
+  until: deployment_trident_csi.resources | length == 1
+  retries: 24
+  delay: 5
+  run_once: true
+
+- name: Pause for 10 seconds
+  pause:
+    seconds: 10
+
+- name: Wait until trident-csi Deployment is ready
+  k8s_info:
+    kind: Deployment
+    namespace: trident
+    name: trident-csi
+  register: deployment_trident_csi
+  until: deployment_trident_csi.resources[0].status.availableReplicas == 1
+  retries: 24
+  delay: 5
+  run_once: true
+
+- name: Copy backend config file(s) to control node
+  template:
+    src: backend.j2
+    dest: /root/trident-installer/backend-{{ item.backendName }}.json
+  with_items: "{{ backends_to_create }}"
+  when: create_backends == true
+  run_once: true
+
+- name: Create Trident backend(s)
+  command: /root/trident-installer/tridentctl -n trident create backend -f /root/trident-installer/backend-{{ item.backendName }}.json
+  with_items: "{{ backends_to_create }}"
+  when: create_backends == true
+  run_once: true
+
+- name: Create NetApp StorageClass(es)
+  k8s:
+    state: present
+    definition: "{{ item }}"
+  with_items: "{{ storageClasses_to_create }}"
+  when: create_StorageClasses == true
+  run_once: true
+
+- name: Fetch tridentctl from control node
+  fetch:
+    src: /root/trident-installer/tridentctl
+    dest: "{{ tridentctl_copy_to_directory }}"
+    flat: yes
+  when: copy_tridentctl_to_localhost == true
+  run_once: true
+
+- name: Make tridentctl on localhost executable
+  delegate_to: localhost
+  become: false
+  file:
+    path: "{{ tridentctl_copy_to_directory }}/tridentctl"
+    mode: '0755'
+  when: copy_tridentctl_to_localhost == true

--- a/roles/netapp-trident/tasks/main.yml
+++ b/roles/netapp-trident/tasks/main.yml
@@ -29,6 +29,7 @@
       - pip
       - setuptools
     state: latest
+  when: ansible_os_family == "RedHat"
 
 - name: Install python dependencies
   pip:

--- a/roles/netapp-trident/tasks/main.yml
+++ b/roles/netapp-trident/tasks/main.yml
@@ -9,7 +9,7 @@
     state: present
   when: ansible_os_family == "Debian"
 
-- name: Install pip (Red Hat / CentOs)
+- name: Install pip (Red Hat / CentOS)
   package:
     name:
       - python2-pip
@@ -22,7 +22,6 @@
     name:
       - openshift>=0.6
       - PyYAML>=3.11
-    executable: pip3
 
 - name: Download and extract Trident installer
   unarchive:

--- a/roles/netapp-trident/tasks/main.yml
+++ b/roles/netapp-trident/tasks/main.yml
@@ -22,6 +22,13 @@
       - python3-pip
     state: present
   when: ansible_os_family == "RedHat"
+  
+- name: Upgrade pip (Red Hat / CentOS)
+  pip:
+    name:
+      - pip
+      - setuptools
+    state: latest
 
 - name: Install python dependencies
   pip:

--- a/roles/netapp-trident/tasks/main.yml
+++ b/roles/netapp-trident/tasks/main.yml
@@ -32,40 +32,36 @@
     state: present
     src: /root/trident-installer/deploy/crds/trident.netapp.io_tridentprovisioners_crd_post1.16.yaml
     wait: yes
-  when: k8s_version >= 1.16
   run_once: true
   environment:
     PYTHONHOME: '{{ deepops_venv }}'
-  when: ansible_distribution == 'Ubuntu'
+  when: k8s_version >= 1.16 and ansible_distribution == 'Ubuntu'
 
 - name: Create TridentProvisioner CRD (K8s version >= 1.16) (Red Hat / CentOS)
   k8s:
     state: present
     src: /root/trident-installer/deploy/crds/trident.netapp.io_tridentprovisioners_crd_post1.16.yaml
     wait: yes
-  when: k8s_version >= 1.16
   run_once: true
-  when: ansible_os_family == 'RedHat'
+  when: k8s_version >= 1.16 and ansible_os_family == 'RedHat'
 
 - name: Create TridentProvisioner CRD (K8s version < 1.16) (Ubuntu)
   k8s:
     state: present
     src: /root/trident-installer/deploy/crds/trident.netapp.io_tridentprovisioners_crd_pre1.16.yaml
     wait: yes
-  when: k8s_version < 1.16
   run_once: true
   environment:
     PYTHONHOME: '{{ deepops_venv }}'
-  when: ansible_distribution == 'Ubuntu'
+  when: k8s_version < 1.16 and ansible_distribution == 'Ubuntu'
 
 - name: Create TridentProvisioner CRD (K8s version < 1.16) (Red Hat / CentOS)
   k8s:
     state: present
     src: /root/trident-installer/deploy/crds/trident.netapp.io_tridentprovisioners_crd_pre1.16.yaml
     wait: yes
-  when: k8s_version < 1.16
   run_once: true
-  when: ansible_os_family == 'RedHat'
+  when: k8s_version < 1.16 and ansible_os_family == 'RedHat'
 
 - name: Deploy Trident operator resources (Ubuntu)
   k8s:
@@ -178,20 +174,18 @@
     state: present
     definition: "{{ item }}"
   with_items: "{{ storageClasses_to_create }}"
-  when: create_StorageClasses == true
   run_once: true
   environment:
     PYTHONHOME: '{{ deepops_venv }}'
-  when: ansible_distribution == 'Ubuntu'
+  when: create_StorageClasses == true and ansible_distribution == 'Ubuntu'
 
 - name: Create NetApp StorageClass(es) (Red Hat / CentOS)
   k8s:
     state: present
     definition: "{{ item }}"
   with_items: "{{ storageClasses_to_create }}"
-  when: create_StorageClasses == true
   run_once: true
-  when: ansible_os_family == 'RedHat'
+  when: create_StorageClasses == true and ansible_os_family == 'RedHat'
 
 - name: Fetch tridentctl from control node
   fetch:

--- a/roles/netapp-trident/tasks/main.yml
+++ b/roles/netapp-trident/tasks/main.yml
@@ -1,12 +1,21 @@
 ---
 # tasks file for netapp-trident role
 
-- name: Install pip
+- name: Install pip (Ubuntu)
   package:
     name:
-      - python3
+      - python-pip
       - python3-pip
     state: present
+  when: ansible_os_family == "Debian"
+
+- name: Install pip (Red Hat / CentOs)
+  package:
+    name:
+      - python2-pip
+      - python3-pip
+    state: present
+  when: ansible_os_family == "RedHat"
 
 - name: Install python dependencies
   pip:

--- a/roles/netapp-trident/tasks/main.yml
+++ b/roles/netapp-trident/tasks/main.yml
@@ -7,45 +7,103 @@
     dest: /root
     remote_src: yes
 
-- name: Create Trident namespace
+- name: Create Trident namespace (ubuntu)
   k8s:
     state: present
     kind: Namespace
     name: trident
     wait: yes
   run_once: true
+  environment:
+    PYTHONHOME: '{{ deepops_venv }}'
+  when: ansible_distribution == 'Ubuntu'
 
-- name: Create TridentProvisioner CRD (K8s version >= 1.16)
+- name: Create Trident namespace (Red Hat / CentOS)
+  k8s:
+    state: present
+    kind: Namespace
+    name: trident
+    wait: yes
+  run_once: true
+  when: ansible_os_family == 'RedHat'
+
+- name: Create TridentProvisioner CRD (K8s version >= 1.16) (Ubuntu)
   k8s:
     state: present
     src: /root/trident-installer/deploy/crds/trident.netapp.io_tridentprovisioners_crd_post1.16.yaml
     wait: yes
   when: k8s_version >= 1.16
   run_once: true
+  environment:
+    PYTHONHOME: '{{ deepops_venv }}'
+  when: ansible_distribution == 'Ubuntu'
 
-- name: Create TridentProvisioner CRD (K8s version < 1.16)
+- name: Create TridentProvisioner CRD (K8s version >= 1.16) (Red Hat / CentOS)
+  k8s:
+    state: present
+    src: /root/trident-installer/deploy/crds/trident.netapp.io_tridentprovisioners_crd_post1.16.yaml
+    wait: yes
+  when: k8s_version >= 1.16
+  run_once: true
+  when: ansible_os_family == 'RedHat'
+
+- name: Create TridentProvisioner CRD (K8s version < 1.16) (Ubuntu)
   k8s:
     state: present
     src: /root/trident-installer/deploy/crds/trident.netapp.io_tridentprovisioners_crd_pre1.16.yaml
     wait: yes
   when: k8s_version < 1.16
   run_once: true
+  environment:
+    PYTHONHOME: '{{ deepops_venv }}'
+  when: ansible_distribution == 'Ubuntu'
 
-- name: Deploy Trident operator resources
+- name: Create TridentProvisioner CRD (K8s version < 1.16) (Red Hat / CentOS)
+  k8s:
+    state: present
+    src: /root/trident-installer/deploy/crds/trident.netapp.io_tridentprovisioners_crd_pre1.16.yaml
+    wait: yes
+  when: k8s_version < 1.16
+  run_once: true
+  when: ansible_os_family == 'RedHat'
+
+- name: Deploy Trident operator resources (Ubuntu)
   k8s:
     state: present
     src: /root/trident-installer/deploy/bundle.yaml
     wait: yes
   run_once: true
+  environment:
+    PYTHONHOME: '{{ deepops_venv }}'
+  when: ansible_distribution == 'Ubuntu'
 
-- name: Create TridentProvisioner CR
+- name: Deploy Trident operator resources (Red Hat / CentOS)
+  k8s:
+    state: present
+    src: /root/trident-installer/deploy/bundle.yaml
+    wait: yes
+  run_once: true
+  when: ansible_os_family == 'RedHat'
+
+- name: Create TridentProvisioner CR (Ubuntu)
   k8s:
     state: present
     src: /root/trident-installer/deploy/crds/tridentprovisioner_cr.yaml
     wait: yes
   run_once: true
+  environment:
+    PYTHONHOME: '{{ deepops_venv }}'
+  when: ansible_distribution == 'Ubuntu'
 
-- name: Wait until trident-csi Deployment exists
+- name: Create TridentProvisioner CR (Red Hat / CentOS)
+  k8s:
+    state: present
+    src: /root/trident-installer/deploy/crds/tridentprovisioner_cr.yaml
+    wait: yes
+  run_once: true
+  when: ansible_os_family == 'RedHat'
+
+- name: Wait until trident-csi Deployment exists (Ubuntu)
   k8s_info:
     kind: Deployment
     namespace: trident
@@ -55,12 +113,27 @@
   retries: 24
   delay: 5
   run_once: true
+  environment:
+    PYTHONHOME: '{{ deepops_venv }}'
+  when: ansible_distribution == 'Ubuntu'
+
+- name: Wait until trident-csi Deployment exists (Red Hat / CentOS)
+  k8s_info:
+    kind: Deployment
+    namespace: trident
+    name: trident-csi
+  register: deployment_trident_csi
+  until: deployment_trident_csi.resources | length == 1
+  retries: 24
+  delay: 5
+  run_once: true
+  when: ansible_os_family == 'RedHat'
 
 - name: Pause for 10 seconds
   pause:
     seconds: 10
 
-- name: Wait until trident-csi Deployment is ready
+- name: Wait until trident-csi Deployment is ready (Ubuntu)
   k8s_info:
     kind: Deployment
     namespace: trident
@@ -70,6 +143,21 @@
   retries: 24
   delay: 5
   run_once: true
+  environment:
+    PYTHONHOME: '{{ deepops_venv }}'
+  when: ansible_distribution == 'Ubuntu'
+
+- name: Wait until trident-csi Deployment is ready (Red Hat / CentOS)
+  k8s_info:
+    kind: Deployment
+    namespace: trident
+    name: trident-csi
+  register: deployment_trident_csi
+  until: deployment_trident_csi.resources[0].status.availableReplicas == 1
+  retries: 24
+  delay: 5
+  run_once: true
+  when: ansible_os_family == 'RedHat'
 
 - name: Copy backend config file(s) to control node
   template:
@@ -85,13 +173,25 @@
   when: create_backends == true
   run_once: true
 
-- name: Create NetApp StorageClass(es)
+- name: Create NetApp StorageClass(es) (Ubuntu)
   k8s:
     state: present
     definition: "{{ item }}"
   with_items: "{{ storageClasses_to_create }}"
   when: create_StorageClasses == true
   run_once: true
+  environment:
+    PYTHONHOME: '{{ deepops_venv }}'
+  when: ansible_distribution == 'Ubuntu'
+
+- name: Create NetApp StorageClass(es) (Red Hat / CentOS)
+  k8s:
+    state: present
+    definition: "{{ item }}"
+  with_items: "{{ storageClasses_to_create }}"
+  when: create_StorageClasses == true
+  run_once: true
+  when: ansible_os_family == 'RedHat'
 
 - name: Fetch tridentctl from control node
   fetch:

--- a/roles/netapp-trident/templates/backend.j2
+++ b/roles/netapp-trident/templates/backend.j2
@@ -1,0 +1,26 @@
+{
+    "version": 1,
+    "storageDriverName": "{{ item.storageDriverName }}",
+    "backendName": "{{ item.backendName }}",
+    "managementLIF": "{{ item.managementLIF }}",
+    "dataLIF": "{{ item.dataLIF }}",
+    "svm": "{{ item.svm }}",
+    "username": "{{ item.username }}",
+    "password": "{{ item.password }}",
+    "storagePrefix": "{{ item.storagePrefix }}",
+    "limitAggregateUsage": "{{ item.limitAggregateUsage }}",
+    "limitVolumeSize": "{{ item.limitVolumeSize }}",
+    "nfsMountOptions": "{{ item.nfsMountOptions }}",
+    "defaults": {
+        "spaceReserve": "{{ item.defaults.spaceReserve }}",
+        "snapshotPolicy": "{{ item.defaults.snapshotPolicy }}",
+        "snapshotReserve": "{{ item.defaults.snapshotReserve }}",
+        "splitOnClone": "{{ item.defaults.splitOnClone }}",
+        "encryption": "{{ item.defaults.encryption }}",
+        "unixPermissions": "{{ item.defaults.unixPermissions }}",
+        "snapshotDir": "{{ item.defaults.snapshotDir }}",
+        "exportPolicy": "{{ item.defaults.exportPolicy }}",
+        "securityStyle": "{{ item.defaults.securityStyle }}",
+        "tieringPolicy": "{{ item.defaults.tieringPolicy }}"
+    }
+}

--- a/roles/netapp-trident/vars/main.yml
+++ b/roles/netapp-trident/vars/main.yml
@@ -1,4 +1,0 @@
----
-# vars file for netapp-trident role
-
-ansible_python_interpreter: python3

--- a/roles/netapp-trident/vars/main.yml
+++ b/roles/netapp-trident/vars/main.yml
@@ -1,0 +1,4 @@
+---
+# vars file for netapp-trident role
+
+ansible_python_interpreter: python3


### PR DESCRIPTION
Adding a role for deploying NetApp Trident on Kubernetes for services that require persistent storage.

[test-results.txt](https://github.com/NVIDIA/deepops/files/4647112/test-results.txt)
