### PR TITLE
Install CUDA Toolkit on DGX by default

### DIFF
--- a/playbooks/nvidia-cuda.yml
+++ b/playbooks/nvidia-cuda.yml
@@ -16,7 +16,7 @@
         name: nvidia.nvidia_driver
       when:
         - ansible_local['gpus']['count']
-        - is_dgx.stat.exists == False
+        - not is_dgx.stat.exists
 
     - name: install nvidia cuda toolkit
       package:
@@ -24,12 +24,10 @@
         state: present
       when:
         - ansible_local['gpus']['count']
-        - is_dgx.stat.exists == False
 
     - name: test nvidia-smi
       command: nvidia-smi
       changed_when: false
       when:
         - ansible_local['gpus']['count']
-        - is_dgx.stat.exists == False
-  environment: "{{proxy_env if proxy_env is defined else{}}}"
+  environment: "{{ proxy_env if proxy_env is defined else{} }}"

--- a/playbooks/nvidia-cuda.yml
+++ b/playbooks/nvidia-cuda.yml
@@ -16,7 +16,7 @@
         name: nvidia.nvidia_driver
       when:
         - ansible_local['gpus']['count']
-        - not is_dgx.stat.exists
+        - is_dgx.stat.exists == False
 
     - name: install nvidia cuda toolkit
       package:

--- a/roles/facts/tasks/main.yml
+++ b/roles/facts/tasks/main.yml
@@ -2,12 +2,12 @@
 - name: apt install pciutils
   apt: name=pciutils update_cache=yes
   when: ansible_os_family == 'Debian'
-  environment: "{{proxy_env if proxy_env is defined else {}}}"
+  environment: "{{ proxy_env if proxy_env is defined else {} }}"
 
 - name: yum install pciutils
   yum: name=pciutils update_cache=yes
   when: ansible_os_family == 'RedHat'
-  environment: "{{proxy_env if proxy_env is defined else {}}}"
+  environment: "{{ proxy_env if proxy_env is defined else {} }}"
 
 - name: create fact directory
   file:


### PR DESCRIPTION
We were avoiding installing the CUDA toolkit on DGX servers in the nvidia-cuda playbook assuming it came from the DGX OS by default, but it does not.

Also fix some linting.