### PR TITLE
Bump install_helm.sh version to match newest kubespray version

### DIFF
--- a/roles/ood-wrapper/vars/ubuntu.yml
+++ b/roles/ood-wrapper/vars/ubuntu.yml
@@ -3,6 +3,8 @@ install_from_src: true
 ood_apache_service_name: apache2
 ood_htpasswd_file: /etc/apache2/.htpasswd
 
+ood_portal_generator: false
+
 ood_url_turbovnc_pkg: https://downloads.sourceforge.net/project/turbovnc/2.2.4/turbovnc_2.2.4_amd64.deb
 
 ood_master_sw_deps:

--- a/scripts/install_helm.sh
+++ b/scripts/install_helm.sh
@@ -40,7 +40,7 @@ if ! type helm >/dev/null 2>&1 ; then
     chmod +x /tmp/get_helm.sh
     #sed -i 's/sudo//g' /tmp/get_helm.sh
     mkdir -p ${HELM_INSTALL_DIR}
-    HELM_INSTALL_DIR=${HELM_INSTALL_DIR} DESIRED_VERSION=v2.14.3 /tmp/get_helm.sh
+    HELM_INSTALL_DIR=${HELM_INSTALL_DIR} DESIRED_VERSION=v2.16.1 /tmp/get_helm.sh # Should match: config/group_vars/k8s-cluster.yml:helm_version:
 fi
 
 # We need to dynamically set up Helm args, so let's use an array


### PR DESCRIPTION
Matching the example configuration:
`config/group_vars/k8s-cluster.yml:helm_version: "v2.16.1"
`
* Note: This does not update the two other version pegged references:
```
playbooks/egxstack-installation.yml:    helm_version: v2.14.3
roles/offline-repo-mirrors/defaults/main.yml:helm_version: "v2.14.3"
```