### PR TITLE
Ensure Lmod role can run cleanly stand-alone on Ubuntu and CentOS

### DIFF
--- a/roles/lmod/defaults/main.yml
+++ b/roles/lmod/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+lmod_rhel_epel_repo_baseurl: "https://download.fedoraproject.org/pub/epel/$releasever/$basearch/"
+lmod_rhel_epel_repo_gpgkey: "https://epel.mirror.constant.com//RPM-GPG-KEY-EPEL-{{ ansible_distribution_major_version }}"

--- a/roles/lmod/defaults/main.yml
+++ b/roles/lmod/defaults/main.yml
@@ -1,3 +1,9 @@
 ---
 lmod_rhel_epel_repo_baseurl: "https://download.fedoraproject.org/pub/epel/$releasever/$basearch/"
 lmod_rhel_epel_repo_gpgkey: "https://epel.mirror.constant.com//RPM-GPG-KEY-EPEL-{{ ansible_distribution_major_version }}"
+
+# include some reasonable defaults for module paths
+sm_prefix: "/sw"
+sm_module_root: "{{ sm_prefix }}/modules"
+sm_module_path: "{{ sm_module_root }}/all"
+sm_software_path: "{{ sm_prefix }}/software"

--- a/roles/lmod/tasks/main.yml
+++ b/roles/lmod/tasks/main.yml
@@ -4,12 +4,21 @@
 ---
 - name: "install packages"
   become: yes
-  action: apt name=lmod state=latest
+  apt:
+    name:
+    - bash
+    - tcsh
+    - lmod
+    state: present
   when: ansible_os_family == "Debian"
 
 - name: "install packages"
   become: yes
-  action: yum name=Lmod state=latest
+  yum:
+    name:
+    - bash
+    - tcsh
+    - Lmod
   when: ansible_os_family == "RedHat"
 
 - name: "mkdir software path"
@@ -72,7 +81,7 @@
   when: ansible_os_family == "Debian"
 
 - name: "auto load lmod "
-  shell: . /etc/profile.d/z00_lmod.csh
+  shell: source /etc/profile.d/z00_lmod.csh
   args:
     executable: /bin/csh
   when: ansible_os_family == "RedHat"

--- a/roles/lmod/tasks/main.yml
+++ b/roles/lmod/tasks/main.yml
@@ -37,7 +37,6 @@
     owner: root
     group: root
     mode: 0777
-  when: ansible_os_family == "Debian"
   tags:
     - configuration
 
@@ -49,7 +48,6 @@
     owner: root
     group: root
     mode: 0777
-  when: ansible_os_family == "RedHat"
   tags:
     - configuration
 
@@ -66,23 +64,18 @@
   shell: unset MODULEPATH_ROOT
   args:
     executable: /bin/bash
-  when: ansible_os_family == "Debian"
 
 - name: "unset previous lmod setup"
   shell: unsetenv MODULEPATH_ROOT
   args:
     executable: /bin/csh
-  when: ansible_os_family == "RedHat"
 
 - name: "auto load lmod"
   shell: . /etc/profile.d/z00_lmod.sh
   args:
     executable: /bin/bash
-  when: ansible_os_family == "Debian"
 
 - name: "auto load lmod "
   shell: source /etc/profile.d/z00_lmod.csh
   args:
     executable: /bin/csh
-  when: ansible_os_family == "RedHat"
-  

--- a/roles/lmod/tasks/main.yml
+++ b/roles/lmod/tasks/main.yml
@@ -2,6 +2,14 @@
 # ansible role to install lmod:
 #
 ---
+- name: RedHat | add epel repo
+  yum_repository:
+    name: epel
+    description: EPEL YUM repo
+    baseurl: "{{ lmod_rhel_epel_repo_baseurl }}"
+    gpgkey: "{{ lmod_rhel_epel_repo_gpgkey }}"
+  environment: "{{proxy_env if proxy_env is defined else {}}}"
+
 - name: "install packages"
   become: yes
   apt:

--- a/roles/lmod/tasks/main.yml
+++ b/roles/lmod/tasks/main.yml
@@ -9,6 +9,7 @@
     baseurl: "{{ lmod_rhel_epel_repo_baseurl }}"
     gpgkey: "{{ lmod_rhel_epel_repo_gpgkey }}"
   environment: "{{proxy_env if proxy_env is defined else {}}}"
+  when: ansible_os_family == "RedHat"
 
 - name: "install packages"
   become: yes

--- a/roles/lmod/templates/z00_lmod.csh
+++ b/roles/lmod/templates/z00_lmod.csh
@@ -38,7 +38,7 @@ if ( ! $?MODULEPATH_ROOT ) then
     #
     # If MANPATH is empty, Lmod is adding a trailing ":" so that
     # the system MANPATH will be found
-    if ( -z "$MANPATH" ) then
+    if (! $?MANPATH ) then
       setenv MANPATH :
     endif
     setenv MANPATH `/usr/share/lmod/lmod/libexec/addto MANPATH /usr/share/lmod/lmod/share/man`

--- a/roles/lmod/templates/z00_lmod.csh
+++ b/roles/lmod/templates/z00_lmod.csh
@@ -31,7 +31,7 @@ if ( ! $?MODULEPATH_ROOT ) then
     setenv MODULEPATH_ROOT      "{{ sm_module_root }}"
     # setenv MODULEPATH           `/usr/share/lmod/lmod/libexec/addto --append MODULEPATH $MODULEPATH_ROOT/$LMOD_sys $MODULEPATH_ROOT/Core`
     # setenv MODULEPATH           `/usr/share/lmod/lmod/libexec/addto --append MODULEPATH /usr/share/lmod/lmod/modulefiles/Core`
-    setenv MODULEPATH           "{{ eb_modulepath }}"
+    setenv MODULEPATH           "{{ sm_module_path }}"
     setenv MODULESHOME          "/usr/share/lmod/lmod"
     setenv BASH_ENV             "$MODULESHOME/init/bash"
 


### PR DESCRIPTION
Currently the Lmod role and playbook can only run successfully on Ubuntu, and even then only as part of the `slurm-cluster.yml` playbook, because they depend on steps performed by earlier playbooks.

This PR makes a few changes to ensure the `lmod.yml` playbook can execute on its own, on both Ubuntu and CentOS.

* Make sure shells are installed
* Correct syntax for csh
* Correct variable names in csh profile script
* Ensure both shells are used in each OS
* Ensure `lmod` role includes sufficient variable defaults that it can run cleanly outside a slurm cluster
* Make sure `epel` repo is present so we can install Lmod

## Test plan

Run the lmod playbook on CentOS and on Ubuntu. The playbook should succeed rather than exiting with an error.

```
ansible-playbook playbooks/lmod.yml
```