### PR TITLE
Fix Kubeflow deletion logic and other related workarounds

### DIFF
--- a/docs/kubeflow.md
+++ b/docs/kubeflow.md
@@ -57,12 +57,12 @@ For the most up-to-date usage information run `./scripts/k8s_deploy_kubeflow.sh 
 ./scripts/k8s_deploy_kubeflow.sh -h
 Usage:
 -h    This message.
--p    Print out the connection info for Kubeflow
--d    Delete Kubeflow from your system (skipping the CRDs and istio-system namespace that may have been installed with Kubeflow
--D    Full Delete Kubeflow from your system along with all Kubeflow CRDs the istio-system namespace. WARNING, do not use this option if other components depend on istio.
+-p    Print out the connection info for Kubeflow.
+-d    Delete Kubeflow from your system (skipping the CRDs and istio-system namespace that may have been installed with Kubeflow.
+-D    Deprecated, same as -d. Previously 'Fully Delete Kubeflow from your system along with all Kubeflow CRDs the istio-system namespace. WARNING, do not use this option if other components depend on istio.'
 -x    Install Kubeflow with multi-user auth (this utilizes Dex, the default is no multi-user auth).
--c    Specify a different Kubeflow config to install with (this option is deprecated)
--w    Wait for Kubeflow homepage to respond
+-c    Specify a different Kubeflow config to install with (this option is deprecated).
+-w    Wait for Kubeflow homepage to respond (also polls for various Kubeflow Deployments to have an available status).
 ```
 
 ## Kubeflow Admin
@@ -72,7 +72,7 @@ Usage:
 To uninstall and re-install Kubeflow run:
 
 ```sh
-./scripts/k8s_deploy_kubeflow.sh -D
+./scripts/k8s_deploy_kubeflow.sh -d
 ./scripts/k8s_deploy_kubeflow.sh
 ```
 

--- a/docs/kubeflow.md
+++ b/docs/kubeflow.md
@@ -10,6 +10,8 @@ Additionally Kubeflow offers [hyper-parameter tuning](https://github.com/kubeflo
 
 Kubeflow is an [open source project](https://github.com/kubeflow/kubeflow) and is regularly evolving and adding [new features](https://github.com/kubeflow/kubeflow/blob/master/ROADMAP.md).
 
+As part of the Kubeflow installation, the MPI Operator will also be installed. This will add the `MPIJob` CustomResourceDefinition to the cluster, enabling multi-pod or multi-node workloads. See [here](https://github.com/kubeflow/mpi-operator/tree/master/) for details and examples.
+
 ## Installation
 
 Deploy Kubernetes by following the [DeepOps Kubernetes Deployment Guide](kubernetes-cluster.md)

--- a/scripts/k8s_deploy_kubeflow.sh
+++ b/scripts/k8s_deploy_kubeflow.sh
@@ -142,7 +142,7 @@ function stand_up() {
 
   # Make cleanup scripts first in case deployment fails
   # TODO: This kfctl delete seems to be failing due to a Kubeflow config bug
-  echo "cd ${KF_DIR} && ${KFCTL} delete -V -f ${CONFIG_FILE} --delete_storage; cd && sudo rm -rf ${KF_DIR}" > ${KUBEFLOW_DEL_SCRIPT}
+  echo "cd ${KF_DIR} && ${KFCTL} delete -V -f ${CONFIG_FILE} --force-deletion --delete_storage; cd && sudo rm -rf ${KF_DIR}" > ${KUBEFLOW_DEL_SCRIPT}
   chmod +x ${KUBEFLOW_DEL_SCRIPT}
 
   # Initialize and apply the Kubeflow project using the specified config. We do this in two steps to allow a chance to customize the config

--- a/scripts/k8s_deploy_kubeflow.sh
+++ b/scripts/k8s_deploy_kubeflow.sh
@@ -149,7 +149,8 @@ function stand_up() {
   ${KFCTL} build -V -f ${CONFIG_URI}
 
   # Update Kubeflow with the NGC containers and NVIDIA configurations
-  ${SCRIPT_DIR}/update_kubeflow_config.py
+  # BUG: Commented out until NGC containers add Kubeflow support, see https://github.com/NVIDIA/deepops/tree/master/containers/ngc
+  # ${SCRIPT_DIR}/update_kubeflow_config.py
 
   # XXX: Add potential CONFIG customizations here before applying
   ${KFCTL} apply -V -f ${CONFIG_FILE}

--- a/scripts/k8s_deploy_kubeflow.sh
+++ b/scripts/k8s_deploy_kubeflow.sh
@@ -36,7 +36,7 @@ function help_me() {
   echo "-h    This message."
   echo "-p    Print out the connection info for Kubeflow"
   echo "-d    Delete Kubeflow from your system (skipping the CRDs and istio-system namespace that may have been installed with Kubeflow"
-  echo "-D    Full Delete Kubeflow from your system along with all Kubeflow CRDs the istio-system namespace. WARNING, do not use this option if other components depend on istio."
+  echo "-D    Deprecatedm same as -d. Previouesly 'Full Delete Kubeflow from your system along with all Kubeflow CRDs the istio-system namespace. WARNING, do not use this option if other components depend on istio.'"
   echo "-x    Install Kubeflow with multi-user auth (this utilizes Dex, the default is no multi-user auth)."
   echo "-c    Specify a different Kubeflow config to install with (this option is deprecated)"
   echo "-w    Wait for Kubeflow homepage to respond"
@@ -65,6 +65,7 @@ function get_opts() {
       D)
         KUBEFLOW_DELETE=true
         KUBEFLOW_FULL_DELETE=true
+        echo "The -D flag is deprecated, use -d instead"
         ;;
       Z)
 	# This is a dangerous command and is not included in the help
@@ -179,29 +180,26 @@ function tear_down() {
   # Kubeflow use leads to some user created namespaces that are not torn down during kfctl delete
   namespaces="kubeflow"
 
-  # Delete other NS that were installed. These might be part of other apps and is slightly dangerous
-  if [ "${KUBEFLOW_FULL_DELETE}" == "true" ]; then
-    namespaces=" ${namespaces} admin auth cert-manager istio-system knative-serving ${KUBEFLOW_EXTRA_NS}"
-  fi
-
   # This runs kfctl delete pointing to the CONFIG that was used at install
   bash ${KUBEFLOW_DEL_SCRIPT} && sleep 5 # There seems to be a timing issue here in kfctl, so we sleep a bit.
 
-  # delete all namespaces, including namespaces that "should" already have been deleted by kfctl delete
-  echo "Re-deleting namespaces ${namespaces} for a full cleanup"
-  kubectl delete ns ${namespaces}
+  # Delete other NS that were installed. These might be part of other apps and is slightly dangerous
+  # LEGACY: This code was implemented to workaround https://github.com/kubeflow/kubeflow/issues/3767, this is supposedly fixed
+  #if [ "${KUBEFLOW_FULL_DELETE}" == "true" ]; then
+  #  namespaces=" ${namespaces} admin auth cert-manager istio-system knative-serving ${KUBEFLOW_EXTRA_NS}"
+  #  # delete all namespaces, including namespaces that "should" already have been deleted by kfctl delete
+  #  echo "Re-deleting namespaces ${namespaces} for a full cleanup"
+  #  kubectl delete ns ${namespaces}
+  #  # These should probably be deleted by kfctl, but they are not
+  #  kubectl delete crd -l app.kubernetes.io/part-of=kubeflow -o name
+  #  kubectl delete all -l app.kubernetes.io/part-of=kubeflow --all-namespaces
+  #fi
 
   # There is an issues in the kfctl delete command that does not properly clean up and leaves NSs in a terminating state, this is a bit hacky but resolves it
   if [ "${KUBEFLOW_EXTRA_FULL_DELETE}" == "true" ]; then
     sleep 10 # Give the other deletion steps proper time to cleanup
     echo "Removing finalizers from all namespaces: ${namespaces}"
     fix_terminating_ns ${namespaces}
-  fi
-
-  if [ "${KUBEFLOW_FULL_DELETE}" == "true" ]; then
-    # These should probably be deleted by kfctl, but they are not
-    kubectl delete crd -l app.kubernetes.io/part-of=kubeflow -o name
-    kubectl delete all -l app.kubernetes.io/part-of=kubeflow --all-namespaces
   fi
 
   rm ${KFCTL}

--- a/scripts/k8s_deploy_kubeflow.sh
+++ b/scripts/k8s_deploy_kubeflow.sh
@@ -147,6 +147,7 @@ function stand_up() {
   # Initialize and apply the Kubeflow project using the specified config. We do this in two steps to allow a chance to customize the config
   cd ${KF_DIR}
   ${KFCTL} build -V -f ${CONFIG_URI}
+  sed -i '/metadata:.*/a\  ClusterName: cluster.local' ${CONFIG_FILE} # BUGFIX: Need to add the ClusterName for proper deletion:https://github.com/kubeflow/kubeflow/issues/4815
 
   # Update Kubeflow with the NGC containers and NVIDIA configurations
   # BUG: Commented out until NGC containers add Kubeflow support, see https://github.com/NVIDIA/deepops/tree/master/containers/ngc

--- a/scripts/k8s_deploy_kubeflow.sh
+++ b/scripts/k8s_deploy_kubeflow.sh
@@ -343,6 +343,7 @@ elif [ ${KUBEFLOW_WAIT} ]; then
 else
   install_dependencies
   stand_up
+  install_mpi_operator
   get_url
   print_info
 fi

--- a/scripts/k8s_deploy_kubeflow.sh
+++ b/scripts/k8s_deploy_kubeflow.sh
@@ -36,7 +36,7 @@ function help_me() {
   echo "-h    This message."
   echo "-p    Print out the connection info for Kubeflow"
   echo "-d    Delete Kubeflow from your system (skipping the CRDs and istio-system namespace that may have been installed with Kubeflow"
-  echo "-D    Deprecatedm same as -d. Previouesly 'Full Delete Kubeflow from your system along with all Kubeflow CRDs the istio-system namespace. WARNING, do not use this option if other components depend on istio.'"
+  echo "-D    Deprecated, same as -d. Previously 'Fully Delete Kubeflow from your system along with all Kubeflow CRDs the istio-system namespace. WARNING, do not use this option if other components depend on istio.'"
   echo "-x    Install Kubeflow with multi-user auth (this utilizes Dex, the default is no multi-user auth)."
   echo "-c    Specify a different Kubeflow config to install with (this option is deprecated)"
   echo "-w    Wait for Kubeflow homepage to respond"

--- a/scripts/k8s_deploy_kubeflow.sh
+++ b/scripts/k8s_deploy_kubeflow.sh
@@ -147,6 +147,13 @@ function stand_up() {
   # Initialize and apply the Kubeflow project using the specified config. We do this in two steps to allow a chance to customize the config
   cd ${KF_DIR}
   ${KFCTL} build -V -f ${CONFIG_URI}
+
+  # Occassionally the kfctl will fail, if this occurs halt all installation
+  if [ $? != 0 ]; then
+    echo -e "\nDeepOps ERROR: Failure building Kubeflow Manifest at ${CONFIG_URI} in ${KF_DIR}"
+     exit 1
+  fi
+
   sed -i '/metadata:.*/a\  ClusterName: cluster.local' ${CONFIG_FILE} # BUGFIX: Need to add the ClusterName for proper deletion:https://github.com/kubeflow/kubeflow/issues/4815
 
   # Update Kubeflow with the NGC containers and NVIDIA configurations

--- a/scripts/k8s_deploy_kubeflow.sh
+++ b/scripts/k8s_deploy_kubeflow.sh
@@ -18,9 +18,9 @@ export KF_DIR="${KF_DIR:-${CONFIG_DIR}/kubeflow-install}"
 export KFCTL="${KFCTL:-${CONFIG_DIR}/kfctl}"
 export KUBEFLOW_DEL_SCRIPT="${KF_DIR}/deepops-delete-kubeflow.sh"
 
-# Download URLs and versions # XXX: kfctl introcuded a version mismatch, this is naming only
-export KFCTL_FILE=kfctl_v1.1-rc.1-0-g3e61b81_linux.tar.gz # https://github.com/kubeflow/kfctl/releases/tag/v1.1-rc.1
-export KFCTL_URL="https://github.com/kubeflow/kfctl/releases/download/v1.1-rc.1/${KFCTL_FILE}"
+# Download URLs and versions, note the kfctl version does not always match the manifest/config version, but best-effort should be made to keep their versions close
+export KFCTL_FILE=kfctl_v1.1.0-0-g9a3621e_linux.tar.gz # https://github.com/kubeflow/kfctl/releases/tag/v1.1.0
+export KFCTL_URL="https://github.com/kubeflow/kfctl/releases/download/v1.1.0/${KFCTL_FILE}"
 
 # Config 1: https://www.kubeflow.org/docs/started/k8s/kfctl-existing-arrikto/
 export AUTH_CONFIG_URI="https://raw.githubusercontent.com/kubeflow/manifests/55d1a9c84ca796f9a098bbeec406acbdcfa6aebe/kfdef/kfctl_istio_dex.v1.0.2.yaml"

--- a/scripts/k8s_deploy_kubeflow.sh
+++ b/scripts/k8s_deploy_kubeflow.sh
@@ -19,8 +19,8 @@ export KFCTL="${KFCTL:-${CONFIG_DIR}/kfctl}"
 export KUBEFLOW_DEL_SCRIPT="${KF_DIR}/deepops-delete-kubeflow.sh"
 
 # Download URLs and versions # XXX: kfctl introcuded a version mismatch, this is naming only
-export KFCTL_FILE=kfctl_v1.0.2-0-ga476281_linux.tar.gz # https://github.com/kubeflow/kfctl/releases/tag/v1.0.2
-export KFCTL_URL="https://github.com/kubeflow/kfctl/releases/download/v1.0.2/${KFCTL_FILE}"
+export KFCTL_FILE=kfctl_v1.1-rc.1-0-g3e61b81_linux.tar.gz # https://github.com/kubeflow/kfctl/releases/tag/v1.1-rc.1
+export KFCTL_URL="https://github.com/kubeflow/kfctl/releases/download/v1.1-rc.1/${KFCTL_FILE}"
 
 # Config 1: https://www.kubeflow.org/docs/started/k8s/kfctl-existing-arrikto/
 export AUTH_CONFIG_URI="https://raw.githubusercontent.com/kubeflow/manifests/55d1a9c84ca796f9a098bbeec406acbdcfa6aebe/kfdef/kfctl_istio_dex.v1.0.2.yaml"


### PR DESCRIPTION
Kubeflow has changed the deletion logic and doing a `kfctl delete -f $CONFIG_FILE` now deletes webcert, istio, custom crds, etc. As such I have removed the workaround code. In doing so the `-D` flag is now deprecated and will do the same thing as `-d`.

In addition to this, there is a minor bug that has been causing errors during uninstal (see https://github.com/kubeflow/kubeflow/issues/4815). I have implemented a workaround to this. We are basically just adding the `ClusterName` field to the downloaded Kubeflow manifest before running apply. Without this fix Kubeflow has been throwing an error when you run a `kfctl delete -f $CONFIG_FILE`

As part of this I have bumped up the `kfctl` binary version to the v1.1-rc-1 release candidate.

I also commented out the broken NGC update script in the process.


**Update**
Included in this PR is now the following:

- Install the MPI Operator when install Kubeflow. Update the docs appropriately.
- Update the polling function to wait for Deployments to complete, not just HTTP to respond.