### PR TITLE
Playbook and role to install the HPC SDK

### DIFF
--- a/config.example/group_vars/slurm-cluster.yml
+++ b/config.example/group_vars/slurm-cluster.yml
@@ -97,7 +97,7 @@ spack_default_packages:
 ################################################################################
 # NVIDIA HPC SDK                                                               #
 ################################################################################
-slurm_install_hpcsdk: false
+slurm_install_hpcsdk: true
 hpcsdk_version: "2020_207"
 
 # In a Slurm cluster, default to setting up HPC SDK as modules rather than in

--- a/config.example/group_vars/slurm-cluster.yml
+++ b/config.example/group_vars/slurm-cluster.yml
@@ -72,6 +72,7 @@ nfs_client_group: "slurm-node"
 # SOFTWARE MODULES (SM)                                                        #
 #   May be built with either EasyBuild or Spack                                #
 ################################################################################
+slurm_install_lmod: true
 
 # Note: the sm_prefix must be in an NFS-shared location
 sm_prefix: "/sw"
@@ -92,6 +93,17 @@ spack_build_packages: false
 spack_default_packages:
 - "cuda@10.2.89"
 - "openmpi@3.1.6 +cuda +pmi schedulers=auto"
+
+################################################################################
+# NVIDIA HPC SDK                                                               #
+################################################################################
+slurm_install_hpcsdk: false
+hpcsdk_version: "2020_207"
+
+# In a Slurm cluster, default to setting up HPC SDK as modules rather than in
+# the default user environment
+hpcsdk_install_as_modules: true
+hpcsdk_install_in_path: false
 
 ################################################################################
 # Open OnDemand                                                                #

--- a/playbooks/lmod.yml
+++ b/playbooks/lmod.yml
@@ -1,0 +1,5 @@
+---
+- hosts: "{{ hostlist | default('all') }}"
+  become: yes
+  roles:
+  - lmod

--- a/playbooks/nvidia-hpc-sdk.yml
+++ b/playbooks/nvidia-hpc-sdk.yml
@@ -1,0 +1,5 @@
+---
+- hosts: "{{ hostlist | default('all') }}"
+  become: true
+  roles:
+  - nvidia-hpc-sdk

--- a/playbooks/slurm-cluster.yml
+++ b/playbooks/slurm-cluster.yml
@@ -42,6 +42,14 @@
 - include: openmpi.yml
   when: slurm_cluster_install_openmpi|default(true)
 
+# Install Lmod
+- include: lmod.yml
+  when: slurm_install_lmod
+
+# Install the NVIDIA HPC SDK
+- include: nvidia-hpc-sdk.yml hostlist=slurm-master
+  when: slurm_install_hpcsdk
+
 # Install monitoring tools
 - include: prometheus.yml hostlist=slurm-master
   when: slurm_enable_monitoring

--- a/roles/lmod/tasks/main.yml
+++ b/roles/lmod/tasks/main.yml
@@ -9,7 +9,7 @@
 
 - name: "install packages"
   become: yes
-  action: yum name=lmod state=latest
+  action: yum name=Lmod state=latest
   when: ansible_os_family == "RedHat"
 
 - name: "mkdir software path"

--- a/roles/nvidia-hpc-sdk/defaults/main.yml
+++ b/roles/nvidia-hpc-sdk/defaults/main.yml
@@ -12,7 +12,8 @@ hpcsdk_version_dir: "20.7"
 
 hpcsdk_temp_dir: "/tmp/hpc-sdk-install"
 hpcsdk_dest_download_path: "{{ hpcsdk_temp_dir }}/nvhpc.tar.gz"
-hpcsdk_clean_up_temp_dir: true
+hpcsdk_clean_up_tarball_after_extract: false
+hpcsdk_clean_up_temp_dir: false
 
 hpcsdk_install_as_modules: false
 hpcsdk_install_in_path: true

--- a/roles/nvidia-hpc-sdk/defaults/main.yml
+++ b/roles/nvidia-hpc-sdk/defaults/main.yml
@@ -1,0 +1,13 @@
+---
+hpcsdk_version: "2020_207"
+hpcsdk_arch: "x86_64"
+hpcsdk_cuda: "multi"
+hpcsdk_download_name: "nvhpc_{{ hpcsdk_version }}_Linux_{{ hpcsdk_arch }}_cuda_{{ hpcsdk_cuda }}"
+hpcsdk_download_url: "https://developer.download.nvidia.com/hpc-sdk/{{ hpcsdk_download_name }}.tar.gz"
+
+hpcsdk_install_dir: "/sw/hpc-sdk"
+hpcsdk_install_type: "single"
+hpcsdk_default_cuda: "11.0"
+
+hpcsdk_temp_dir: "/tmp/hpc-sdk-install"
+hpcsdk_dest_download_path: "{{ hpcsdk_temp_dir }}/nvhpc.tar.gz"

--- a/roles/nvidia-hpc-sdk/defaults/main.yml
+++ b/roles/nvidia-hpc-sdk/defaults/main.yml
@@ -12,6 +12,7 @@ hpcsdk_version_dir: "20.7"
 
 hpcsdk_temp_dir: "/tmp/hpc-sdk-install"
 hpcsdk_dest_download_path: "{{ hpcsdk_temp_dir }}/nvhpc.tar.gz"
+hpcsdk_clean_up_temp_dir: true
 
 hpcsdk_install_as_modules: false
 hpcsdk_install_in_path: true

--- a/roles/nvidia-hpc-sdk/defaults/main.yml
+++ b/roles/nvidia-hpc-sdk/defaults/main.yml
@@ -8,6 +8,10 @@ hpcsdk_download_url: "https://developer.download.nvidia.com/hpc-sdk/{{ hpcsdk_do
 hpcsdk_install_dir: "/sw/hpc-sdk"
 hpcsdk_install_type: "single"
 hpcsdk_default_cuda: "11.0"
+hpcsdk_version_dir: "20.7"
 
 hpcsdk_temp_dir: "/tmp/hpc-sdk-install"
 hpcsdk_dest_download_path: "{{ hpcsdk_temp_dir }}/nvhpc.tar.gz"
+
+hpcsdk_install_as_modules: false
+hpcsdk_install_in_path: true

--- a/roles/nvidia-hpc-sdk/defaults/main.yml
+++ b/roles/nvidia-hpc-sdk/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 hpcsdk_version: "2020_207"
 hpcsdk_arch: "x86_64"
-hpcsdk_cuda: "multi"
+hpcsdk_cuda: "11.0"
 hpcsdk_download_name: "nvhpc_{{ hpcsdk_version }}_Linux_{{ hpcsdk_arch }}_cuda_{{ hpcsdk_cuda }}"
 hpcsdk_download_url: "https://developer.download.nvidia.com/hpc-sdk/{{ hpcsdk_download_name }}.tar.gz"
 

--- a/roles/nvidia-hpc-sdk/tasks/main.yml
+++ b/roles/nvidia-hpc-sdk/tasks/main.yml
@@ -49,6 +49,12 @@
     NVHPC_INSTALL_TYPE: "{{ hpcsdk_install_type }}"
     NVHPC_DEFAULT_CUDA: "{{ hpcsdk_default_cuda }}"
 
+- name: clean up the temp directory
+  file:
+    path: "{{ hpcsdk_temp_dir }}"
+    state: absent
+  when: hpcsdk_clean_up_temp_dir
+
 - name: run the makelocalrc script
   command: "{{ hpcsdk_install_dir }}/Linux_{{ hpcsdk_arch }}/{{ hpcsdk_version_dir }}/compilers/bin/makelocalrc -x {{ hpcsdk_install_dir }}/Linux_{{ hpcsdk_arch }}/{{ hpcsdk_version_dir }}/compilers"
   args:

--- a/roles/nvidia-hpc-sdk/tasks/main.yml
+++ b/roles/nvidia-hpc-sdk/tasks/main.yml
@@ -43,6 +43,7 @@
   with_items:
   - "z95_nvhpc.sh"
   - "z95_nvhpc.csh"
+  when: hpcsdk_install_in_path
 
 - name: add profile script to source modules
   template:

--- a/roles/nvidia-hpc-sdk/tasks/main.yml
+++ b/roles/nvidia-hpc-sdk/tasks/main.yml
@@ -33,7 +33,7 @@
     NVHPC_INSTALL_TYPE: "{{ hpcsdk_install_type }}"
     NVHPC_DEFAULT_CUDA: "{{ hpcsdk_default_cuda }}"
 
-- name: add profile script to source modules
+- name: add profile script to add to environment
   template:
     src: "{{ item }}"
     dest: "/etc/profile.d/{{ item }}"
@@ -43,3 +43,15 @@
   with_items:
   - "z95_nvhpc.sh"
   - "z95_nvhpc.csh"
+
+- name: add profile script to source modules
+  template:
+    src: "{{ item }}"
+    dest: "/etc/profile.d/{{ item }}"
+    owner: "root"
+    group: "root"
+    mode: "0644"
+  with_items:
+  - "z95_nvhpc_modules.sh"
+  - "z95_nvhpc_modules.csh"
+  when: hpcsdk_install_as_modules

--- a/roles/nvidia-hpc-sdk/tasks/main.yml
+++ b/roles/nvidia-hpc-sdk/tasks/main.yml
@@ -1,4 +1,19 @@
 ---
+- name: install dependencies (ubuntu)
+  apt:
+    name:
+    - "gcc"
+    - "g++"
+    state: present
+  when: ansible_distribution == "Ubuntu"
+
+- name: install dependencies (rhel)
+  yum:
+    name:
+    - "gcc"
+    - "gcc-c++"
+  when: ansible_os_family == "RedHat"
+
 - name: ensure download and install directories exist
   file:
     path: "{{ item }}"
@@ -27,11 +42,17 @@
   command: "./install"
   args:
     chdir: "{{ hpcsdk_temp_dir }}/{{ hpcsdk_download_name }}"
+    creates: "{{ hpcsdk_install_dir }}/Linux_{{ hpcsdk_arch }}/{{ hpcsdk_version_dir }}/compilers/bin/nvc"
   environment:
     NVHPC_SILENT: "true"
     NVHPC_INSTALL_DIR: "{{ hpcsdk_install_dir }}"
     NVHPC_INSTALL_TYPE: "{{ hpcsdk_install_type }}"
     NVHPC_DEFAULT_CUDA: "{{ hpcsdk_default_cuda }}"
+
+- name: run the makelocalrc script
+  command: "{{ hpcsdk_install_dir }}/Linux_{{ hpcsdk_arch }}/{{ hpcsdk_version_dir }}/compilers/bin/makelocalrc -x {{ hpcsdk_install_dir }}/Linux_{{ hpcsdk_arch }}/{{ hpcsdk_version_dir }}/compilers"
+  args:
+    creates: "{{ hpcsdk_install_dir }}/Linux_{{ hpcsdk_arch }}/{{ hpcsdk_version_dir }}/compilers/bin/localrc"
 
 - name: add profile script to add to environment
   template:

--- a/roles/nvidia-hpc-sdk/tasks/main.yml
+++ b/roles/nvidia-hpc-sdk/tasks/main.yml
@@ -1,0 +1,45 @@
+---
+- name: ensure download and install directories exist
+  file:
+    path: "{{ item }}"
+    state: "directory"
+    owner: "root"
+    group: "root"
+    mode: "0755"
+  with_items:
+  - "{{ hpcsdk_temp_dir }}"
+  - "{{ hpcsdk_install_dir }}"
+
+- name: download nvidia hpc sdk
+  get_url:
+    url: "{{ hpcsdk_download_url }}"
+    dest: "{{ hpcsdk_dest_download_path }}"
+    mode: "0444"
+
+- name: extract archive
+  unarchive:
+    src: "{{ hpcsdk_dest_download_path }}"
+    dest: "{{ hpcsdk_temp_dir }}"
+    remote_src: true
+    creates: "{{ hpcsdk_temp_dir }}/{{ hpcsdk_download_name }}/install"
+
+- name: run the installer
+  command: "./install"
+  args:
+    chdir: "{{ hpcsdk_temp_dir }}/{{ hpcsdk_download_name }}"
+  environment:
+    NVHPC_SILENT: "true"
+    NVHPC_INSTALL_DIR: "{{ hpcsdk_install_dir }}"
+    NVHPC_INSTALL_TYPE: "{{ hpcsdk_install_type }}"
+    NVHPC_DEFAULT_CUDA: "{{ hpcsdk_default_cuda }}"
+
+- name: add profile script to source modules
+  template:
+    src: "{{ item }}"
+    dest: "/etc/profile.d/{{ item }}"
+    owner: "root"
+    group: "root"
+    mode: "0644"
+  with_items:
+  - "z95_nvhpc.sh"
+  - "z95_nvhpc.csh"

--- a/roles/nvidia-hpc-sdk/templates/z95_nvhpc.csh
+++ b/roles/nvidia-hpc-sdk/templates/z95_nvhpc.csh
@@ -1,0 +1,2 @@
+#!/usr/bin/env csh
+setenv MODULEPATH = "$MODULEPATH:{{ hpcsdk_install_dir }}/modulefiles)"

--- a/roles/nvidia-hpc-sdk/templates/z95_nvhpc.csh
+++ b/roles/nvidia-hpc-sdk/templates/z95_nvhpc.csh
@@ -1,2 +1,6 @@
 #!/usr/bin/env csh
-setenv MODULEPATH = "$MODULEPATH:{{ hpcsdk_install_dir }}/modulefiles)"
+
+setenv NVARCH `uname -s`_`uname -m`
+setenv NVCOMPILERS {{ hpcsdk_install_dir }}
+setenv MANPATH "$MANPATH":$NVCOMPILERS/$NVARCH/{{ hpcsdk_version_dir }}/compilers/man
+set path = ($NVCOMPILERS/$NVARCH/{{ hpcsdk_version_dir }}/compilers/bin $path)

--- a/roles/nvidia-hpc-sdk/templates/z95_nvhpc.sh
+++ b/roles/nvidia-hpc-sdk/templates/z95_nvhpc.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+export MODULEPATH="${MODULEPATH:+$MODULEPATH:}{{ hpcsdk_install_dir }}/modulefiles"

--- a/roles/nvidia-hpc-sdk/templates/z95_nvhpc.sh
+++ b/roles/nvidia-hpc-sdk/templates/z95_nvhpc.sh
@@ -1,2 +1,6 @@
 #!/usr/bin/env bash
-export MODULEPATH="${MODULEPATH:+$MODULEPATH:}{{ hpcsdk_install_dir }}/modulefiles"
+
+export NVARCH="$(uname -s)_$(uname -m)"
+export NVCOMPILERS="{{ hpcsdk_install_dir }}"
+export MANPATH="${MANPATH:+$MANPATH:}{{ hpcsdk_install_dir }}/${NVCOMPILERS}/${NVARCH}/{{ hpcsdk_version_dir }}/compilers/man"
+export PATH="${NVCOMPILERS}/${NVARCH}/{{ hpcsdk_version_dir }}/compilers/bin:${PATH}"

--- a/roles/nvidia-hpc-sdk/templates/z95_nvhpc_modules.csh
+++ b/roles/nvidia-hpc-sdk/templates/z95_nvhpc_modules.csh
@@ -1,0 +1,2 @@
+#!/usr/bin/env csh
+setenv MODULEPATH = "$MODULEPATH:{{ hpcsdk_install_dir }}/modulefiles)"

--- a/roles/nvidia-hpc-sdk/templates/z95_nvhpc_modules.sh
+++ b/roles/nvidia-hpc-sdk/templates/z95_nvhpc_modules.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+export MODULEPATH="${MODULEPATH:+$MODULEPATH:}{{ hpcsdk_install_dir }}/modulefiles"

--- a/virtual/vars_files/virt_slurm.yml
+++ b/virtual/vars_files/virt_slurm.yml
@@ -6,3 +6,6 @@ hosts_network_interface: "eth1"
 slurm_allow_ssh_user:
 - "vagrant"
 - "root"
+
+# Don't install HPC SDK by default in virtual cluster, as it can run out of disk space
+slurm_install_hpcsdk: false

--- a/virtual/vars_files/virt_slurm.yml
+++ b/virtual/vars_files/virt_slurm.yml
@@ -7,5 +7,7 @@ slurm_allow_ssh_user:
 - "vagrant"
 - "root"
 
-# Don't install HPC SDK by default in virtual cluster, as it can run out of disk space
-slurm_install_hpcsdk: false
+# Perform cleanup tasks during the install to minimize disk space impact
+hpcsdk_clean_up_tarball_after_extract: true
+hpcsdk_clean_up_temp_dir: true
+slurm_build_dir_cleanup: true


### PR DESCRIPTION
* Add a playbook and role which will install and set up the HPC SDK
* Add the HPC SDK to Slurm clusters by default
* A little supporting work to ensure Modules are set up correctly

Note that because the HPC SDK may be installed either on a cluster, or on a stand-alone development workstation, we provide two options for setting up the environment:

* `hpcsdk_install_in_path`: Sets up profile scripts to put the HPC SDK in the user's default environment. Defaults to `true` in the role, but `false` in a Slurm cluster.
* `hpcsdk_install_as_modules`: Sets up profile scripts to add the HPC SDK Modulefiles to the `MODULEPATH`. Defaults to `false` in the role, but `true` in a Slurm cluster.

## Test plan

1. Turn up default virtual Slurm cluster. SSH to login node and confirm that the `nvhpc` module shows up in `module avail`.
1. Run the `nvidia-hpc-sdk.yml` playbook against an arbitrary node not in a Slurm cluster. SSH to the node and confirm that `nvc` shows up in the `PATH`.