### PR TITLE
Add some extra debugging to the jenking run-gpu-test

### DIFF
--- a/.jenkins-scripts/run-gpu-job.sh
+++ b/.jenkins-scripts/run-gpu-job.sh
@@ -10,7 +10,11 @@ chmod 755 "$K8S_CONFIG_DIR/artifacts/kubectl"
 # Verify Nodes & run single GPU test
 kubectl get nodes
 kubectl describe nodes
-timeout 120 kubectl run gpu-test --rm -t -i --restart=Never --image=nvidia/cuda --limits=nvidia.com/gpu=1 -- nvidia-smi
+
+# Occassionally this gpu-test fails and/or hangs. To ease debugging of this we run the initial kubectl cmd in the background so that we can describe the pod in-case it fails.
+timeout 120 kubectl run gpu-test --rm -t -i --restart=Never --image=nvidia/cuda --limits=nvidia.com/gpu=1 -- nvidia-smi &
+sleep 10 && kubectl describe pods gpu-test || echo "Pod already finished creating and has been removed -- kubectl describe is expected to fail."
+wait
 
 # Run multi-GPU test
 if [ "${DEEPOPS_FULL_INSTALL}" ]; then


### PR DESCRIPTION
This test has been hanging every night when run on CentOS.

I did this manually while debugging and figured the output would be useful to have in the test logs going forward.

After exectuting the test gpu job for k8s it does a describe pod on the test. In most cases this should show "Pulling image". In failed cases it will show out of resources, etc.