### PR TITLE
Helm rollback

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Check out the [video tutorial](https://drive.google.com/file/d/1RNLQYlgJqE8JMv0n
 
 ## Releases
 
-Latest release: [DeepOps 20.02 Release](https://github.com/NVIDIA/deepops/releases/tag/20.02)
+Latest release: [DeepOps 20.02.1 Release](https://github.com/NVIDIA/deepops/releases/tag/20.02.1)
 
 It is recommended to use the latest release branch for stable code (linked above). All development takes place on the master branch, which is generally functional but may change significantly between releases.
 

--- a/config.example/group_vars/k8s-cluster.yml
+++ b/config.example/group_vars/k8s-cluster.yml
@@ -28,3 +28,8 @@ deepops_gpu_operator_enabled: false
 dashboard_enabled: true
 dashboard_image_tag: "v2.0.0-rc5"
 dashboard_image_repo: "kubernetesui/dashboard"
+
+# kubespray v2.13.1 deploys helm v3.1.2 which causes breaking changes in various
+# helm-deployable scripts
+# https://github.com/kubernetes-sigs/kubespray/pull/5503
+helm_version: "v2.16.1"


### PR DESCRIPTION
* rolls back helm to v2.16.1
* fixes README to point to latest release tag (20.02.1 vs 20.02)