### PR TITLE
Allow user to specify custom prolog/epilogs to copy

### DIFF
--- a/roles/slurm/defaults/main.yml
+++ b/roles/slurm/defaults/main.yml
@@ -55,11 +55,17 @@ slurm_oversubscribe: "NO"
 # Default: <not included>
 # slurm_default_job_timelimit: 
 
-# Use the provided prolog/epilog
+# Set up prolog and epilog
 slurm_enable_prolog_epilog: true
 
 # Useful to delete old files (e.g. from previous versions of deepops)
 slurm_clear_old_prolog_epilog: false
+
+# Fileglob patterns used to copy prolog and epilog files
+prolog_d_fileglob: "prolog.d/*"
+prolog_parts_fileglob: "prolog-parts.d/*"
+epilog_d_fileglob: "epilog.d/*"
+epilog_parts_fileglob: "epilog-parts.d/*"
 
 # Disable clearing of shared memory when user login shell exits
 slurm_fix_shm: true

--- a/roles/slurm/tasks/prolog_epilog.yml
+++ b/roles/slurm/tasks/prolog_epilog.yml
@@ -62,7 +62,7 @@
   tags:
     - epilog
 
-- name: copy prologs
+- name: copy prolog.d/
   copy:
     src: "{{ item }}"
     dest: /etc/slurm/prolog.d/
@@ -70,11 +70,11 @@
     group: slurm
     mode: 0755
   with_fileglob:
-    - prolog.d/*
+    - "{{ prolog_d_fileglob }}"
   tags:
     - prolog
 
-- name: copy prologs
+- name: copy prolog-parts.d/
   copy:
     src: "{{ item }}"
     dest: /etc/slurm/prolog-parts.d/
@@ -82,11 +82,11 @@
     group: slurm
     mode: 0755
   with_fileglob:
-    - prolog-parts.d/*
+    - "{{ prolog_parts_fileglob }}"
   tags:
     - prolog
 
-- name: copy epilogs
+- name: copy epilog.d/
   copy:
     src: "{{ item }}"
     dest: /etc/slurm/epilog.d/
@@ -94,11 +94,11 @@
     group: slurm
     mode: 0755
   with_fileglob:
-    - epilog.d/*
+    - "{{ epilog_d_fileglob }}"
   tags:
     - epilog
 
-- name: copy epilogs
+- name: copy epilog-parts.d/
   copy:
     src: "{{ item }}"
     dest: /etc/slurm/epilog-parts.d/
@@ -106,6 +106,6 @@
     group: slurm
     mode: 0755
   with_fileglob:
-    - epilog-parts.d/*
+    - "{{ epilog_parts_fileglob }}"
   tags:
     - epilog


### PR DESCRIPTION
Currently our prolog and epilog scripts are "all or nothing". If, for example, a user chooses not to use Docker, they will still get the prolog/epilogs that deal with Docker. The user also cannot add custom prolog/epilog scripts via DeepOps.

This PR provides a mechanism for the user to specify custom file globs to copy prolog and epilog from, so the user can more easily make site-specific changes.

The user can now set the following variables to copy alternate files for prolog and epilog:

* `prolog_d_fileglob`: Files copied to `/etc/slurm/prolog.d`
* `prolog_parts_fileglob`: Files copied to `/etc/slurm/prolog-parts.d`
* `epilog_d_fileglob`: Files copied to `/etc/slurm/epilog.d`
* `epilog_parts_fileglob`: Files copied to `/etc/slurm/epilog-parts.d`

## Test plan

* Ran with default configuration to ensure default prolog and epilog still work with the change to variables.
* Ran again with the following config and confirmed that alternate scripts were placed instead:
    * `slurm_clear_old_prolog_epilog: true`
    * `prolog_parts_fileglob: "/tmp/prolog-parts/*"`
    * `epilog_parts_fileglob: "/tmp/epilog-parts/*"`