### PR TITLE
Add flags to make NV driver and Singularity optional on Slurm clusters

### DIFF
--- a/config.example/group_vars/slurm-cluster.yml
+++ b/config.example/group_vars/slurm-cluster.yml
@@ -36,6 +36,8 @@ hosts_add_ansible_managed_hosts_groups: ["slurm-cluster"]
 ################################################################################
 slurm_cluster_install_cuda: yes
 slurm_cluster_install_openmpi: yes
+slurm_cluster_install_nvidia_driver: yes
+slurm_cluster_install_singularity: yes
 
 ################################################################################
 # NFS                                                                          #

--- a/config.example/group_vars/slurm-cluster.yml
+++ b/config.example/group_vars/slurm-cluster.yml
@@ -37,7 +37,7 @@ hosts_add_ansible_managed_hosts_groups: ["slurm-cluster"]
 slurm_cluster_install_cuda: yes
 slurm_cluster_install_openmpi: yes
 slurm_cluster_install_nvidia_driver: yes
-slurm_cluster_install_singularity: yes
+slurm_cluster_install_singularity: no
 
 ################################################################################
 # NFS                                                                          #

--- a/playbooks/slurm-cluster.yml
+++ b/playbooks/slurm-cluster.yml
@@ -17,6 +17,7 @@
 
 # Install NVIDIA driver
 - include: nvidia-driver.yml
+  when: slurm_cluster_install_nvidia_driver|default(true)
 
 # Install NVIDIA CUDA Toolkit
 - include: nvidia-cuda.yml
@@ -56,6 +57,7 @@
 
 # Install Singularity
 - include: singularity.yml
+  when: slurm_cluster_install_singularity|default(true)
 
 # Install Open OnDemand
 - include: open-ondemand.yml


### PR DESCRIPTION
In general we want DeepOps to set up a full-featured cluster, but sometimes we don't want that!

* The user may want to configure some components outside of DeepOps
* The user might not need some functionality, like containers
* Or the user might be a DeepOps developer trying to iterate quickly on some piece of code! 😉 

This PR adds new flags to make the NVIDIA driver install and Singularity install optional in Slurm clusters. With this change, all major software installs should now have optional flags except for Slurm itself, plus the minor administrative tasks for Ansible or Slurm to work.

## Test plan

Turned up a virtual cluster with `cluster_up.sh`, with Kubernetes disabled, Slurm enabled, and a vars file including the following:

```
slurm_cluster_install_cuda: no
slurm_cluster_install_openmpi: no
slurm_cluster_install_nvidia_driver: no
slurm_cluster_install_singularity: no
slurm_install_enroot: no
slurm_install_pyxis: no
slurm_enable_monitoring: no
slurm_enable_nfs_server: no
slurm_enable_nfs_client_nodes: no
chrony_install: no
allow_user_set_gpu_clocks: no
```

This gets me a minimally-functional Slurm cluster!

```
$ vagrant ssh virtual-login01
Last login: Tue Aug 11 19:36:44 2020 from 10.0.0.1
vagrant@virtual-login01:~$ srun -N1 hostname
virtual-gpu01
```

And the total turnup time is 13m10s, vs usually taking >25m.