### PR TITLE
[nvidia-mig] Remove unnecessary steps and only reset services if MIG mode changes are needed

### DIFF
--- a/playbooks/nvidia-mig.yml
+++ b/playbooks/nvidia-mig.yml
@@ -5,19 +5,15 @@
   become: yes
 
   vars:
+    # Various services referencing nvidia GPUs, that need to be stopped when
+    # toggling MIG mode.
+    #
+    # Notably nvidia-persistenced and fabric-manager handle MIG and GPU resets
+    # already and don't need to be stopped.
     nv_services:
-      - nvsm
-      - nvidia-persistenced
-      - nvidia-fabricmanager
-      - nv_peer_mem
-      - dcgm
-      - docker
-    nv_modules:
-      - nv_peer_mem
-      - nvidia_uvm
-      - nvidia_drm
-      - nvidia_modeset
-      - nvidia
+      - dcgm.service
+      - nvsm.service
+      - docker.service
 
   tasks:
     # Check for MIG-capable devices
@@ -26,73 +22,34 @@
       register: has_mig
 
     # Pre-tasks
-    - name: stop system services
+    - name: collect facts about services
+      service_facts:
+      tags: enable, disable, never
+
+    - name: stop system services referencing nvidia
       systemd:
         state: stopped
-        enabled: no
         name: "{{ item }}"
-      with_items: "{{ nv_services }}"
-      tags: enable, disable, never
-    - name: unload drivers
-      modprobe:
-        state: absent
-        name: "{{ item }}"
-      with_items: "{{ nv_modules }}"
+      loop: "{{ nv_services }}"
+      when: item in ansible_facts.services and ansible_facts.services[item].state == "running"
       tags: enable, disable, never
 
     # Manage MIG
     - name: enable MIG mode
       command: nvidia-smi -mig 1
       tags: enable, never
+
     - name: disable MIG mode
       command: nvidia-smi -mig 0
       tags: disable, never
 
     # Post-tasks
-    - name: wait for MIG stuff to settle down and nvidia-persistenced to start again
-      pause:
-        seconds: 20
-      tags: enable, disable, never
-    - name: stop system services
-      systemd:
-        state: stopped
-        enabled: no
-        name: "{{ item }}"
-      with_items: "{{ nv_services }}"
-      tags: enable, disable, never
-    - name: unload drivers
-      modprobe:
-        state: absent
-        name: "{{ item }}"
-      with_items: "{{ nv_modules }}"
-      tags: enable, disable, never
-    - name: start fabric manager
+    - name: restart system services referencing nvidia
       systemd:
         state: started
-        name: nvidia-fabricmanager
-      tags: enable, disable, never
-    - name: stop nvidia-persistenced again
-      systemd:
-        state: stopped
-        name: nvidia-persistenced
-      tags: enable, disable, never
-    - name: reset GPUs
-      command: nvidia-smi --gpu-reset
-      tags: enable, disable, never
-    - name: load drivers
-      modprobe:
-        state: present
         name: "{{ item }}"
-      with_items: "{{ nv_modules }}"
-      ignore_errors: true
-      tags: enable, disable, never
-    - name: start system services
-      systemd:
-        state: started
-        enabled: yes
-        name: "{{ item }}"
-      with_items: "{{ nv_services }}"
-      ignore_errors: true
+      loop: "{{ nv_services }}"
+      when: item in ansible_facts.services and ansible_facts.services[item].state == "running"
       tags: enable, disable, never
 
     # Permissions

--- a/playbooks/nvidia-mig.yml
+++ b/playbooks/nvidia-mig.yml
@@ -15,42 +15,83 @@
       - nvsm.service
       - docker.service
 
+    # By default assume no changes are needed. Set to True as needed.
+    need_changes: False
+
   tasks:
     # Check for MIG-capable devices
-    - name: check for MIG capable devices
+    - name: Query MIG mode
       command: nvidia-smi --query-gpu=pci.bus_id,mig.mode.current --format=csv,noheader
-      register: has_mig
+      register: mig_status
+      tags: always
 
-    # Pre-tasks
-    - name: collect facts about services
-      service_facts:
+    - name: Count GPUs with MIG enabled, disabled and N/A
+      set_fact:
+        mig_enabled_count: "{{ mig_status.stdout | regex_findall(\"Enabled\") | length }}"
+        mig_disabled_count: "{{ mig_status.stdout | regex_findall(\"Disabled\") | length }}"
+        mig_not_available_count: "{{ mig_status.stdout | regex_findall(\"(\\[N/A\\])\") | length }}"
+      tags: always
+
+    # Fail if MIG is requested to be enabled, but no GPUs support MIG. The
+    # opposite is considered ok as a GPU with no MIG support can be considered
+    # having it always disabled.
+    - fail:
+        msg: "No GPUs supporting MIG found while MIG was requested to be enabled."
+      when: mig_enabled_count == "0" and mig_disabled_count == "0"
+      tags: enable
+
+    - name: Check that we need to enable MIG on any GPUs
+      set_fact:
+        need_changes: True
+      when: mig_disabled_count != "0"
+      tags: enable
+
+    - name: Check that we need to disable MIG on any GPUs
+      set_fact:
+        need_changes: True
+      when: mig_enabled_count != "0"
+      tags: disable
+
+    - name: Display info if no MIG changes are needed
+      debug:
+        msg: "All GPUs in the desired MIG state already, skipping most of the other tasks."
+      when: not need_changes
       tags: enable, disable, never
 
-    - name: stop system services referencing nvidia
-      systemd:
-        state: stopped
-        name: "{{ item }}"
-      loop: "{{ nv_services }}"
-      when: item in ansible_facts.services and ansible_facts.services[item].state == "running"
-      tags: enable, disable, never
+    - name: Apply new MIG mode settings
+      block:
+        # Pre-tasks
+        - name: collect facts about services
+          service_facts:
+          tags: enable, disable, never
 
-    # Manage MIG
-    - name: enable MIG mode
-      command: nvidia-smi -mig 1
-      tags: enable, never
+        - name: stop system services referencing nvidia
+          systemd:
+            state: stopped
+            name: "{{ item }}"
+          loop: "{{ nv_services }}"
+          when: item in ansible_facts.services and ansible_facts.services[item].state == "running"
+          tags: enable, disable, never
 
-    - name: disable MIG mode
-      command: nvidia-smi -mig 0
-      tags: disable, never
+        # Manage MIG
+        - name: enable MIG mode
+          command: nvidia-smi -mig 1
+          tags: enable, never
 
-    # Post-tasks
-    - name: restart system services referencing nvidia
-      systemd:
-        state: started
-        name: "{{ item }}"
-      loop: "{{ nv_services }}"
-      when: item in ansible_facts.services and ansible_facts.services[item].state == "running"
-      tags: enable, disable, never
+        - name: disable MIG mode
+          command: nvidia-smi -mig 0
+          tags: disable, never
+
+        # Post-tasks
+        - name: restart system services referencing nvidia
+          systemd:
+            state: started
+            name: "{{ item }}"
+          loop: "{{ nv_services }}"
+          when: item in ansible_facts.services and ansible_facts.services[item].state == "running"
+          tags: enable, disable, never
+
+      when: need_changes
 
     # Permissions
     - name: grant user permissions to manage MIG instances


### PR DESCRIPTION
Enabling MIG mode requires a GPU reset, but nvidia-smi -mig 0/1 takes
care of it already, as long as there are no daemons or other processes
getting in the way. There are also two daemons that do handshake
explicitly with nvidia-smi for GPU reset, namely nvidia-fabricmanager
and nvidia-persistenced, and they do not need to be stopped.

It's also unnecessary to unload any nvidia modules, or stop the
nv_peer_memory service that only loads/unloads modules.

Fix all of that. And also make sure to only restart daemons that were
actually running when the playbook was executed, and stop enabling any
of them.