### PR TITLE
Changes so the default OpenMPI works with Slurm correctly

### DIFF
--- a/.jenkins-scripts/test-mpi-job.sh
+++ b/.jenkins-scripts/test-mpi-job.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+source .jenkins-scripts/jenkins-common.sh
+
+# Upload MPI source
+scp  \
+	-o "UserKnownHostsFile /dev/null" \
+	-i "${HOME}/.ssh/id_rsa" \
+	examples/slurm-mpi-hello/mpi-hello.c \
+	"vagrant@10.0.0.5${GPU01}:mpi-hello.c"
+
+# Compile the program
+ssh \
+	-o "StrictHostKeyChecking no" \
+	-o "UserKnownHostsFile /dev/null" \
+	-l vagrant \
+	-i "${HOME}/.ssh/id_rsa" \
+	"10.0.0.5${GPU01}" \
+	mpicc -o ./mpi-hello mpi-hello.c
+
+# Run with srun
+ssh \
+	-o "StrictHostKeyChecking no" \
+	-o "UserKnownHostsFile /dev/null" \
+	-l vagrant \
+	-i "${HOME}/.ssh/id_rsa" \
+	"10.0.0.5${GPU01}" \
+	srun --mpi=pmix -n 2 '~/mpi-hello'

--- a/.jenkins-scripts/test-mpi-job.sh
+++ b/.jenkins-scripts/test-mpi-job.sh
@@ -3,6 +3,7 @@ source .jenkins-scripts/jenkins-common.sh
 
 # Upload MPI source
 scp  \
+	-o "StrictHostKeyChecking no" \
 	-o "UserKnownHostsFile /dev/null" \
 	-i "${HOME}/.ssh/id_rsa" \
 	examples/slurm-mpi-hello/mpi-hello.c \

--- a/config.example/group_vars/slurm-cluster.yml
+++ b/config.example/group_vars/slurm-cluster.yml
@@ -37,7 +37,6 @@ hosts_add_ansible_managed_hosts_groups: ["slurm-cluster"]
 # Optional installs                                                            #
 ################################################################################
 slurm_cluster_install_cuda: yes
-slurm_cluster_install_openmpi: yes
 slurm_cluster_install_nvidia_driver: yes
 slurm_cluster_install_singularity: no
 
@@ -117,6 +116,7 @@ hpcsdk_install_in_path: false
 # using the OpenMPI provided in the HPC SDK, but if you need a custom build,   #
 # this can help you get started.
 ################################################################################
+slurm_cluster_install_openmpi: false
 openmpi_version: 4.0.4
 openmpi_install_prefix: "/usr/local"
 openmpi_configure: "./configure --prefix={{ openmpi_install_prefix }} --disable-dependency-tracking --disable-getpwuid --with-pmix={{ pmix_install_prefix }} --with-hwloc={{ hwloc_install_prefix }} --with-pmi={{ slurm_install_prefix }} --with-slurm={{ slurm_install_prefix }}"

--- a/config.example/group_vars/slurm-cluster.yml
+++ b/config.example/group_vars/slurm-cluster.yml
@@ -5,6 +5,8 @@
 # Playbook: slurm, slurm-cluster, slurm-perf, slurm-perf-cluster, slurm-validation
 slurm_version: 20.02.4
 slurm_install_prefix: /usr/local
+pmix_install_prefix: /opt/deepops/pmix
+hwloc_install_prefix: /opt/deepops/pmix
 #slurm_user_home: /local/slurm
 slurm_manage_gpus: true
 #slurm_cluster_name: deepops
@@ -106,6 +108,18 @@ hpcsdk_version: "2020_207"
 # the default user environment
 hpcsdk_install_as_modules: true
 hpcsdk_install_in_path: false
+
+################################################################################
+# OpenMPI build                                                                #
+#                                                                              #
+# The openmpi.yml playbook will build a custom-configured OpenMPI based on the #
+# Slurm, PMIx, and hwloc on the cluster. In most cases you should be fine with #
+# using the OpenMPI provided in the HPC SDK, but if you need a custom build,   #
+# this can help you get started.
+################################################################################
+openmpi_version: 4.0.4
+openmpi_install_prefix: "/usr/local"
+openmpi_configure: "./configure --prefix={{ openmpi_install_prefix }} --disable-dependency-tracking --disable-getpwuid --with-pmix={{ pmix_install_prefix }} --with-hwloc={{ hwloc_install_prefix }} --with-pmi={{ slurm_install_prefix }} --with-slurm={{ slurm_install_prefix }}"
 
 ################################################################################
 # Open OnDemand                                                                #

--- a/config.example/group_vars/slurm-cluster.yml
+++ b/config.example/group_vars/slurm-cluster.yml
@@ -6,7 +6,7 @@
 slurm_version: 20.02.4
 slurm_install_prefix: /usr/local
 pmix_install_prefix: /opt/deepops/pmix
-hwloc_install_prefix: /opt/deepops/pmix
+hwloc_install_prefix: /opt/deepops/hwloc
 #slurm_user_home: /local/slurm
 slurm_manage_gpus: true
 #slurm_cluster_name: deepops

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -60,6 +60,11 @@ pipeline {
           sh '''
             timeout 60 bash -x ./.jenkins-scripts/test-slurm-nfs-mount.sh
           '''
+
+          echo "Test MPI"
+          sh '''
+            timeout 60 bash -x ./.jenkins-scripts/test-mpi-job.sh
+          '''
         }
       }
     }

--- a/jenkins/Jenkinsfile-multi-nightly
+++ b/jenkins/Jenkinsfile-multi-nightly
@@ -88,6 +88,11 @@ pipeline {
             timeout 60 bash -x ./.jenkins-scripts/test-slurm-job.sh
           '''
 
+          echo "Test MPI"
+          sh '''
+            timeout 60 bash -x ./.jenkins-scripts/test-mpi-job.sh
+          '''
+
           echo "Reset repo and unmunge files"
           sh '''
             git reset --hard

--- a/jenkins/Jenkinsfile-nightly
+++ b/jenkins/Jenkinsfile-nightly
@@ -175,6 +175,11 @@ pipeline {
           sh '''
             timeout 60  bash -x ./.jenkins-scripts/test-slurm-job.sh
           '''
+
+          echo "Test MPI"
+          sh '''
+            timeout 60 bash -x ./.jenkins-scripts/test-mpi-job.sh
+          '''
         }
       }
     }

--- a/roles/openmpi/tasks/main.yml
+++ b/roles/openmpi/tasks/main.yml
@@ -118,3 +118,7 @@
   args:
     chdir: "{{ openmpi_build_dir }}"
   when: openmpi_build
+
+- name: run ldconfig to ensure libs are found
+  command: "ldconfig"
+  when: openmpi_build

--- a/roles/slurm/defaults/main.yml
+++ b/roles/slurm/defaults/main.yml
@@ -86,7 +86,7 @@ hwloc_configure: "./configure --prefix={{ hwloc_install_prefix }} --enable-stati
 hwloc_force_rebuild: no
 
 slurm_include_pmix: yes
-pmix_version: 3.1.5
+pmix_version: 2.2.4
 pmix_src_url: "https://github.com/openpmix/openpmix/releases/download/v{{ pmix_version }}/pmix-{{ pmix_version }}.tar.bz2"
 pmix_install_prefix: /opt/deepops/pmix
 pmix_configure: "./configure --prefix={{ pmix_install_prefix }} --with-hwloc={{ hwloc_install_prefix }}"

--- a/virtual/vars_files/virt_slurm.yml
+++ b/virtual/vars_files/virt_slurm.yml
@@ -11,3 +11,6 @@ slurm_allow_ssh_user:
 hpcsdk_clean_up_tarball_after_extract: true
 hpcsdk_clean_up_temp_dir: true
 slurm_build_dir_cleanup: true
+
+# Build OpenMPI locally for testing
+slurm_cluster_install_openmpi: true


### PR DESCRIPTION
Currently, our default OpenMPI build does not integrate with Slurm correctly to run with `srun`.

```
vagrant@virtual-login01:~/deepops/examples/slurm-mpi-hello$ mpicc -o hello mpi-hello.c
vagrant@virtual-login01:~/deepops/examples/slurm-mpi-hello$ srun -n2  ./hello
[virtual-gpu01:01394] OPAL ERROR: Error in file pmix3x_client.c at line 112
--------------------------------------------------------------------------
```

This (or similar) errors appear regardless of which `--mpi` transport is specified with `srun`. After a bunch of debugging, this seems to stem from the internal PMIx in OpenMPI conflicting with the PMIx built against Slurm.

This PR makes the following changes in order to get MPI/Slurm integration working correctly:

* Build OpenMPI against the external PMIx and hwloc we use with Slurm.
* Change to using PMIx 2.2.4 instead of 3.1.5.
    * This change was also needed to use `srun` with the OpenMPI bundled in the HPC SDK, as it was built with an older PMIx.
* Also link so we can use PMI2 transport as an option.

Additionally, some misc changes that got rolled in:

* Adds a Jenkins test for MPI
* Defaults most clusters to not build OpenMPI during the `slurm-cluster.yml` playbook, as we already have a perfectly good MPI in the NVIDIA HPC SDK install. 😉 

Note that most of the configuration changes are made in `config.example/group_vars/slurm-cluster.yml`. I didn't change the defaults in `roles/openmpi`, on the basis that the role should be able to work independently of Slurm if you're using it stand-alone.

Test plan
----------

Build a DeepOps Slurm cluster with the OpenMPI build enabled (default config with the virtual cluster), then test with `examples/slurm-mpi-hello/mpi-hello.c`.

With the OpenMPI we build:
```
vagrant@virtual-login01:~$ git clone https://github.com/nvidia/deepops
Cloning into 'deepops'...
remote: Enumerating objects: 24, done.
remote: Counting objects: 100% (24/24), done.
remote: Compressing objects: 100% (21/21), done.
remote: Total 11587 (delta 5), reused 13 (delta 2), pack-reused 11563
Receiving objects: 100% (11587/11587), 8.79 MiB | 5.80 MiB/s, done.
Resolving deltas: 100% (7026/7026), done.
vagrant@virtual-login01:~$ cd deepops/examples/slurm-mpi-hello/
vagrant@virtual-login01:~/deepops/examples/slurm-mpi-hello$ mpicc -o hello ./mpi-hello.c
vagrant@virtual-login01:~/deepops/examples/slurm-mpi-hello$ srun -n2 ./hello
Hello from process 0 of 2 on host virtual-gpu01
Hello from process 1 of 2 on host virtual-gpu01
vagrant@virtual-login01:~/deepops/examples/slurm-mpi-hello$ srun -n2 --mpi=pmix ./hello
Hello from process 0 of 2 on host virtual-gpu01
Hello from process 1 of 2 on host virtual-gpu01
```

And with the OpenMPI bundled in the HPC SDK:

```
vagrant@virtual-login01:~/deepops/examples/slurm-mpi-hello$ module load nvhpc
vagrant@virtual-login01:~/deepops/examples/slurm-mpi-hello$ which mpicc
/sw/hpc-sdk/Linux_x86_64/20.7/comm_libs/mpi/bin/mpicc
vagrant@virtual-login01:~/deepops/examples/slurm-mpi-hello$ mpicc -o nvhpc-hello ./mpi-hello.c
vagrant@virtual-login01:~/deepops/examples/slurm-mpi-hello$ export OMPI_MCA_btl="^vader,openib"    # Suppress warnings for unavailable transports
vagrant@virtual-login01:~/deepops/examples/slurm-mpi-hello$ srun -n2  ./nvhpc-hello
Hello from process 1 of 2 on host virtual-gpu01
Hello from process 0 of 2 on host virtual-gpu01
```