### PR TITLE
Run prometheus node exporter role on Slurm master

### DIFF
--- a/playbooks/slurm-cluster.yml
+++ b/playbooks/slurm-cluster.yml
@@ -38,7 +38,7 @@
   when: slurm_enable_monitoring
 - include: prometheus-slurm-exporter.yml hostlist=slurm-master
   when: slurm_enable_monitoring
-- include: prometheus-node-exporter.yml hostlist=slurm-node
+- include: prometheus-node-exporter.yml hostlist=slurm-cluster
   when: slurm_enable_monitoring
 - include: nvidia-dcgm-exporter.yml hostlist=slurm-node
   when: slurm_enable_monitoring


### PR DESCRIPTION
Need to run the node exporter role on the master node in addition to the compute nodes so the Prometheus targets are configured.