### PR TITLE
Add libnuma-dev to Ubuntu openmpi_deps

### DIFF
--- a/roles/openmpi/vars/ubuntu.yml
+++ b/roles/openmpi/vars/ubuntu.yml
@@ -1,3 +1,4 @@
 ---
 openmpi_deps:
   - build-essential
+  - libnuma-dev


### PR DESCRIPTION
Required to build openmpi. The package was observed to be missing on a
login node running Ubuntu 18.04 when using Deepops to deploy Slurm.

Signed-Off-By: Joe Handzik <jhandzik@nvidia.com>