### PR TITLE
Enable docker networking by default.

### DIFF
--- a/config.example/group_vars/all.yml
+++ b/config.example/group_vars/all.yml
@@ -39,6 +39,11 @@ chrony_config_server:
   - 2.pool.ntp.org
   - 3.pool.ntp.org
 
+# Enable docker iptables
+# If this isn't set, containers won't have access to the outside net
+# See https://github.com/kubernetes-sigs/kubespray/issues/2002
+docker_iptables_enabled: true
+
 
 ################################################################################
 # SOFTWARE                                                                     #

--- a/playbooks/docker.yml
+++ b/playbooks/docker.yml
@@ -2,9 +2,11 @@
 - hosts: "{{ hostlist | default('all') }}"
   become: true
   become_method: sudo
+  vars_files:
+    # include kubespray-defaults here so that we can set the facts using the
+    # kubespray 0040-set_facts.yml tasks
+    - ../kubespray/roles/kubespray-defaults/defaults/main.yaml
   tasks:
-    - name: include default kubespray vars required for set_facts tasks
-      include_vars: ../kubespray/roles/kubespray-defaults/defaults/main.yaml
     - name: include kubespray task to set facts required for docker role
       include: ../kubespray/roles/kubernetes/preinstall/tasks/0040-set_facts.yml
     - name: remove docker overrides from DGX OS


### PR DESCRIPTION
See https://github.com/kubernetes-sigs/kubespray/issues/2002

If this isn't set, we can't reach the outside net from within containers. This affects downloading data within containers, pip installing within jupyter, etc.