### PR TITLE
Make Trident version variable-driven

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@
 /galaxy-roles/
 /k8s-config/
 /kubectl
+/tridentctl

--- a/config.example/group_vars/netapp-trident.yml
+++ b/config.example/group_vars/netapp-trident.yml
@@ -1,11 +1,15 @@
 ---
 # vars file for netapp-trident playbook
 
+# URL of the Trident installer package that you wish to download and use
+trident_version: "20.07.0"
+trident_installer_url: "https://github.com/NetApp/trident/releases/download/v{{ trident_version }}/trident-installer-{{ trident_version }}.tar.gz"
+
 # Kubernetes version
 # Note: Do not include patch version, e.g. provide value of 1.16, not 1.16.7.
 # Note: Versions 1.14 and above are supported when deploying Trident with DeepOps.
 #   If you are using an earlier version, you must deploy Trident manually.
-k8s_version: 1.16
+k8s_version: 1.17
 
 # Denotes whether or not to create new backends after deploying trident
 # For more info, refer to: https://netapp-trident.readthedocs.io/en/stable-v20.04/kubernetes/operator-install.html#creating-a-trident-backend
@@ -34,7 +38,7 @@ backends_to_create:
       splitOnClone: false
       encryption: false
       unixPermissions: 777
-      snapshotDir: true
+      snapshotDir: false
       exportPolicy: default
       securityStyle: unix
       tieringPolicy: none

--- a/roles/netapp-trident/defaults/main.yml
+++ b/roles/netapp-trident/defaults/main.yml
@@ -1,6 +1,10 @@
 ---
 # defaults file for netapp-trident role
 
+# URL of the Trident installer package that you wish to download and use
+trident_version: "20.07.0"
+trident_installer_url: "https://github.com/NetApp/trident/releases/download/v{{ trident_version }}/trident-installer-{{ trident_version }}.tar.gz"
+
 # Kubernetes version
 # Note: Do not include patch version, e.g. provide value of 1.16, not 1.16.7.
 # Note: Versions 1.14 and above are supported when deploying Trident with DeepOps.

--- a/roles/netapp-trident/tasks/main.yml
+++ b/roles/netapp-trident/tasks/main.yml
@@ -3,7 +3,7 @@
 
 - name: Download and extract Trident installer
   unarchive:
-    src: https://github.com/NetApp/trident/releases/download/v20.04.0/trident-installer-20.04.0.tar.gz
+    src: '{{ trident_installer_url }}'
     dest: /root
     remote_src: yes
 


### PR DESCRIPTION
Updating 'netapp-trident' role:

- Making Trident version variable driven.
- Updating default variables based on feedback.
- Adding 'tridentctl' to '.gitignore' ('.tridenctl' is optionally copied to localhost during execution of the 'netapp-trident' role).