### PR TITLE
disable ood_portal_generator on Ubuntu

### DIFF
--- a/roles/ood-wrapper/vars/ubuntu.yml
+++ b/roles/ood-wrapper/vars/ubuntu.yml
@@ -3,6 +3,8 @@ install_from_src: true
 ood_apache_service_name: apache2
 ood_htpasswd_file: /etc/apache2/.htpasswd
 
+ood_portal_generator: false
+
 ood_url_turbovnc_pkg: https://downloads.sourceforge.net/project/turbovnc/2.2.4/turbovnc_2.2.4_amd64.deb
 
 ood_master_sw_deps:


### PR DESCRIPTION
ood_portal_generator does not properly find the folder to place the generated portal config file. I disabled it on Ubuntu only so the templated file can be used instead.