### PR TITLE
Temporary work-around for Kubespray issue 6160

### DIFF
--- a/config.example/group_vars/all.yml
+++ b/config.example/group_vars/all.yml
@@ -226,3 +226,25 @@ deepops_dir: /opt/deepops
 # Directory for python virtualenv
 # Roles: K8s GPU operator, GPU plugin, OpenShift/K8s
 deepops_venv: '{{ deepops_dir }}/venv'
+
+
+################################################################################
+# Bugfix - https://github.com/kubernetes-sigs/kubespray/issues/6160            #
+################################################################################
+ubuntu_docker_pkg_info:
+  pkg_mgr: apt
+  pkgs:
+  - name: "docker-ce-cli=5:19.03.8~3-0~ubuntu-{{ ansible_distribution_release|lower }}"
+    force: yes
+  - name: "docker-ce=5:18.09.7~3-0~ubuntu-{{ ansible_distribution_release|lower }}"
+    force: yes
+
+docker_yum_conf: "/etc/yum_docker.conf"
+
+redhat_docker_pkg_info:
+  pkg_mgr: yum
+  pkgs:
+  - name: "docker-ce-cli-19.03.8-3.el7"
+    yum_conf: "{{ docker_yum_conf }}"
+  - name: "docker-ce-18.09.7-3.el7"
+    yum_conf: "{{ docker_yum_conf }}"

--- a/playbooks/docker.yml
+++ b/playbooks/docker.yml
@@ -3,6 +3,14 @@
   become: true
   become_method: sudo
   tasks:
+    - name: Bugfix for https://github.com/kubernetes-sigs/kubespray/issues/6160 (Ubuntu)
+      set_fact:
+        docker_package_info: "{{ ubuntu_docker_pkg_info }}"
+      when: ansible_distribution == 'Ubuntu'
+    - name: Bugfix for https://github.com/kubernetes-sigs/kubespray/issues/6160 (RedHat)
+      set_fact:
+        docker_package_info: "{{ redhat_docker_pkg_info }}"
+      when: ansible_os_family == 'RedHat'
     - name: include default kubespray vars required for set_facts tasks
       include_vars: ../kubespray/roles/kubespray-defaults/defaults/main.yaml
     - name: include kubespray task to set facts required for docker role

--- a/playbooks/k8s-cluster.yml
+++ b/playbooks/k8s-cluster.yml
@@ -49,6 +49,17 @@
   tags:
     - bootstrap
 
+- hosts: all
+  tasks:
+    - name: Bugfix for https://github.com/kubernetes-sigs/kubespray/issues/6160 (Ubuntu)
+      set_fact:
+        docker_package_info: "{{ ubuntu_docker_pkg_info }}"
+      when: ansible_distribution == 'Ubuntu'
+    - name: Bugfix for https://github.com/kubernetes-sigs/kubespray/issues/6160 (RedHat)
+      set_fact:
+        docker_package_info: "{{ redhat_docker_pkg_info }}"
+      when: ansible_os_family == 'RedHat'
+
 # Install Kubernetes
 # for configuration, see: config/group_vars/k8s-cluster.yml
 - include: ../kubespray/cluster.yml


### PR DESCRIPTION
https://github.com/kubernetes-sigs/kubespray/issues/6160

Kubespray pins the version of `docker-ce`, but does not pin the version
of `docker-ce-cli` by default.

Unfortunately, Docker has published a version of `docker-ce-cli` (19.03.9)
which is no longer compatible with the pinned `docker-ce` version
(18.09.7). When the two are installed together, any docker cli commands
like `docker images` result in an error like:

```
Error response from daemon: client version 1.40 is too new. Maximum
supported API version is 1.39
```

This PR adds configuration for the Kubespray docker role to pin the
`docker-ce-cli` version as well as the `docker-ce` version.

We will need to track the Kubespray issue so that we can remove this
WAR when it's fixed upstream.