### PR TITLE
Add back behavior that removes NoSchedule taint from kube-master nodes

### DIFF
--- a/.jenkins-scripts/get-k8s-debug.sh
+++ b/.jenkins-scripts/get-k8s-debug.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -x
+source .jenkins-scripts/jenkins-common.sh
+
+# Ensure working directory is root
+cd "${ROOT_DIR}"
+
+export KF_DIR=${ROOT_DIR}/config/kubeflow
+export KFCTL=${ROOT_DIR}/config/kfctl
+
+# Get some basic info about all nodes
+kubectl describe nodes
+kubectl get nodes
+
+# Get some basic info about all running pods
+kubectl get pods -A
+kubectl get daemonsets -A
+
+# Get helm status (requires helm install)
+helm list

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -36,6 +36,11 @@ pipeline {
             bash -x ./.jenkins-scripts/test-cluster-up.sh
           '''
 
+          echo "Get K8S Cluster Status"
+          sh '''
+            bash -x ./.jenkins-scripts/get-k8s-debug.sh
+          '''
+
           echo "Verify we can run a GPU job"
           sh '''
             timeout 500 bash -x ./.jenkins-scripts/run-gpu-job.sh

--- a/jenkins/Jenkinsfile-multi-nightly
+++ b/jenkins/Jenkinsfile-multi-nightly
@@ -36,6 +36,11 @@ pipeline {
             bash -x ./.jenkins-scripts/test-cluster-up.sh
           '''
 
+          echo "Get K8S Cluster Status"
+          sh '''
+            bash -x ./.jenkins-scripts/get-k8s-debug.sh
+          '''
+
           echo "Verify we can run a GPU job"
           sh '''
             timeout 500 bash -x ./.jenkins-scripts/run-gpu-job.sh
@@ -122,6 +127,11 @@ pipeline {
           echo "Cluster Up - Multiple GPU & MGMT Nodes"
           sh '''
             bash -x ./.jenkins-scripts/test-cluster-up.sh
+          '''
+
+          echo "Get K8S Cluster Status"
+          sh '''
+            bash -x ./.jenkins-scripts/get-k8s-debug.sh
           '''
 
           echo "Verify we can run a GPU job"

--- a/jenkins/Jenkinsfile-nightly
+++ b/jenkins/Jenkinsfile-nightly
@@ -36,6 +36,11 @@ pipeline {
             bash -x ./.jenkins-scripts/test-cluster-up.sh
           '''
 
+          echo "Get K8S Cluster Status"
+          sh '''
+            bash -x ./.jenkins-scripts/get-k8s-debug.sh
+          '''
+
           echo "Verify we can run a GPU job"
           sh '''
             timeout 500 bash -x ./.jenkins-scripts/run-gpu-job.sh
@@ -122,6 +127,11 @@ pipeline {
           echo "Cluster Up"
           sh '''
             bash -x ./.jenkins-scripts/test-cluster-up.sh
+          '''
+
+          echo "Get K8S Cluster Status"
+          sh '''
+            bash -x ./.jenkins-scripts/get-k8s-debug.sh
           '''
 
           echo "Verify we can run a GPU job"

--- a/playbooks/k8s-cluster.yml
+++ b/playbooks/k8s-cluster.yml
@@ -200,4 +200,15 @@
   tags:
     - local
 
+# Remove taint from kube-master nodes.
+# This keeps backwards compatibility and allows a few services (monitoring/etc.) to run properly.
+- hosts: kube-master
+  gather_facts: false
+  vars:
+    ansible_become: no
+  tasks:
+    - name: kubeadm | Remove taint for master with node role
+      command: "{{ artifacts_dir }}/kubectl --kubeconfig {{ artifacts_dir }}/admin.conf taint node {{ inventory_hostname }} node-role.kubernetes.io/master:NoSchedule-"
+      delegate_to: localhost
+      failed_when: false # Taint will not be present if kube-master also under kube-node
 


### PR DESCRIPTION
4bfb4a6307a801ade0b6bfd6f3e7bc7ed8d77cc6 removed `kubectl taint nodes --all node-role.kubernetes.io/master:NoSchedule- >/dev/null 2>&1` from the `install_helm.sh`. Doing this has caused services to behave differently. I've seen some behavior changes in MetalLB, Kubeflow, and Prometheus.

I am suggesting that we add this behavior back in by adding this to the cluster playbook. This can also be accomplished by adding the `kube-master` to `kube-node` in `inventory`, but that could have other side effects so I think this change is best.

We did not catch this in the nightly tests because under virtual, the `mgmt` node is also under `kube-node`.

* Remove NoSchedule from kube-masters
* Update Jenkins to show output of describe node for easy future debug