### PR TITLE
missed a prereq for the ansible selinux module

### DIFF
--- a/roles/nfs/tasks/client.yml
+++ b/roles/nfs/tasks/client.yml
@@ -20,6 +20,12 @@
   tags:
     - nfs
 
+- name: rhel | install management prereq
+  yum:
+    name: "libsemanage-python"
+    state: present
+  when: ansible_os_family == "RedHat"
+
 - name: rhel | enable nfs home directory usage
   seboolean:
     name: "use_nfs_home_dirs"


### PR DESCRIPTION
ARGH

Makes #599 actually work correctly on a minimal CentOS image, instead of the development image I was using previously.