### PR TITLE
Remove duplicate vars section

### DIFF
--- a/playbooks/docker.yml
+++ b/playbooks/docker.yml
@@ -18,12 +18,11 @@
   become: true
   become_method: sudo
   vars:
+    # override deprecated dockerproject repo; old docker repo broken as of 03.04.2020
+    dockerproject_rh_repo_base_url: 'https://download.docker.com/linux/centos/7/$basearch/stable'
+    dockerproject_rh_repo_gpgkey: 'https://download.docker.com/linux/centos/gpg'
     fallback_ips: []
   roles:
     - { role: kubespray-defaults }
     - { role: "../kubespray/roles/container-engine/docker", tags: docker }
   environment: "{{proxy_env if proxy_env is defined else {}}}"
-  vars:
-    # override deprecated dockerproject repo; old docker repo broken as of 03.04.2020
-    dockerproject_rh_repo_base_url: 'https://download.docker.com/linux/centos/7/$basearch/stable'
-    dockerproject_rh_repo_gpgkey: 'https://download.docker.com/linux/centos/gpg'


### PR DESCRIPTION
I can't replicate the failure from Jenkins, but this removes the duplicate vars section, only the last one is read.