### PR TITLE
Only install helm chart for plugin/operator once

### DIFF
--- a/playbooks/nvidia-gpu-operator.yml
+++ b/playbooks/nvidia-gpu-operator.yml
@@ -14,7 +14,7 @@
     - nvidia-gpu-operator
 
 # GPU operator
-- hosts: kube-master
+- hosts: kube-master[0]
   become: yes
   tasks:
     - name: Install helm chart for GPU operator

--- a/playbooks/nvidia-k8s-gpu-device-plugin.yml
+++ b/playbooks/nvidia-k8s-gpu-device-plugin.yml
@@ -1,5 +1,5 @@
 ---
-- hosts: kube-master
+- hosts: kube-master[0]
   become: true
   tasks:
     - name: install k8s GPU plugin


### PR DESCRIPTION
The nightly Jenkins job started failing, it looks like it is due to the helm install being run several times on all 3 master nodes. Pushing this change to only run once.