### PR TITLE
Add a flag to disable running the chrony playbook in cluster turnup

### DIFF
--- a/config.example/group_vars/all.yml
+++ b/config.example/group_vars/all.yml
@@ -30,7 +30,7 @@
 
 # NTP configuration
 # Playbook: chrony-client
-install_chrony: yes
+chrony_install: yes
 chrony_service_state: "started"
 chrony_service_enabled: "yes"
 chrony_timezone: "Etc/UTC"

--- a/config.example/group_vars/all.yml
+++ b/config.example/group_vars/all.yml
@@ -30,6 +30,7 @@
 
 # NTP configuration
 # Playbook: chrony-client
+install_chrony: yes
 chrony_service_state: "started"
 chrony_service_enabled: "yes"
 chrony_timezone: "Etc/UTC"

--- a/playbooks/k8s-cluster.yml
+++ b/playbooks/k8s-cluster.yml
@@ -31,7 +31,7 @@
 
 # Configure Chrony (NTP) sync
 - include: chrony-client.yml
-  when: install_chrony
+  when: chrony_install
 
 # Install the OpenShift API libraries required by the GPU plugin
 - include: bootstrap-openshift.yml

--- a/playbooks/k8s-cluster.yml
+++ b/playbooks/k8s-cluster.yml
@@ -31,6 +31,7 @@
 
 # Configure Chrony (NTP) sync
 - include: chrony-client.yml
+  when: install_chrony
 
 # Install the OpenShift API libraries required by the GPU plugin
 - include: bootstrap-openshift.yml

--- a/playbooks/slurm-cluster.yml
+++ b/playbooks/slurm-cluster.yml
@@ -13,7 +13,7 @@
 
 # Configure Chrony (NTP) sync
 - include: chrony-client.yml
-  when: install_chrony
+  when: chrony_install
 
 # Install NVIDIA driver
 - include: nvidia-driver.yml

--- a/playbooks/slurm-cluster.yml
+++ b/playbooks/slurm-cluster.yml
@@ -13,6 +13,7 @@
 
 # Configure Chrony (NTP) sync
 - include: chrony-client.yml
+  when: install_chrony
 
 # Install NVIDIA driver
 - include: nvidia-driver.yml


### PR DESCRIPTION
Addresses feature request in #593 . Chrony is still enabled by default.

## Test plan

Set `install_chrony: false` in configuration before running either the `slurm-cluster.yml` or `k8s-cluster.yml` playbook. Observe that the `chrony-client.yml` playbook is skipped:

```
PLAY [all] *********************************************************************************************************************************************************************************************************

TASK [Configure Chrony client] *************************************************************************************************************************************************************************************skipping: [virtual-login01]
skipping: [virtual-gpu01]

TASK [Set timezone] ************************************************************************************************************************************************************************************************skipping: [virtual-login01]
skipping: [virtual-gpu01]
```