### PR TITLE
Add a quick test to actually launch a container via Kubeflow pipelines

### DIFF
--- a/.jenkins-scripts/run-gpu-job.sh
+++ b/.jenkins-scripts/run-gpu-job.sh
@@ -11,10 +11,9 @@ chmod 755 "$K8S_CONFIG_DIR/artifacts/kubectl"
 kubectl get nodes
 kubectl describe nodes
 
-# Occassionally this gpu-test fails and/or hangs. To ease debugging of this we run the initial kubectl cmd in the background so that we can describe the pod in-case it fails.
-timeout 120 kubectl run gpu-test --rm -t -i --restart=Never --image=nvidia/cuda --limits=nvidia.com/gpu=1 -- nvidia-smi &
-sleep 10 && kubectl describe pods gpu-test || echo "Pod already finished creating and has been removed -- kubectl describe is expected to fail."
-wait
+# Occassionally this gpu-test fails and/or hangs. To ease debugging of this we run a describe several seconds into the launch.
+sleep 10 && kubectl describe pods gpu-test &
+timeout 120 kubectl run gpu-test --rm -t -i --restart=Never --image=nvidia/cuda --limits=nvidia.com/gpu=1 -- nvidia-smi
 
 # Run multi-GPU test
 if [ "${DEEPOPS_FULL_INSTALL}" ]; then

--- a/.jenkins-scripts/test-kubeflow-pipeline.py
+++ b/.jenkins-scripts/test-kubeflow-pipeline.py
@@ -1,0 +1,27 @@
+import kfp
+import json
+import time
+
+# Define and build a Kubeflow Pipeline
+@kfp.dsl.pipeline(
+    name="kubeflow-quick-test",
+    description="Verify Kubeflow can launch a container via a pipeline")
+def test_kubeflow_op():
+    op = kfp.dsl.ContainerOp(
+      name='kubeflow-test-op',
+      image='nvcr.io/nvidia/rapidsai/rapidsai:cuda10.1-runtime-centos7',
+      command=["/bin/bash", "-cx"],
+      arguments=["echo 'Container started!'"],
+      file_outputs={}
+      )                 
+kfp.compiler.Compiler().compile(test_kubeflow_op, 'kubeflow-test.yml')
+
+# Connect to Kubeflow and create job, this simply rungs RAPIDS and prints out a message                 
+run_result = kfp.Client(host=None).create_run_from_pipeline_package('kubeflow-test.yml', arguments={})    
+
+for i in range(70): # The test .sh times out after 600 seconds. So we run a little longer than that. This accounts mostly for NGC download time.
+    status = kfp.Client(host=None).get_run(run_result.run_id).run.status
+    if status == "Succeeded":
+        print("SUCCESS: Kubeflow launched a container successfully")
+        break
+    time.sleep(10) # Wait 10 seconds and poll

--- a/.jenkins-scripts/test-kubeflow-pipeline.sh
+++ b/.jenkins-scripts/test-kubeflow-pipeline.sh
@@ -12,7 +12,9 @@ sudo pip3 install kfp
 # Don't wait for katib or a few other things that take longer to initialize
 export KUBEFLOW_DEPLOYMENTS="profiles-deployment centraldashboard ml-pipeline minio mysql metadata-db"
 ./scripts/k8s_deploy_kubeflow.sh -w
-sleep 30
+sleep 60 # Do this to allow appropriate "kubeflow initialization" time
+
+kubectl get pods -n kubeflow # Do this for debug purposes
 
 # Run the Kubeflow pipeline test, this will build a pipeline that launches an NGC container
 timeout 600 python3 .jenkins-scripts/test-kubeflow-pipeline.py

--- a/.jenkins-scripts/test-kubeflow-pipeline.sh
+++ b/.jenkins-scripts/test-kubeflow-pipeline.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -x
+source .jenkins-scripts/jenkins-common.sh
+
+# Ensure working directory is root
+cd "${ROOT_DIR}"
+
+# Install the optional kfp package
+sudo pip3 install kfp
+
+# Wait for the kubeflow pipeline service to be ready, and then wait another 30 seconds for other random Kubeflow initialization
+# Don't wait for katib or a few other things that take longer to initialize
+export KUBEFLOW_DEPLOYMENTS="profiles-deployment centraldashboard ml-pipeline minio mysql metadata-db"
+./scripts/k8s_deploy_kubeflow.sh -w
+sleep 30
+
+# Run the Kubeflow pipeline test, this will build a pipeline that launches an NGC container
+timeout 600 python3 .jenkins-scripts/test-kubeflow-pipeline.py

--- a/jenkins/Jenkinsfile-multi-nightly
+++ b/jenkins/Jenkinsfile-multi-nightly
@@ -138,6 +138,11 @@ pipeline {
              timeout 1500 bash -x ./.jenkins-scripts/test-kubeflow.sh
           '''
 
+          echo "Test Kubeflow pipeline"
+          sh '''
+             timeout 1500 bash -x ./.jenkins-scripts/test-kubeflow-pipeline.sh
+          '''
+
           echo "Test Monitoring installation"
           sh '''
              timeout 800 bash -x ./.jenkins-scripts/test-monitoring.sh

--- a/jenkins/Jenkinsfile-multi-nightly
+++ b/jenkins/Jenkinsfile-multi-nightly
@@ -50,6 +50,11 @@ pipeline {
              timeout 1500 bash -x ./.jenkins-scripts/test-kubeflow.sh
           '''
 
+          echo "Test Kubeflow pipeline"
+          sh '''
+             timeout 1500 bash -x ./.jenkins-scripts/test-kubeflow-pipeline.sh
+          '''
+
           echo "Test Monitoring installation"
           sh '''
              timeout 800 bash -x ./.jenkins-scripts/test-monitoring.sh

--- a/jenkins/Jenkinsfile-nightly
+++ b/jenkins/Jenkinsfile-nightly
@@ -108,12 +108,12 @@ pipeline {
             bash -x ./.jenkins-scripts/munge-files.sh
           '''
 
-          echo "Vagrant Up - Multi-Nodes"
+          echo "Vagrant Up"
           sh '''
             bash -x ./.jenkins-scripts/vagrant-startup.sh
           '''
 
-          echo "Cluster Up - Multi-Nodes"
+          echo "Cluster Up"
           sh '''
             bash -x ./.jenkins-scripts/test-cluster-up.sh
           '''
@@ -136,6 +136,11 @@ pipeline {
           echo "Test Kubeflow installation"
           sh '''
              timeout 1500 bash -x ./.jenkins-scripts/test-kubeflow.sh
+          '''
+
+          echo "Test Kubeflow pipeline"
+          sh '''
+             timeout 1500 bash -x ./.jenkins-scripts/test-kubeflow-pipeline.sh
           '''
 
           echo "Test Monitoring installation"

--- a/jenkins/Jenkinsfile-nightly
+++ b/jenkins/Jenkinsfile-nightly
@@ -50,6 +50,11 @@ pipeline {
              timeout 1500 bash -x ./.jenkins-scripts/test-kubeflow.sh
           '''
 
+          echo "Test Kubeflow pipeline"
+          sh '''
+             timeout 1500 bash -x ./.jenkins-scripts/test-kubeflow-pipeline.sh
+          '''
+
           echo "Test Monitoring installation"
           sh '''
              timeout 800 bash -x ./.jenkins-scripts/test-monitoring.sh


### PR DESCRIPTION
This adds a new test to the nightly and multi-node nightly Jenkins files.

The test contains two scripts.

1. A test-kubeflow-pipeline.sh which simply installs `kfp` via pip and runs the python file.
2. A test-kubeflow-pipeline.py which Creates a Kubeflow pipeline that launches a RAPIDS container and polls Kubeflow for 600 seconds for a successful launch.


This test is meant to verify that Kubeflow is actually able to deploy a container (via pipelines at least). It could potentially run into issues downloading from NGC, but I set the timeout to 600 seconds, so it shouldn't fail unless Kubeflow actually fails to launch a container.

This is not actually validating any GPU functionality for Kubeflow.

This would be a great spot to add some ResourceOps to test creating things like Volumes, MPIJobs, etc. But for now I kept it simple.