### PR TITLE
Update Kubespray to get upstream docker cli fix

### DIFF
--- a/playbooks/docker.yml
+++ b/playbooks/docker.yml
@@ -17,6 +17,8 @@
 - hosts: "{{ hostlist | default('all') }}"
   become: true
   become_method: sudo
+  vars:
+    fallback_ips: []
   roles:
     - { role: kubespray-defaults }
     - { role: "../kubespray/roles/container-engine/docker", tags: docker }


### PR DESCRIPTION
See https://github.com/kubernetes-sigs/kubespray/releases/tag/v2.13.1