### PR TITLE
Increase a few timeouts to try to address CI failures

### DIFF
--- a/.jenkins-scripts/run-gpu-job.sh
+++ b/.jenkins-scripts/run-gpu-job.sh
@@ -13,7 +13,7 @@ kubectl describe nodes
 
 # Occassionally this gpu-test fails and/or hangs. To ease debugging of this we run a describe several seconds into the launch.
 sleep 10 && kubectl describe pods gpu-test &
-timeout 120 kubectl run gpu-test --rm -t -i --restart=Never --image=nvidia/cuda --limits=nvidia.com/gpu=1 -- nvidia-smi
+timeout 300 kubectl run gpu-test --rm -t -i --restart=Never --image=nvidia/cuda --limits=nvidia.com/gpu=1 -- nvidia-smi
 
 # Run multi-GPU test
 if [ "${DEEPOPS_FULL_INSTALL}" ]; then

--- a/scripts/k8s_deploy_loadbalancer.sh
+++ b/scripts/k8s_deploy_loadbalancer.sh
@@ -38,4 +38,4 @@ if ! helm status metallb >/dev/null 2>&1; then
 	helm install metallb stable/metallb "${helm_install_args[@]}"
 fi
 
-kubectl wait --for=condition=Ready -l app=metallb,component=controller pod
+kubectl wait --timeout=120s --for=condition=Ready -l app=metallb,component=controller pod


### PR DESCRIPTION
Testing locally on CentOS I saw a few timeouts in the common path for k8s deployment.

- MetalLB deployment takes >30s
- GPU test job took ~4 minutes before completing

## Test plan

Ran with the increased timeouts, and saw both jobs succeed.