### PR TITLE
Final fix for Kubeflow Pipeline test

### DIFF
--- a/.jenkins-scripts/test-kubeflow-pipeline.py
+++ b/.jenkins-scripts/test-kubeflow-pipeline.py
@@ -10,8 +10,8 @@ import time
 def test_kubeflow_op():
     op = kfp.dsl.ContainerOp(
       name='kubeflow-test-op',
-      image='nvcr.io/nvidia/rapidsai/rapidsai:cuda10.1-runtime-centos7',
-      command=["/bin/bash", "-cx"],
+      image='busybox',
+      command=["/bin/sh", "-cx"],
       arguments=["echo 'Container started!'"],
       file_outputs={}
       )                 
@@ -19,19 +19,19 @@ kfp.compiler.Compiler().compile(test_kubeflow_op, 'kubeflow-test.yml')
 
 # Connect to Kubeflow and create job, this simply rungs RAPIDS and prints out a message                 
 while True:
+    time.sleep(30) # Occassionally Kubeflow fails to respond even when all deployments are up. I don't know why, sometimes it is a 403, sometimes a 500, and sometimes it works. So we will just wait and re-try until the test/script times out.
     try:
         print("Submitting Kubeflow pipeline")
         run_result = kfp.Client(host=None).create_run_from_pipeline_package('kubeflow-test.yml', arguments={})
         break # This means it worked!
     except kfp_server_api.rest.ApiException as e:
         print("Hit an error, waiting and trying again: {}".format(e))
-        time.sleep(30) # Occassionally Kubeflow fails to respond even when all deployments are up. I don't know why, sometimes it is a 403, sometimes a 500, and sometimes it works. So we will just wait and re-try until the test/script times out.
 
-for i in range(70): # The test .sh times out after 600 seconds. So we run a little longer than that. This accounts mostly for NGC download time.
+for i in range(70): # The test eventually times out. So we run a little longer than that. This accounts mostly for NGC download time.
     print("Polling for pipeline status: {} - {}".format(run_result, i))
-    status = kfp.Client(host=None).get_run(run_result.run_id).run.status
-    if status == "Succeeded":
+    run = kfp.Client(host=None).get_run(run_result.run_id).run
+    if run.status == "Succeeded":
         print("SUCCESS: Kubeflow launched a container successfully")
         break
-    print("Got {}, waiting some more...".format(status))
+    print("Got {}, waiting some more... {}".format(run.status, run))
     time.sleep(10) # Wait 10 seconds and poll

--- a/.jenkins-scripts/test-kubeflow-pipeline.sh
+++ b/.jenkins-scripts/test-kubeflow-pipeline.sh
@@ -17,4 +17,5 @@ kubectl get pods -n kubeflow # Do this for debug purposes
 
 # Run the Kubeflow pipeline test, this will build a pipeline that launches an NGC container
 # For some reason the initial pipeline creation hangs sometime (and doesn't timeout or error out or provide any logging) so we run this twice until success or timeout
-timeout 600 python3 .jenkins-scripts/test-kubeflow-pipeline.py || timeout 600 python3 .jenkins-scripts/test-kubeflow-pipeline.py
+python3 .jenkins-scripts/test-kubeflow-pipeline.py
+kubectl get pods -n kubeflow # Do this for debug purposes

--- a/.jenkins-scripts/test-monitoring.sh
+++ b/.jenkins-scripts/test-monitoring.sh
@@ -16,10 +16,13 @@ while [ ${time} -lt ${timeout} ]; do
   curl -s --raw -L "${prometheus_url}" && \
     curl -s --raw -L "${grafana_url}" && \
     curl -s --raw -L "${alertmanager_url}"  && \
-    echo "Monitoring URLs are all responding" && exit 0
+    echo "Monitoring URLs are all responding" && break
   let time=$time+15
   sleep 15
 done
+
+# Delete Monitoring
+source ./scripts/k8s_deploy_monitoring.sh -d && exit 0
 
 # Monitoring deployment failure
 echo "Monitoring did not come up in time"


### PR DESCRIPTION
After a bunch of debugging it seems like the random test failures were a combination of out-of-disk-space (RAPIDS container was 10GB+ and couldn't find a place to land), which is resolved by using busyingbox. Additionally a timing issue where Kubeflow pipeline responds as okay, but actually isn't and requires a initialization period.

In addition to that I put in a test for monitoring deletion, because it is a good test and I thought it might save some disk space.

If this continues to error, I'm going to just yank this test.