### PR TITLE
Move Kubeflow install steps out of kubernetes docs and add debugging steps, etc.

### DIFF
--- a/docs/kubeflow.md
+++ b/docs/kubeflow.md
@@ -38,8 +38,78 @@ Kubeflow configuration files will be saved to `./config/kubeflow-install`.
 
 The kfctl binary will be saved to `./config/kfctl`. For easier management this file can be copied to `/usr/local/bin` or added to the `PATH`.
 
+The services can be reached from the following address:
+* Kubeflow: http://mgmt:31380
+
 ## Login information
 
 The default username is `admin@kubeflow.org` and the default password is `12341234`.
 
 These can be modified at startup time following the steps outlined [here](https://www.kubeflow.org/docs/started/k8s/kfctl-existing-arrikto/).
+
+## Other usage
+
+For the most up-to-date usage information run `./scripts/k8s_deploy_kubeflow.sh -h`.
+
+```sh
+./scripts/k8s_deploy_kubeflow.sh -h
+Usage:
+-h    This message.
+-p    Print out the connection info for Kubeflow
+-d    Delete Kubeflow from your system (skipping the CRDs and istio-system namespace that may have been installed with Kubeflow
+-D    Full Delete Kubeflow from your system along with all Kubeflow CRDs the istio-system namespace. WARNING, do not use this option if other components depend on istio.
+-x    Install Kubeflow with multi-user auth (this utilizes Dex, the default is no multi-user auth).
+-c    Specify a different Kubeflow config to install with (this option is deprecated)
+-w    Wait for Kubeflow homepage to respond
+```
+
+## Kubeflow Admin
+
+### Uninstalling
+
+To uninstall and re-install Kubeflow run:
+
+```sh
+./scripts/k8s_deploy_kubeflow.sh -D
+./scripts/k8s_deploy_kubeflow.sh
+```
+
+### Modifying Kubeflow configuration
+
+To modify the Kubeflow configuration, modify the downloaded `CONFIG` YAML file in `config/kubeflow-install/` or one of the many overlay YAML files in `config/kubeflow-install/kustomize`.
+
+After modifying the configuration, apply the changes to the cluster using `kfctl`:
+
+```sh
+cd config/kubeflow-install
+../kfctl apply -f kfctl_k8s_istio.yaml
+```
+
+## Debugging common issues
+
+### No DefaultStorageClass defined or ready
+
+A common issue with Kubeflow installation is that no DefaultStorageClass has been defined or that Ceph has been not been deployed correctly.
+
+This can be idenfitied if most of the Kubeflow Pods are running and the MySQL pod and several others remain in a Pending state. The GUI may also load and throw a "Profile Error". Run the following to debug further:
+
+```sh
+kubectl get pods -n kubeflow
+```
+> NOTE: Everything should be in a running state.
+
+Verify Ceph is running and/or a DefaultStorageClass is defined:
+
+```
+kubectl get storageclass | grep default
+./scripts/ceph_poll.sh
+```
+> NOTE: If Ceph is being used, `ceph_poll.sh` should exit after several seconds and Ceph should be the default StorageClass. 
+
+
+To correct this issue:
+1. Uninstall Rook/Ceph: `./scripts/rmrook.sh`
+2. Uninstall Kubeflow: `./scripts/k8s_deploy_kubeflow.sh -D`
+3. Re-install Rook/ceph: `./scripts/k8s_deploy_rook.sh`
+4. Poll for Ceph to initialize (wait for this script to exit): `./scripts/ceph_poll.sh`
+5. Re-install Kubeflow: `./scripts/k8s_deploy_kubeflow.sh`

--- a/docs/kubernetes-cluster.md
+++ b/docs/kubernetes-cluster.md
@@ -108,7 +108,7 @@ Deploy a Ceph cluster running on Kubernetes for services that require persistent
 ./scripts/k8s_deploy_rook.sh
 ```
 
-Poll the Ceph status by running:
+Poll the Ceph status by running (this script will return when Ceph initialization is complete):
 
 ```sh
 ./scripts/ceph_poll.sh
@@ -184,13 +184,9 @@ Many K8s applications require the deployment of a Load Balancer and Ingress. To 
 
 ### Kubeflow
 
-Kubeflow is a popular way for multiple users to run ML workloads. It exposes a Jupyter Notebook interface where users can request access to GPUs via the browser GUI. Deploy Kubeflow with a convenient script:
+Kubeflow is a popular way for multiple users to run ML workloads. It exposes a Jupyter Notebook interface where users can request access to GPUs via the browser GUI and allows a user to build automated AI pipelines. To deploy Kubeflow refer to the [DeepOps Kubeflow Guide](kubeflow.md).
 
-```sh
-./scripts/k8s_deploy_kubeflow.sh
-```
-
-For more on Kubeflow, please refer to the [official documentation](https://www.kubeflow.org/docs/about/kubeflow/).
+For more information on Kubeflow, please refer to the [official documentation](https://www.kubeflow.org/docs/about/kubeflow/).
 
 ## Cluster Maintenance
 


### PR DESCRIPTION
Kubernetes docs updates:
* ceph_poll clarification
* Remove Kubeflow install steps and point to kubeflow.md instead. This way users can see all the dependencies, proper install steps, etc. and we can maintain information in that .md file.

Kubeflow docs updates:
* Add url/port
* Add a "usage section"
* Add debugging steps for common ceph not setup issue
* Add uninstall/reinstall steps
* Add reconfigure/update steps