### PR TITLE
Set up NFS shares on Slurm cluster by default

### DIFF
--- a/.jenkins-scripts/test-slurm-nfs-mount.sh
+++ b/.jenkins-scripts/test-slurm-nfs-mount.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -e
+
+source .jenkins-scripts/jenkins-common.sh
+ssh -v \
+	-o "StrictHostKeyChecking no" \
+	-o "UserKnownHostsFile /dev/null" \
+	-l vagrant \
+	-i "${HOME}/.ssh/id_rsa" \
+	"10.0.0.5${GPU01}" \
+	"showmount -e | grep home"
+
+ssh -v \
+	-o "StrictHostKeyChecking no" \
+	-o "UserKnownHostsFile /dev/null" \
+	-l vagrant \
+	-i "${HOME}/.ssh/id_rsa" \
+	"10.0.0.6${GPU01}" \
+        "mount | grep nfs | grep home"

--- a/config.example/group_vars/slurm-cluster.yml
+++ b/config.example/group_vars/slurm-cluster.yml
@@ -53,12 +53,10 @@ nfs_mounts:
     options: async,vers=3
 
 # Flags for enable/disable of NFS deployment
-#  - Set up an NFS server on the controller node?
+#  - Set up an NFS server on nfs-server?
 slurm_enable_nfs_server: true
-#  - Mount NFS filesystems on the clients?
+#  - Mount NFS filesystems on nfs-clients?
 slurm_enable_nfs_client_nodes: true
-#  - Mount NFS filesystems on the controller node (only use if not the server)
-slurm_enable_nfs_client_master: "{{ not slurm_enable_nfs_server }}"
 
 ################################################################################
 # SOFTWARE MODULES (SM)                                                        #

--- a/config.example/group_vars/slurm-cluster.yml
+++ b/config.example/group_vars/slurm-cluster.yml
@@ -58,6 +58,10 @@ slurm_enable_nfs_server: true
 #  - Mount NFS filesystems on nfs-clients?
 slurm_enable_nfs_client_nodes: true
 
+# Inventory host groups to use for NFS server or clients
+nfs_server_group: "slurm-master"
+nfs_client_group: "slurm-node"
+
 ################################################################################
 # SOFTWARE MODULES (SM)                                                        #
 #   May be built with either EasyBuild or Spack                                #

--- a/config.example/group_vars/slurm-cluster.yml
+++ b/config.example/group_vars/slurm-cluster.yml
@@ -52,6 +52,14 @@ nfs_mounts:
     path: /sw
     options: async,vers=3
 
+# Flags for enable/disable of NFS deployment
+#  - Set up an NFS server on the controller node?
+slurm_enable_nfs_server: true
+#  - Mount NFS filesystems on the clients?
+slurm_enable_nfs_client_nodes: true
+#  - Mount NFS filesystems on the controller node (only use if not the server)
+slurm_enable_nfs_client_master: "{{ not slurm_enable_nfs_server }}"
+
 ################################################################################
 # SOFTWARE MODULES (SM)                                                        #
 #   May be built with either EasyBuild or Spack                                #

--- a/config.example/inventory
+++ b/config.example/inventory
@@ -53,6 +53,12 @@ kube-node
 slurm-master
 slurm-node
 
+[nfs-server:children]
+slurm-master
+
+[nfs-clients:children]
+slurm-node
+
 ######
 # SSH connection configuration
 ######

--- a/config.example/inventory
+++ b/config.example/inventory
@@ -53,12 +53,6 @@ kube-node
 slurm-master
 slurm-node
 
-[nfs-server:children]
-slurm-master
-
-[nfs-clients:children]
-slurm-node
-
 ######
 # SSH connection configuration
 ######

--- a/docs/slurm-cluster.md
+++ b/docs/slurm-cluster.md
@@ -59,6 +59,11 @@ Instructions for deploying a GPU cluster with Slurm
 Now that Slurm is installed, try a ["Hello World" example using MPI](../examples/slurm-mpi-hello/README.md).
 
 
+## Configuring shared filesystems
+
+For information about configuring a shared NFS filesystem on your Slurm cluster, see the documentation on [Slurm and NFS](./slurm-nfs.md).
+
+
 ## Installing tools and applications
 
 You may optionally choose to install a tool for managing additional packages on your Slurm cluster.

--- a/docs/slurm-nfs.md
+++ b/docs/slurm-nfs.md
@@ -65,7 +65,7 @@ To configure DeepOps to use your existing server, you should set the following c
 
 * Set `slurm_enable_nfs_server` to `false`
 
-* Set `slurm_enable_nfs_client_master` to `true`
+* Add `slurm-master` to the `[nfs-clients]` section in your Ansible inventory file (`config/inventory`)
 
 * Configure the `nfs_mounts` variable as shown below, repeating the list item for each NFS export
 
@@ -89,4 +89,3 @@ If you want to disable the use of any NFS mounts, or want to configure NFS yours
 
 * Set `slurm_enable_nfs_server` to `false`
 * Set `slurm_enable_nfs_client_master` to `false`
-* Set `slurm_enable_nfs_client_nodes` to `false`

--- a/docs/slurm-nfs.md
+++ b/docs/slurm-nfs.md
@@ -1,0 +1,92 @@
+Slurm cluster configuration for NFS filesystems
+===============================================
+
+Slurm clusters typically depend on the presence of one or more shared filesystems, mounted on all the nodes in the cluster.
+Having a shared filesystem simplifies software installation and provides a common working space for user jobs,
+and many common HPC applications depend on the presence of such a filesystem.
+
+Our default configuration in DeepOps achieves this by configuring the Slurm control/login node as an NFS server,
+and the compute nodes as clients of the NFS server.
+
+
+## Configuring NFS shares from the Slurm control node
+
+By default, we configure two NFS exports from the control node to the compute nodes:
+
+* `/home`: The user home directory space is shared across all nodes in the cluster.
+    This is a common pattern on most HPC clusters.
+* `/sw`: This directory provides a separate directory for installing software that needs to be built from source.
+    In most clusters this will be an admin-only area, not writeable by regular users, but this is a choice for the cluster admin.
+
+If you would like to make changes to that configuration, you can do so be setting the following variables.
+
+### Exports from the Slurm control node
+
+```
+nfs_exports:
+- path: "<absolute path of exported directory on control node>"
+  options: "<ips allowed to mount>(<options for the NFS export>)"
+- path: "<absolute path of another exported directory>"
+  options: "<ips allowed to mount>(<options for the NFS export>)"
+...
+```
+
+You can add as many additional exports to the list as you wish, configuring each appropriately.
+
+The `options` field for each export, which specifies the IPs allowed to mount these exports and the options for the export, follows the format of the NFS `/etc/exports` file.
+For documentation on the available NFS export options, see the manpages for your Linux distribution: `man 5 exports`.
+
+
+### NFS mounts on the clients
+
+```
+nfs_mounts:
+- mountpoint: "<absolute path of directory to mount share on clients>"
+  server: "<hostname of NFS server>"
+  path: "<path of the export from the server>"
+  options: "<nfs mount options>"
+- mountpoint: "<absolute path of another directory to mount share on clients>"
+  server: "<hostname of NFS server>"
+  path: "<path of the export from the server>"
+  options: "<nfs mount options>"
+...
+```
+
+As above, you can add as many additional mounts to the list as you wish.
+
+The `options` field for each mount specifies the NFS options used to mount the filesystem.
+For the available NFS options, see the manpages for your Linux distribution: `man 5 nfs`.
+
+
+## Configuring a separate NFS server
+
+If your site already has an NFS server, you may wish to use your existing server rather than setting up the Slurm control node to serve NFS.
+To configure DeepOps to use your existing server, you should set the following configuration values:
+
+* Set `slurm_enable_nfs_server` to `false`
+
+* Set `slurm_enable_nfs_client_master` to `true`
+
+* Configure the `nfs_mounts` variable as shown below, repeating the list item for each NFS export
+
+```
+nfs_mounts:
+- mountpoint: "<absolute path of directory to mount share on clients>"
+  server: "<hostname of NFS server>"
+  path: "<path of the export from the server>"
+  options: "<nfs mount options>"
+- mountpoint: "<absolute path of another directory to mount share on clients>"
+  server: "<hostname of NFS server>"
+  path: "<path of the export from the server>"
+  options: "<nfs mount options>"
+...
+
+```
+
+## Disabling NFS
+
+If you want to disable the use of any NFS mounts, or want to configure NFS yourself outside of DeepOps, set the following variables:
+
+* Set `slurm_enable_nfs_server` to `false`
+* Set `slurm_enable_nfs_client_master` to `false`
+* Set `slurm_enable_nfs_client_nodes` to `false`

--- a/docs/slurm-nfs.md
+++ b/docs/slurm-nfs.md
@@ -88,4 +88,4 @@ nfs_mounts:
 If you want to disable the use of any NFS mounts, or want to configure NFS yourself outside of DeepOps, set the following variables:
 
 * Set `slurm_enable_nfs_server` to `false`
-* Set `slurm_enable_nfs_client_master` to `false`
+* Set `slurm_enable_nfs_client_nodes` to `false`

--- a/docs/slurm-nfs.md
+++ b/docs/slurm-nfs.md
@@ -65,7 +65,7 @@ To configure DeepOps to use your existing server, you should set the following c
 
 * Set `slurm_enable_nfs_server` to `false`
 
-* Add `slurm-master` to the `[nfs-clients]` section in your Ansible inventory file (`config/inventory`)
+* Set `nfs_client_group` to `"slurm-cluster"`
 
 * Configure the `nfs_mounts` variable as shown below, repeating the list item for each NFS export
 

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -49,6 +49,11 @@ pipeline {
           sh '''
             timeout 60 bash -x ./.jenkins-scripts/test-slurm-job.sh
           '''
+
+          echo "Test NFS"
+          sh '''
+            timeout 60 bash -x ./.jenkins-scripts/test-slurm-nfs-mount.sh
+          '''
         }
       }
     }

--- a/playbooks/open-ondemand.yml
+++ b/playbooks/open-ondemand.yml
@@ -2,16 +2,6 @@
 - hosts: slurm-master
   become: yes
   roles:
-    - { role: nfs, nfs_is_server: yes }
-
-- hosts: slurm-node
-  become: yes
-  roles:
-    - { role: nfs, nfs_is_client: yes }
-
-- hosts: slurm-master
-  become: yes
-  roles:
     - {role: ood-wrapper, ood_is_server: yes }
 
 - hosts: slurm-node

--- a/playbooks/slurm-cluster.yml
+++ b/playbooks/slurm-cluster.yml
@@ -23,6 +23,14 @@
 # Install software
 - include: software.yml
 
+# Set up NFS filesystem
+- include: nfs-server.yml hostlist=slurm-master
+  when: slurm_enable_nfs_server
+- include: nfs-client.yml hostlist=slurm-node
+  when: slurm_enable_nfs_client_nodes
+- include: nfs-client.yml hostlist=slurm-master
+  when: slurm_enable_nfs_client_master
+
 # Install Slurm
 - include: slurm.yml
 

--- a/playbooks/slurm-cluster.yml
+++ b/playbooks/slurm-cluster.yml
@@ -24,9 +24,13 @@
 - include: software.yml
 
 # Set up NFS filesystem
-- include: nfs-server.yml hostlist=nfs-server
+- include: nfs-server.yml
+  vars:
+    hostlist: "{{ nfs_server_group | default('slurm-master') }}"
   when: slurm_enable_nfs_server
-- include: nfs-client.yml hostlist=nfs-clients
+- include: nfs-client.yml
+  vars:
+    hostlist: "{{ nfs_client_group | default('slurm-node') }}"
   when: slurm_enable_nfs_client_nodes
 
 # Install Slurm

--- a/playbooks/slurm-cluster.yml
+++ b/playbooks/slurm-cluster.yml
@@ -24,12 +24,10 @@
 - include: software.yml
 
 # Set up NFS filesystem
-- include: nfs-server.yml hostlist=slurm-master
+- include: nfs-server.yml hostlist=nfs-server
   when: slurm_enable_nfs_server
-- include: nfs-client.yml hostlist=slurm-node
+- include: nfs-client.yml hostlist=nfs-clients
   when: slurm_enable_nfs_client_nodes
-- include: nfs-client.yml hostlist=slurm-master
-  when: slurm_enable_nfs_client_master
 
 # Install Slurm
 - include: slurm.yml

--- a/virtual/scripts/setup_slurm.sh
+++ b/virtual/scripts/setup_slurm.sh
@@ -33,17 +33,3 @@ ansible-playbook \
 	-l slurm-cluster \
 	-e "@${VIRT_DIR}/vars_files/virt_slurm.yml" ${ansible_extra_args} \
 	"${ROOT_DIR}/playbooks/slurm-cluster.yml"
-
-# Configure NFS server for /shared
-ansible-playbook \
-	-i "${VIRT_DIR}/config/inventory" \
-	-l slurm-master \
-	-e "@${VIRT_DIR}/vars_files/virt_slurm.yml" ${ansible_extra_args} \
-	"${ROOT_DIR}/playbooks/nfs-server.yml"
-
-# Configure NFS clients for /shared
-ansible-playbook \
-	-i "${VIRT_DIR}/config/inventory" \
-	-l slurm-node \
-	-e "@${VIRT_DIR}/vars_files/virt_slurm.yml" ${ansible_extra_args} \
-	"${ROOT_DIR}/playbooks/nfs-client.yml"

--- a/virtual/vars_files/virt_slurm.yml
+++ b/virtual/vars_files/virt_slurm.yml
@@ -1,15 +1,4 @@
 ---
-# Configure a global NFS share across the slurm cluster
-nfs_mounts:
-- mountpoint: "/shared"
-  server: '{{ groups["slurm-master"][0] }}'
-  path: "/shared"
-  options: "nfsvers=3,rw,sync"
-
-nfs_exports:
-- path: "/shared"
-  options: "*(rw,sync)"
-
 # For virtual cluster, ensure hosts file correctly uses private network
 hosts_network_interface: "eth1"
 

--- a/virtual/virtual_inventory
+++ b/virtual/virtual_inventory
@@ -42,12 +42,6 @@ virtual-gpu01
 slurm-master
 slurm-node
 
-[nfs-server:children]
-slurm-master
-
-[nfs-clients:children]
-slurm-node
-
 ######
 # SSH connection configuration
 ######

--- a/virtual/virtual_inventory
+++ b/virtual/virtual_inventory
@@ -42,14 +42,11 @@ virtual-gpu01
 slurm-master
 slurm-node
 
-######
-# NFS
-######
-[nfs-server]
-virtual-login01
+[nfs-server:children]
+slurm-master
 
-[nfs-clients]
-virtual-gpu01
+[nfs-clients:children]
+slurm-node
 
 ######
 # SSH connection configuration

--- a/virtual/virtual_inventory_full
+++ b/virtual/virtual_inventory_full
@@ -54,12 +54,6 @@ virtual-gpu02
 slurm-master
 slurm-node
 
-[nfs-server:children]
-slurm-master
-
-[nfs-clients:children]
-slurm-node
-
 ######
 # SSH connection configuration
 ######

--- a/virtual/virtual_inventory_full
+++ b/virtual/virtual_inventory_full
@@ -54,15 +54,11 @@ virtual-gpu02
 slurm-master
 slurm-node
 
-######
-# NFS
-######
-[nfs-server]
-virtual-login01
+[nfs-server:children]
+slurm-master
 
-[nfs-clients]
-virtual-gpu01
-virtual-gpu02
+[nfs-clients:children]
+slurm-node
 
 ######
 # SSH connection configuration


### PR DESCRIPTION
* Enable NFS shares on Slurm cluster explicitly in the `slurm-cluster.yml` playbook
* Adds variables to the config for turning this on and off
* Adds documentation on using and configuring NFS shares