### PR TITLE
K8s dashboard version updates and access fixes

### DIFF
--- a/.jenkins-scripts/test-dashboard.sh
+++ b/.jenkins-scripts/test-dashboard.sh
@@ -13,7 +13,7 @@ source ./scripts/k8s_deploy_dashboard_user.sh
 timeout=120
 time=0
 while [ ${time} -lt ${timeout} ]; do
-  curl -ks --raw -L "${dashboard_url}" && \
+  curl -ks --raw -kL "${dashboard_url}" | grep "Kubernetes Dashboard" && \
     echo "Dashboard URLs are all responding" && exit 0
   let time=$time+15
   sleep 15

--- a/config.example/group_vars/k8s-cluster.yml
+++ b/config.example/group_vars/k8s-cluster.yml
@@ -26,11 +26,12 @@ deepops_gpu_operator_enabled: false
 # Addons deployed in kube-system namespaces are handled.
 #podsecuritypolicy_enabled: false
 
-# kubespray v2.12.2 deploys dashboard 1.10.1 which is no longer supported in k8s 1.16
-# https://github.com/kubernetes/dashboard/issues/4401#issuecomment-540476478
+# Pin the version of kubespray dashboard https://github.com/kubernetes/dashboard/releases/tag/v2.0.3
 dashboard_enabled: true
-dashboard_image_tag: "v2.0.0-rc5"
+dashboard_image_tag: "v2.0.3"
 dashboard_image_repo: "kubernetesui/dashboard"
+dashboard_metrics_scrape_tagr: "v1.0.4"
+dashboard_metrics_scraper_repo: "kubernetesui/metrics-scraper"
 
 # kubespray v2.13.1 deploys helm v3.1.2
 helm_version: "v3.1.2"

--- a/scripts/k8s_deploy_dashboard_user.sh
+++ b/scripts/k8s_deploy_dashboard_user.sh
@@ -9,12 +9,13 @@ if [ $? -eq 0 ] ; then
 fi
 
 # Get IP of first master
+dashboard_port=$(kubectl -n kube-system get svc kubernetes-dashboard --no-headers -o custom-columns=PORT:.spec.ports.*.nodePort)
 master_ip=$(kubectl get nodes -l node-role.kubernetes.io/master= --no-headers -o custom-columns=IP:.status.addresses.*.address | cut -f1 -d, | head -1)
 
 # Get access token
 token=$(kubectl -n kube-system describe secret $(kubectl -n kube-system get secret | grep admin-user | awk '{print $1}') | grep ^token: | awk '{print $2}')
 
-export dashboard_url="https://${master_ip}:31443"
+export dashboard_url="https://${master_ip}:${dashboard_port}"
 
 # Print Dashboard address
 echo

--- a/scripts/k8s_deploy_dashboard_user.sh
+++ b/scripts/k8s_deploy_dashboard_user.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# Make the dashboard a NodePort
+kubectl patch svc -n kube-system kubernetes-dashboard  -p '{"spec": {"type": "NodePort", "ports": [{"nodePort": 31443, "port": 443}] }}'
+
 kubectl -n kube-system get sa admin-user 2>&1 | grep "NotFound" >/dev/null 2>&1
 if [ $? -eq 0 ] ; then
     kubectl apply -f services/k8s-dashboard-admin.yml
@@ -11,7 +14,8 @@ master_ip=$(kubectl get nodes -l node-role.kubernetes.io/master= --no-headers -o
 # Get access token
 token=$(kubectl -n kube-system describe secret $(kubectl -n kube-system get secret | grep admin-user | awk '{print $1}') | grep ^token: | awk '{print $2}')
 
-export dashboard_url="https://${master_ip}:6443/api/v1/namespaces/kube-system/services/https:kubernetes-dashboard:/proxy/#!/login"
+export dashboard_url="https://${master_ip}:31443"
+
 # Print Dashboard address
 echo
 echo "Dashboard is available at: ${dashboard_url}"


### PR DESCRIPTION
Addressess https://github.com/NVIDIA/deepops/issues/631

* Bump version of kubernetes dashboard from v2.0.0-rc5 to v2.0.3 along with metrics-scraper
* Update Jenkins test to ignore ssl warning and validate the response of the dashboard
* Update dashboard deployment script to create a NodePort at `31443`, the existing access method no longer worked.