### PR TITLE
 use ansible_ssh_private_key_file + '.pub' in slurm.yml, don't assume id_rsa

### DIFF
--- a/config.example/group_vars/k8s-cluster.yml
+++ b/config.example/group_vars/k8s-cluster.yml
@@ -34,3 +34,6 @@ dashboard_image_repo: "kubernetesui/dashboard"
 
 # kubespray v2.13.1 deploys helm v3.1.2
 helm_version: "v3.1.2"
+
+# Ensure hosts file generation only runs across k8s cluster
+hosts_add_ansible_managed_hosts_groups: ["k8s-cluster"]

--- a/playbooks/slurm.yml
+++ b/playbooks/slurm.yml
@@ -12,7 +12,7 @@
       authorized_key:
         user: root
         state: present
-        key: "{{ lookup('file', lookup('env','HOME') + '/.ssh/id_rsa.pub') }}"
+        key: "{{ lookup('file', ansible_ssh_private_key_file | default(lookup('env','HOME') + '/.ssh/id_rsa') + '.pub') }}"
 
 # Build slurm first on all nodes
 - hosts: slurm-cluster

--- a/roles/nvidia-gpu-operator/tasks/main.yml
+++ b/roles/nvidia-gpu-operator/tasks/main.yml
@@ -2,13 +2,13 @@
 # While we would prefer to use the Ansible helm module, it's broken! :-(
 # See https://github.com/ansible/ansible/pull/57897
 # Unfortunately this will not be fixed until Ansible 2.10 which is not yet released.
-# So for now we will run helm commands directly...
+# So for now we will run /usr/local/bin/helm commands directly...
 
 - name: install gpu-operator helm repo
-  command: helm repo add nvidia "{{ gpu_operator_helm_repo }}"
+  command: /usr/local/bin/helm repo add nvidia "{{ gpu_operator_helm_repo }}"
 
 - name: update helm repos
-  command: helm repo update
+  command: /usr/local/bin/helm repo update
 
 - name: install nvidia gpu operator
-  command: helm upgrade --install "{{ gpu_operator_release_name }}" "{{ gpu_operator_chart_name }}" --version "{{ gpu_operator_chart_version }}" --wait
+  command: /usr/local/bin/helm upgrade --install "{{ gpu_operator_release_name }}" "{{ gpu_operator_chart_name }}" --version "{{ gpu_operator_chart_version }}" --wait

--- a/roles/nvidia-k8s-gpu-device-plugin/tasks/main.yml
+++ b/roles/nvidia-k8s-gpu-device-plugin/tasks/main.yml
@@ -5,10 +5,10 @@
 # So for now we will run helm commands directly...
 
 - name: install nvidia k8s gpu device plugin helm repo
-  command: helm repo add nvdp "{{ k8s_gpu_plugin_helm_repo }}"
+  command: /usr/local/bin/helm repo add nvdp "{{ k8s_gpu_plugin_helm_repo }}"
 
 - name: update helm repos
-  command: helm repo update
+  command: /usr/local/bin/helm repo update
 
 - name: install nvidia k8s gpu device plugin
-  command: helm upgrade --install "{{ k8s_gpu_plugin_release_name }}" "{{ k8s_gpu_plugin_chart_name }}" --version "{{ k8s_gpu_plugin_chart_version }}" --wait
+  command: /usr/local/bin/helm upgrade --install "{{ k8s_gpu_plugin_release_name }}" "{{ k8s_gpu_plugin_chart_name }}" --version "{{ k8s_gpu_plugin_chart_version }}" --wait


### PR DESCRIPTION
The slurm.yml was always using /home/$USER/.ssh/id_rsa.pub.

Now it uses {{ ansible_ssh_private_key_file  }}.pub if ansible_ssh_private_key_file  is set.
