### PR TITLE
peg rook/ceph container to a version not master

### DIFF
--- a/services/rook-cluster.yml
+++ b/services/rook-cluster.yml
@@ -69,7 +69,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       containers:
       - name: rook-ceph-tools
-        image: rook/ceph:master
+        image: rook/ceph:v1.2.7
         command: ["/tini"]
         args: ["-g", "--", "/usr/local/bin/toolbox.sh"]
         imagePullPolicy: IfNotPresent


### PR DESCRIPTION
Fix as mentioned in https://github.com/NVIDIA/deepops/issues/570.

In the rook yml we were using `rook/ceph:master` for a container. This caused some issues as rook/ceph moved forward and the rest of our config was tied to an only version.