### PR TITLE
Fix broken Kubeflow deployment (version bump + improved test)

### DIFF
--- a/.jenkins-scripts/test-kubeflow-pipeline.py
+++ b/.jenkins-scripts/test-kubeflow-pipeline.py
@@ -1,4 +1,5 @@
 import kfp
+import kfp_server_api
 import json
 import time
 
@@ -17,11 +18,20 @@ def test_kubeflow_op():
 kfp.compiler.Compiler().compile(test_kubeflow_op, 'kubeflow-test.yml')
 
 # Connect to Kubeflow and create job, this simply rungs RAPIDS and prints out a message                 
-run_result = kfp.Client(host=None).create_run_from_pipeline_package('kubeflow-test.yml', arguments={})    
+while True:
+    try:
+        print("Submitting Kubeflow pipeline")
+        run_result = kfp.Client(host=None).create_run_from_pipeline_package('kubeflow-test.yml', arguments={})
+        break # This means it worked!
+    except kfp_server_api.rest.ApiException as e:
+        print("Hit an error, waiting and trying again: {}".format(e))
+        time.sleep(30) # Occassionally Kubeflow fails to respond even when all deployments are up. I don't know why, sometimes it is a 403, sometimes a 500, and sometimes it works. So we will just wait and re-try until the test/script times out.
 
 for i in range(70): # The test .sh times out after 600 seconds. So we run a little longer than that. This accounts mostly for NGC download time.
+    print("Polling for pipeline status: {}".format(i))
     status = kfp.Client(host=None).get_run(run_result.run_id).run.status
     if status == "Succeeded":
         print("SUCCESS: Kubeflow launched a container successfully")
         break
+    print("Got {}, waiting some more...".format(status))
     time.sleep(10) # Wait 10 seconds and poll

--- a/.jenkins-scripts/test-kubeflow-pipeline.py
+++ b/.jenkins-scripts/test-kubeflow-pipeline.py
@@ -28,7 +28,7 @@ while True:
         time.sleep(30) # Occassionally Kubeflow fails to respond even when all deployments are up. I don't know why, sometimes it is a 403, sometimes a 500, and sometimes it works. So we will just wait and re-try until the test/script times out.
 
 for i in range(70): # The test .sh times out after 600 seconds. So we run a little longer than that. This accounts mostly for NGC download time.
-    print("Polling for pipeline status: {}".format(i))
+    print("Polling for pipeline status: {} - {}".format(run_result, i))
     status = kfp.Client(host=None).get_run(run_result.run_id).run.status
     if status == "Succeeded":
         print("SUCCESS: Kubeflow launched a container successfully")

--- a/.jenkins-scripts/test-kubeflow-pipeline.sh
+++ b/.jenkins-scripts/test-kubeflow-pipeline.sh
@@ -16,4 +16,5 @@ export KUBEFLOW_DEPLOYMENTS="profiles-deployment centraldashboard ml-pipeline mi
 kubectl get pods -n kubeflow # Do this for debug purposes
 
 # Run the Kubeflow pipeline test, this will build a pipeline that launches an NGC container
-timeout 600 python3 .jenkins-scripts/test-kubeflow-pipeline.py
+# For some reason the initial pipeline creation hangs sometime (and doesn't timeout or error out or provide any logging) so we run this twice until success or timeout
+timeout 600 python3 .jenkins-scripts/test-kubeflow-pipeline.py || timeout 600 python3 .jenkins-scripts/test-kubeflow-pipeline.py

--- a/.jenkins-scripts/test-kubeflow-pipeline.sh
+++ b/.jenkins-scripts/test-kubeflow-pipeline.sh
@@ -12,7 +12,6 @@ sudo pip3 install kfp
 # Don't wait for katib or a few other things that take longer to initialize
 export KUBEFLOW_DEPLOYMENTS="profiles-deployment centraldashboard ml-pipeline minio mysql metadata-db"
 ./scripts/k8s_deploy_kubeflow.sh -w
-sleep 60 # Do this to allow appropriate "kubeflow initialization" time
 
 kubectl get pods -n kubeflow # Do this for debug purposes
 

--- a/jenkins/Jenkinsfile-multi-nightly
+++ b/jenkins/Jenkinsfile-multi-nightly
@@ -56,16 +56,6 @@ pipeline {
              timeout 1500 bash -x ./.jenkins-scripts/test-kubeflow.sh
           '''
 
-          echo "Test Kubeflow pipeline"
-          sh '''
-             timeout 1500 bash -x ./.jenkins-scripts/test-kubeflow-pipeline.sh
-          '''
-
-          echo "Test Kubeflow pipeline"
-          sh '''
-             timeout 1500 bash -x ./.jenkins-scripts/test-kubeflow-pipeline.sh
-          '''
-
           echo "Test Monitoring installation"
           sh '''
              timeout 800 bash -x ./.jenkins-scripts/test-monitoring.sh
@@ -74,6 +64,11 @@ pipeline {
           echo "Test Dashboard installation"
           sh '''
              timeout 180 bash -x ./.jenkins-scripts/test-dashboard.sh
+          '''
+
+          echo "Test Kubeflow pipeline"
+          sh '''
+             timeout 1500 bash -x ./.jenkins-scripts/test-kubeflow-pipeline.sh
           '''
 
           echo "Start new virtual environment pre-Slurm checks"
@@ -149,16 +144,6 @@ pipeline {
              timeout 1500 bash -x ./.jenkins-scripts/test-kubeflow.sh
           '''
 
-          echo "Test Kubeflow pipeline"
-          sh '''
-             timeout 1500 bash -x ./.jenkins-scripts/test-kubeflow-pipeline.sh
-          '''
-
-          echo "Test Kubeflow pipeline"
-          sh '''
-             timeout 1500 bash -x ./.jenkins-scripts/test-kubeflow-pipeline.sh
-          '''
-
           echo "Test Monitoring installation"
           sh '''
              timeout 800 bash -x ./.jenkins-scripts/test-monitoring.sh
@@ -167,6 +152,11 @@ pipeline {
           echo "Test Dashboard installation"
           sh '''
              timeout 180 bash -x ./.jenkins-scripts/test-dashboard.sh
+          '''
+
+          echo "Test Kubeflow pipeline"
+          sh '''
+             timeout 1500 bash -x ./.jenkins-scripts/test-kubeflow-pipeline.sh
           '''
 
           echo "Start new virtual environment pre-Slurm checks"

--- a/jenkins/Jenkinsfile-nightly
+++ b/jenkins/Jenkinsfile-nightly
@@ -56,11 +56,6 @@ pipeline {
              timeout 1500 bash -x ./.jenkins-scripts/test-kubeflow.sh
           '''
 
-          echo "Test Kubeflow pipeline"
-          sh '''
-             timeout 1500 bash -x ./.jenkins-scripts/test-kubeflow-pipeline.sh
-          '''
-
           echo "Test Monitoring installation"
           sh '''
              timeout 800 bash -x ./.jenkins-scripts/test-monitoring.sh
@@ -69,6 +64,11 @@ pipeline {
           echo "Test Dashboard installation"
           sh '''
              timeout 180 bash -x ./.jenkins-scripts/test-dashboard.sh
+          '''
+
+          echo "Test Kubeflow pipeline"
+          sh '''
+             timeout 1500 bash -x ./.jenkins-scripts/test-kubeflow-pipeline.sh
           '''
 
           echo "Start new virtual environment pre-Slurm checks"
@@ -144,11 +144,6 @@ pipeline {
              timeout 1500 bash -x ./.jenkins-scripts/test-kubeflow.sh
           '''
 
-          echo "Test Kubeflow pipeline"
-          sh '''
-             timeout 1500 bash -x ./.jenkins-scripts/test-kubeflow-pipeline.sh
-          '''
-
           echo "Test Monitoring installation"
           sh '''
              timeout 800 bash -x ./.jenkins-scripts/test-monitoring.sh
@@ -157,6 +152,11 @@ pipeline {
           echo "Test Dashboard installation"
           sh '''
              timeout 180 bash -x ./.jenkins-scripts/test-dashboard.sh
+          '''
+
+          echo "Test Kubeflow pipeline"
+          sh '''
+             timeout 1500 bash -x ./.jenkins-scripts/test-kubeflow-pipeline.sh
           '''
 
           echo "Start new virtual environment pre-Slurm checks"

--- a/scripts/k8s_deploy_kubeflow.sh
+++ b/scripts/k8s_deploy_kubeflow.sh
@@ -34,7 +34,7 @@ export AUTH_CONFIG_URI="https://raw.githubusercontent.com/kubeflow/manifests/55d
 export AUTH_CONFIG_FILE="${KF_DIR}/kfctl_istio_dex.v1.0.2.yaml" # https://github.com/kubeflow/manifests/releases/tag/v1.0.2
 
 # Config 2: https://www.kubeflow.org/docs/started/k8s/kfctl-k8s-istio/
-export CONFIG_URI="https://raw.githubusercontent.com/kubeflow/manifests/928cf483361730121ac18bc4d0e7a9c129f15ee2/kfdef/kfctl_k8s_istio.yaml"
+export CONFIG_URI="https://raw.githubusercontent.com/kubeflow/manifests/master/kfdef/kfctl_k8s_istio.yaml" # Not a hash or branch tag because of https://github.com/kubeflow/manifests/pull/1459
 export CONFIG_FILE="${KF_DIR}/kfctl_k8s_istio.yaml" #  Not v1.0.2 due to https://github.com/kubeflow/manifests/issues/991
 
 


### PR DESCRIPTION
A few days ago some Tensorboard packages disappeared and there was a hotfix pushed out to the istio manifest.

This PR:

1. Bumps Kubeflow to use the latest manifest/version
2. Wraps some better debuging/logic into the Kubeflow pipeline test to check this