### PR TITLE
WIP: default to using GPU operator for NVIDIA driver, etc

### DIFF
--- a/config.example/group_vars/k8s-cluster.yml
+++ b/config.example/group_vars/k8s-cluster.yml
@@ -18,7 +18,7 @@ kubelet_flexvolumes_plugins_dir: /usr/libexec/kubernetes/kubelet-plugins/volume/
 
 # Provide option to use GPU Operator instead of setting up NVIDIA driver and
 # Docker configuration.
-deepops_gpu_operator_enabled: false
+deepops_gpu_operator_enabled: true
 
 # When set to true, enables the PodSecurityPolicy admission controller and
 # defines two policies: privileged (applying to all resources in kube-system


### PR DESCRIPTION
I'm going to propose that we should use the GPU operator by default for Kubernetes under DeepOps.

Right now I just want to see how this PR does under our CI tests, as I'm not sure how this will interact with our Slurm tests. 😛 So please don't merge this, even though it's not marked as a draft PR in Github. I just want to see the CI tests fail (or pass!) and how.