### PR TITLE
Update to latest ansible-role-enroot

### DIFF
--- a/config.example/group_vars/slurm-cluster.yml
+++ b/config.example/group_vars/slurm-cluster.yml
@@ -117,7 +117,4 @@ allow_user_set_gpu_clocks: no
 ################################################################################
 slurm_install_enroot: true
 slurm_install_pyxis: true
-enroot_deb_packages:
-  - 'https://github.com/NVIDIA/enroot/releases/download/v3.1.0/enroot_3.1.0-1_amd64.deb'
-  - 'https://github.com/NVIDIA/enroot/releases/download/v3.1.0/enroot+caps_3.1.0-1_amd64.deb'
 slurm_pyxis_tarball_url: https://github.com/NVIDIA/pyxis/archive/v0.7.0.tar.gz

--- a/requirements.yml
+++ b/requirements.yml
@@ -24,7 +24,7 @@
   version: "v1.2.1"
 
 - src: https://github.com/NVIDIA/ansible-role-enroot.git
-  verions: "v0.1.2"
+  version: "v0.3.0"
 
 - src: geerlingguy.filebeat
   version: "2.0.1"


### PR DESCRIPTION
- New version of enroot (v3.1.1)
- Role now supports CentOS/RHEL install