### PR TITLE
Persist Prometheus data to PV with option to use legacy code-path

### DIFF
--- a/config.example/helm/monitoring-no-persist.yml
+++ b/config.example/helm/monitoring-no-persist.yml
@@ -1,0 +1,59 @@
+prometheusOperator:
+  nodeSelector:
+    node-role.kubernetes.io/master: ""
+
+prometheus:
+  ingress:
+    enabled: true
+    annotations:
+      kubernetes.io/ingress.class: "nginx"
+      nginx.ingress.kubernetes.io/ssl-redirect: "false"
+      nginx.ingress.kubernetes.io/rewrite-target: /
+  prometheusSpec:
+    nodeSelector:
+      node-role.kubernetes.io/master: ""
+  service:
+    type: NodePort
+    nodePort: 30500
+  additionalServiceMonitors:
+  - name: dcgm-exporter
+    selector:
+      matchLabels:
+        app: dcgm-exporter
+    endpoints:
+    - port: scrape
+      interval: 1s
+      honorLabels: true       
+  serviceMonitorsSelector:
+    matchLabels:
+      prometheus: "kube-prometheus"
+
+alertmanager:
+  ingress:
+    enabled: true
+    annotations:
+      kubernetes.io/ingress.class: "nginx"
+      nginx.ingress.kubernetes.io/ssl-redirect: "false"
+      nginx.ingress.kubernetes.io/rewrite-target: /
+  alertmanagerSpec:
+    nodeSelector:
+      node-role.kubernetes.io/master: ""
+  service:
+    type: NodePort
+    nodePort: 30400
+
+grafana:
+  adminPassword: deepops
+  ingress:
+    enabled: true
+    annotations:
+      kubernetes.io/ingress.class: "nginx"
+      nginx.ingress.kubernetes.io/ssl-redirect: "false"
+      nginx.ingress.kubernetes.io/rewrite-target: /
+  nodeSelector:
+    node-role.kubernetes.io/master: ""
+  service:
+    type: NodePort
+    nodePort: 30200
+  serverDashboardConfigmaps:
+    - kube-prometheus-grafana-gpu

--- a/config.example/helm/monitoring.yml
+++ b/config.example/helm/monitoring.yml
@@ -9,7 +9,17 @@ prometheus:
       kubernetes.io/ingress.class: "nginx"
       nginx.ingress.kubernetes.io/ssl-redirect: "false"
       nginx.ingress.kubernetes.io/rewrite-target: /
+  server:
+    persistentVolume:
+      enabled: true
   prometheusSpec:
+    storageSpec:
+      volumeClaimTemplate:
+        spec:
+          accessModes: ["ReadWriteOnce"]
+          resources:
+            requests:
+              storage: 10Gi
     nodeSelector:
       node-role.kubernetes.io/master: ""
   service:

--- a/scripts/k8s_deploy_monitoring.sh
+++ b/scripts/k8s_deploy_monitoring.sh
@@ -20,6 +20,10 @@ fi
 
 HELM_CHARTS_REPO_STABLE="${HELM_CHARTS_REPO_STABLE:-https://kubernetes-charts.storage.googleapis.com}"
 HELM_PROMETHEUS_CHART_VERSION="${HELM_PROMETHEUS_CHART_VERSION:-8.15.0}"
+
+PROMETHEUS_YAML_CONFIG="${PROMETHEUS_YAML_CONFIG:-${config_dir}/helm/monitoring.yml}"
+PROMETHEUS_YAML_NO_PERSIST_CONFIG="${PROMETHEUS_YAML_NO_PERSIST_CONFIG:-${config_dir}/helm/monitoring-no-persist.yml}"
+
 ingress_name="nginx-ingress"
 
 function help_me() {
@@ -30,11 +34,12 @@ function help_me() {
     echo "-h      This message."
     echo "-p      Print monitoring URLs."
     echo "-d      Delete monitoring namespace and crds. Note, this may delete PVs storing prometheus metrics."
+    echo "-x      Disable persistent data, this deploys Prometheus with no PV backing resulting in a loss of data across reboots."
     echo "delete  Legacy positional argument for delete. Same as -d flag."
 }
 
 function get_opts() {
-    while getopts "hdp" option; do
+    while getopts "hdpx" option; do
         case $option in
             d)
                 delete_monitoring
@@ -47,6 +52,10 @@ function get_opts() {
             p)
                 print_monitoring
                 exit 0
+                ;;
+	    x)
+		PROMETHEUS_YAML_CONFIG="${PROMETHEUS_YAML_NO_PERSIST_CONFIG}"
+		NO_PERSIST="true"
                 ;;
             * )
                 # Leave this here to preserve legacy positional args behavior
@@ -73,6 +82,37 @@ function delete_monitoring() {
     kubectl delete crd thanosrulers.monitoring.coreos.com
     kubectl delete ns monitoring
 }
+
+
+function install_dependencies() {
+    # kubectl
+    kubectl version
+    if [ $? -ne 0 ] ; then
+        echo "Unable to talk to Kubernetes API"
+        exit 1
+    fi
+
+    # Install/initialize Helm if needed
+    ./scripts/install_helm.sh
+
+    # Rook
+    kubectl get storageclass 2>&1 | grep "No resources found." >/dev/null 2>&1
+    if [ $? -eq 0 ] ; then
+        echo "No storageclass found"
+        echo "This is required to persist Prometheus data"
+        echo ""
+        if [ ${NO_PERSIST} ]; then
+            echo "WARNING: Persistance has been disabled, rebooting or migrating the Prometheus pod will result in loss of all data"
+	    sleep 5 # Sleep to give the user time to see a warning
+        else
+            echo "To continue without persistent storage, use the '-x' flag: ./scripts/k8s_deploy_monitoring.sh -x"
+            echo "To provision Ceph storage, run: ./scripts/k8s_deploy_rook.sh"
+            echo "ERROR: deployment has stopped"
+            exit 1
+        fi
+    fi
+}
+
 
 function setup_prom_monitoring() {
     # Add Helm stable repo if it doesn't exist
@@ -120,7 +160,7 @@ function setup_prom_monitoring() {
             --version "${HELM_PROMETHEUS_CHART_VERSION}" \
             --name prometheus-operator \
             --namespace monitoring \
-            --values ${config_dir}/helm/monitoring.yml \
+            --values ${PROMETHEUS_YAML_CONFIG} \
             --set alertmanager.ingress.hosts[0]="alertmanager-${ingress_ip_string}" \
             --set prometheus.ingress.hosts[0]="prometheus-${ingress_ip_string}" \
             --set grafana.ingress.hosts[0]="grafana-${ingress_ip_string}" \
@@ -190,15 +230,7 @@ function print_monitoring() {
 
 get_opts ${@}
 
-kubectl version
-if [ $? -ne 0 ] ; then
-    echo "Unable to talk to Kubernetes API"
-    exit 1
-fi
-
-# Install/initialize Helm if needed
-./scripts/install_helm.sh
-
+install_dependencies
 setup_prom_monitoring
 setup_gpu_monitoring
 print_monitoring

--- a/scripts/k8s_deploy_monitoring.sh
+++ b/scripts/k8s_deploy_monitoring.sh
@@ -58,17 +58,17 @@ function get_opts() {
 		NO_PERSIST="true"
                 ;;
             * )
-                # Leave this here to preserve legacy positional args behavior
-                if [ "${1}" == "delete" ]; then
-                    delete_monitoring
-                    exit 0
-                else
-                    help_me
-                    exit 1
-                fi
+                help_me
+                exit 1
                 ;;
         esac
     done
+
+    # Leave this here to preserve legacy positional args behavior
+    if [ "${1}" == "delete" ]; then
+        delete_monitoring
+        exit 0
+    fi
 }
 
 function delete_monitoring() {

--- a/services/prometheus-monitor.yml
+++ b/services/prometheus-monitor.yml
@@ -585,9 +585,9 @@ metadata:
   annotations:
     volume.alpha.kubernetes.io/storage-class: default
 spec:
-  storageClassName: rook-ceph-block
+  storageClassName: ""
   accessModes:
     - ReadWriteOnce
   resources:
     requests:
-      storage: 2Gi
+      storage: 10Gi

--- a/services/prometheus-monitor.yml
+++ b/services/prometheus-monitor.yml
@@ -585,7 +585,6 @@ metadata:
   annotations:
     volume.alpha.kubernetes.io/storage-class: default
 spec:
-  storageClassName: ""
   accessModes:
     - ReadWriteOnce
   resources:

--- a/virtual/vagrant_shutdown.sh
+++ b/virtual/vagrant_shutdown.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -ex
+set -x
 
 # To destroy the virtual cluster, we just tear down all VMs
 VIRT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"


### PR DESCRIPTION
Based off this PR: https://github.com/NVIDIA/deepops/pull/560

**New** features:

- The default behavior has changed, it now relies on a default storage class
- Default behavior now persists prom data to a PV
- New `-x` flag uses old `yml` which does not persist data to a PV
- Fixed some logic in cmd line parsing
- Added a new Jenkins test that verify delete logic, and PV deployment (does not verify data persists)

**Test plan:**
1. Deploy Kubernetes without Ceph
2. Attempt  to run script. [it should fail]
3. Attempt to run script with -x flag [Verify GPU Node dashboard comes up]
4. Wait 5 minutes and reboot all pods in monitoring namespace. [Verify data has left GPU Node dashboard]
5. Attempt to run script with -d flag [Verify it is deleted
6. Install rook/ceph
7. Attempt to run script [Verify GPU Node dashboard comes up]
8. Wait 5 minutes and reboot all pods in monitoring namespace. [Verify data has persisted in GPU Node dashboard]
9. Attempt to run script with "delete" option [Verify it is deleted]
