### PR TITLE
Enable usage of NFS home dirs on RHEL/CentOS

### DIFF
--- a/roles/nfs/tasks/client.yml
+++ b/roles/nfs/tasks/client.yml
@@ -19,3 +19,10 @@
   when: nfs_mounts|length
   tags:
     - nfs
+
+- name: rhel | enable nfs home directory usage
+  seboolean:
+    name: "use_nfs_home_dirs"
+    state: yes
+    persistent: yes
+  when: ansible_os_family == "RedHat"


### PR DESCRIPTION
On CentOS 7, if SELinux is enabled, NFS home directories are disabled by
default. This impacts our virtual cluster turnup (which uses NFS
homedirs in Slurm), as well as most Slurm workflows.

This PR adds a flag to enable NFS home directories when running on
CentOS.

Test Plan
---------

Run the virtual cluster turnup with default Vagrant boxes to turn up a
CentOS cluster. (Or turn on SELinux on any other CentOS test setup.)

Before this PR, you will fail to SSH if the node reboots or you SSH
after running the NFS playbook. After this PR, it should work!