### PR TITLE
Revert recent Rook upgrade

### DIFF
--- a/scripts/k8s_deploy_rook.sh
+++ b/scripts/k8s_deploy_rook.sh
@@ -6,7 +6,7 @@
 # `helm upgrade --namespace rook-ceph rook-ceph rook-release/rook-ceph --version v0.9.0-174.g3b14e51`
 
 HELM_ROOK_CHART_REPO="${HELM_ROOK_CHART_REPO:-https://charts.rook.io/release}"
-HELM_ROOK_CHART_VERSION="${HELM_ROOK_CHART_VERSION:-v1.3.4}"
+HELM_ROOK_CHART_VERSION="${HELM_ROOK_CHART_VERSION:-v1.1.1}"
 
 ./scripts/install_helm.sh
 

--- a/services/rook-cluster.yml
+++ b/services/rook-cluster.yml
@@ -7,7 +7,7 @@ metadata:
 spec:
   cephVersion:
     # For the latest ceph images, see https://hub.docker.com/r/ceph/ceph/tags
-    image: ceph/ceph:v15.2.2
+    image: ceph/ceph:v14.2
   dataDirHostPath: /var/lib/rook
   mon:
     count: 3
@@ -16,7 +16,7 @@ spec:
     enabled: true
   storage:
     useAllNodes: true
-    useAllDevices: true
+    useAllDevices: false
     directories:
       - path: /var/lib/rook
     config:
@@ -39,25 +39,14 @@ metadata:
    name: rook-ceph-block
    annotations:
      storageclass.kubernetes.io/is-default-class: "true"
-# based on https://rook.io/docs/rook/master/ceph-block.html
-provisioner: rook-ceph.rbd.csi.ceph.com
+provisioner: ceph.rook.io/block
 parameters:
-  # clusterID is the namespace where the rook cluster is running
-  clusterID: rook-ceph
-  # Ceph pool into which the RBD image shall be created
-  pool: replicapool
-  # RBD image format. Defaults to "2".
-  imageFormat: "2"
-  # RBD image features. Available for imageFormat: "2". CSI RBD currently supports only `layering` feature.
-  imageFeatures: layering
-  # The secrets contain Ceph admin credentials.
-  csi.storage.k8s.io/provisioner-secret-name: rook-csi-rbd-provisioner
-  csi.storage.k8s.io/provisioner-secret-namespace: rook-ceph
-  csi.storage.k8s.io/node-stage-secret-name: rook-csi-rbd-node
-  csi.storage.k8s.io/node-stage-secret-namespace: rook-ceph
-  # Specify the filesystem type of the volume. Default is "ext4"
-  csi.storage.k8s.io/fstype: xfs
-  # Default is "Delete", https://kubernetes.io/docs/concepts/storage/storage-classes/
+  blockPool: replicapool
+  # The value of "clusterNamespace" MUST be the same as the one in which your rook cluster exist
+  clusterNamespace: rook-ceph
+  # Specify the filesystem type of the volume. If not specified, it will use `ext4`.
+  fstype: xfs
+# Optional, default reclaimPolicy is "Delete". Other options are: "Retain", "Recycle" as documented in https://kubernetes.io/docs/concepts/storage/storage-classes/
 reclaimPolicy: Retain
 ---
 apiVersion: apps/v1


### PR DESCRIPTION
We needed to set useAllDevices to true to automatically use the NVME drives in AWS md5 instances.

However this is making the nightly tests fail and may have undesirable consequences in certain clusters, so we are re-disabling this.