### PR TITLE
Make some generalizations to the HPL test that make it more flexible and capable of running on AWS

### DIFF
--- a/tests/hpl-burnin/hplfiles/HPL.dat_1x1_workshop_16G
+++ b/tests/hpl-burnin/hplfiles/HPL.dat_1x1_workshop_16G
@@ -2,8 +2,8 @@ HPLinpack benchmark input file
 Innovative Computing Laboratory, University of Tennessee
 HPL.out      output file name (if any)
 6            device out (6=stdout,7=stderr,file)
-1            # of problems sizes (N)
-15744     Ns
+6            # of problems sizes (N)
+45120 45312 45504 45696 45888 46080     Ns
 1             # of NBs
 192         NBs
 0            PMAP process mapping (0=Row-,1=Column-major)
@@ -29,4 +29,3 @@ HPL.out      output file name (if any)
 0            U  in (0=transposed,1=no-transposed) form
 1            Equilibration (0=no,1=yes)
 8            memory alignment in double (> 0)
-

--- a/tests/hpl-burnin/hplfiles/HPL.dat_1x1_workshop_16G
+++ b/tests/hpl-burnin/hplfiles/HPL.dat_1x1_workshop_16G
@@ -1,0 +1,32 @@
+HPLinpack benchmark input file
+Innovative Computing Laboratory, University of Tennessee
+HPL.out      output file name (if any)
+6            device out (6=stdout,7=stderr,file)
+1            # of problems sizes (N)
+15744     Ns
+1             # of NBs
+192         NBs
+0            PMAP process mapping (0=Row-,1=Column-major)
+1            # of process grids (P x Q)
+1         Ps
+1         Qs
+16.0         threshold
+1            # of panel fact
+1        PFACTs (0=left, 1=Crout, 2=Right)
+1            # of recursive stopping criterium
+8          NBMINs (>= 1)
+1            # of panels in recursion
+2            NDIVs
+1            # of recursive panel fact.
+2        RFACTs (0=left, 1=Crout, 2=Right)
+1            # of broadcast
+0          BCASTs (0=1rg,1=1rM,2=2rg,3=2rM,4=Lng,5=LnM)
+1            # of lookahead depth
+0            DEPTHs (>=0)
+1            SWAP (0=bin-exch,1=long,2=mix)
+192          swapping threshold
+1            L1 in (0=transposed,1=no-transposed) form
+0            U  in (0=transposed,1=no-transposed) form
+1            Equilibration (0=no,1=yes)
+8            memory alignment in double (> 0)
+

--- a/tests/hpl-burnin/launch_experiment_slurm.sh
+++ b/tests/hpl-burnin/launch_experiment_slurm.sh
@@ -21,7 +21,7 @@
 ###    When all the jobs are down, run the verify script, put the results in the results directory
 ### - Set the full expdir from this script
 
-export HPL_DIR=${HPL_DIR:-/mnt/shared}
+export HPL_DIR=${HPL_DIR:-${HOME}}
 
 ## Set default options
 niters=5

--- a/tests/hpl-burnin/launch_experiment_slurm.sh
+++ b/tests/hpl-burnin/launch_experiment_slurm.sh
@@ -132,7 +132,7 @@ elif [ x"${system}" == x"workshop" ]; then
 	export gpus_per_node=1
 	export NV_GPUCLOCK=1530
 	export NV_MEMCLOCK=877
-	export hpldat="/mnt/shared/deepops/tests/hpl-burnin/hplfiles/HPL.dat_1x1_workshop_16G"
+	export hpldat="${HPL_SCRIPTS_DIR}/hplfiles/HPL.dat_1x1_workshop_16G"
 	echo "WARN; Running in non-performant workshop configuration"
 else
 	echo "ERROR: Generic systems are not supported yet."

--- a/tests/hpl-burnin/launch_experiment_slurm.sh
+++ b/tests/hpl-burnin/launch_experiment_slurm.sh
@@ -21,7 +21,8 @@
 ###    When all the jobs are down, run the verify script, put the results in the results directory
 ### - Set the full expdir from this script
 
-export HPL_DIR=${HPL_DIR:-${HOME}}
+export HPL_DIR=${HPL_DIR:-${HOME}} # The shared directory where scripts, data, and results are stored
+export HPL_SCRIPTS_DIR=${HPL_SCRIPTS_DIR:-${HPL_DIR}/deepops/tests/hpl-burnin} # The shared directory where these scripts are stored
 
 ## Set default options
 niters=5
@@ -167,7 +168,7 @@ fi
 export SYSTEM=${system}
 export GPUS_PER_NODE=${gpus_per_node}
 
-RUNSCRIPT=submit_hpl_cuda${cudaver}.sh
+RUNSCRIPT=${HPL_SCRIPTS_DIR}/submit_hpl_cuda${cudaver}.sh
 
 # Set a name for the experiment
 export EXPNAME=${nodes_per_job}node_${system}_$(date +%Y%m%d%H%M%S)
@@ -196,7 +197,7 @@ fi
 ### Report all variables
 echo ""
 echo "Experiment Variables:"
-for V in HPL_DIR EXPDIR system nodes_per_job gpus_per_node gpuclock memclock  niters cudaver partition usehca maxnodes mpiopts gresstr total_nodes hpldat; do
+for V in HPL_DIR HPL_SCRIPTS_DIR EXPDIR system nodes_per_job gpus_per_node gpuclock memclock  niters cudaver partition usehca maxnodes mpiopts gresstr total_nodes hpldat; do
 	echo -n "${V}: "
         if [ x"${!V}" != x"" ]; then	
         	echo "${!V}"
@@ -264,7 +265,7 @@ echo "===================="
 
 VLOGFN=${EXPDIR}/verify_results.txt
 
-./verify_hpl_experiment.py ${EXPDIR} | tee ${VLOGFN}
+${HPL_SCRIPTS_DIR}/verify_hpl_experiment.py ${EXPDIR} | tee ${VLOGFN}
 
 echo "Run Summary:"
 echo "Experiment Results Directory: ${EXPDIR}"
@@ -273,7 +274,7 @@ echo "Nodes Per Job:: ${nodes_per_job}"
 echo "Verify Log: ${VLOGFN}"
 
 echo ""
-echo "To rerun the verification: ./verify_hpl_experiment.py ${EXPDIR}"
+echo "To rerun the verification: ${HPL_SCRIPTS_DIR}/verify_hpl_experiment.py ${EXPDIR}"
 echo ""
 
 

--- a/tests/hpl-burnin/launch_experiment_slurm.sh
+++ b/tests/hpl-burnin/launch_experiment_slurm.sh
@@ -21,6 +21,8 @@
 ###    When all the jobs are down, run the verify script, put the results in the results directory
 ### - Set the full expdir from this script
 
+export HPL_DIR=${HPL_DIR:-/mnt/shared}
+
 ## Set default options
 niters=5
 cudaver=10.1
@@ -169,7 +171,7 @@ RUNSCRIPT=submit_hpl_cuda${cudaver}.sh
 
 # Set a name for the experiment
 export EXPNAME=${nodes_per_job}node_${system}_$(date +%Y%m%d%H%M%S)
-export EXPDIR=$(pwd)/results/${EXPNAME}
+export EXPDIR=${HPL_DIR}/results/${EXPNAME}
 
 if [ -d $EXPDIR ]; then
 	echo "ERROR: Directory already exists: $EXPDIR"
@@ -194,7 +196,7 @@ fi
 ### Report all variables
 echo ""
 echo "Experiment Variables:"
-for V in EXPDIR system nodes_per_job gpus_per_node gpuclock memclock  niters cudaver partition usehca maxnodes mpiopts gresstr total_nodes hpldat; do
+for V in HPL_DIR EXPDIR system nodes_per_job gpus_per_node gpuclock memclock  niters cudaver partition usehca maxnodes mpiopts gresstr total_nodes hpldat; do
 	echo -n "${V}: "
         if [ x"${!V}" != x"" ]; then	
         	echo "${!V}"

--- a/tests/hpl-burnin/launch_experiment_slurm.sh
+++ b/tests/hpl-burnin/launch_experiment_slurm.sh
@@ -128,6 +128,12 @@ elif [ x"${system}" == x"dgxa100" ]; then
 	export NV_MEMCLOCK=877
 	echo "ERROR: DGX A100 is not supported yet.  Exiting"
 	exit
+elif [ x"${system}" == x"workshop" ]; then
+	export gpus_per_node=1
+	export NV_GPUCLOCK=1530
+	export NV_MEMCLOCK=877
+	export hpldat="/mnt/shared/deepops/tests/hpl-burnin/hplfiles/HPL.dat_1x1_workshop_16G"
+	echo "WARN; Running in non-performant workshop configuration"
 else
 	echo "ERROR: Generic systems are not supported yet."
 	exit

--- a/tests/hpl-burnin/run_hpl_cuda10.1.sh
+++ b/tests/hpl-burnin/run_hpl_cuda10.1.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #location of HPL 
 
-export HPL_DIR=${HPL_DIR:-/mnt/shared}
+export HPL_DIR=${HPL_DIR:-${HOME}}
 
 CUDAVER=${cudaver:-"10.1"}
 

--- a/tests/hpl-burnin/run_hpl_cuda10.1.sh
+++ b/tests/hpl-burnin/run_hpl_cuda10.1.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #location of HPL 
 
-export HPL_DIR=${HPL_DIR:-$(pwd)}
+export HPL_DIR=${HPL_DIR:-/mnt/shared}
 
 CUDAVER=${cudaver:-"10.1"}
 

--- a/tests/hpl-burnin/submit_hpl_cuda10.1.sh
+++ b/tests/hpl-burnin/submit_hpl_cuda10.1.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 #location of HPL
 
-export HPL_DIR=${HPL_DIR:-/mnt/shared}
+export HPL_DIR=${HPL_DIR:-${HOME}} # Shared location where all HPL files are stored
+export HPL_SCRIPTS_DIR=${HPL_DIR:-${HPL_DIR}/deepops/tests/hpl-burnin} # Shared location where these scripts are stored
+export HPL_FILE_DIR=${HPL_FILE_DIR:-${HPL_DIR}/hplfiles} # Shared location where .dat files are stored
 
 export PATH=/usr/local/cuda/bin:$PATH
 export LD_LIBRARY_PATH=/usr/local/cuda/lib64:$LD_LIBRARY_PATH
@@ -47,7 +49,7 @@ if [ x"${HPLDAT}" != x"" ]; then
 	echo "Using predefined HPL.dat file: ${HPLDAT}"
 	HPLFN=${HPLDAT}
 else
-	HPLFNDIR=$HPL_DIR/hplfiles
+	HPLFNDIR=$HPL_FILE_DIR
 	if [ ${GPUS_PER_NODE} == 8 ]; then
 		case ${NNODES} in
 			1) PxQ=4x2 ;;
@@ -153,7 +155,7 @@ mpirun -np $NNODES -npernode 1 ${LOCAL_MPIOPTS}  ${mpiopts} nvidia-smi -ac ${NVC
 echo "" | tee -a $RESULT_FILE
 
 ## Run HPL
-mpirun -np $NPROCS -bind-to none -x LD_LIBRARY_PATH ${LOCAL_MPIOPTS} ${mpiopts} ${HPL_DIR}/run_hpl_cuda10.1.sh 2>&1 | tee -a $RESULT_FILE
+mpirun -np $NPROCS -bind-to none -x LD_LIBRARY_PATH ${LOCAL_MPIOPTS} ${mpiopts} ${HPL_SCRIPTS_DIR}/run_hpl_cuda10.1.sh 2>&1 | tee -a $RESULT_FILE
 
 ## Cleanup Run
 cd ${HPL_DIR}

--- a/tests/hpl-burnin/submit_hpl_cuda10.1.sh
+++ b/tests/hpl-burnin/submit_hpl_cuda10.1.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #location of HPL
 
-export HPL_DIR=$(pwd)
+export HPL_DIR=${HPL_DIR:-/mnt/shared}
 
 export PATH=/usr/local/cuda/bin:$PATH
 export LD_LIBRARY_PATH=/usr/local/cuda/lib64:$LD_LIBRARY_PATH


### PR DESCRIPTION
* Remove all hardcoded paths, replace with HPL_DIR - > NFS location (typically ~/) and HPL_SCRIPTS_DIR (the deepops location of the hpl scripts).
* Add a "workshop" system that runs on a single GPU for AWS workshops
* Misc. cleanup and doc updates