### PR TITLE
Update rmrook to properly delete with helm 3

### DIFF
--- a/scripts/rmrook.sh
+++ b/scripts/rmrook.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 kubectl delete -f services/rook-cluster.yml
-helm del --purge rook-ceph
+helm delete rook-ceph
 kubectl -n rook-ceph delete cephcluster rook-ceph
 kubectl -n rook-ceph delete storageclass rook-ceph-block
 kubectl delete ns rook-ceph-system


### PR DESCRIPTION
* Missed the rmrook script in the helm upgrade, without this `rmrook.sh` leaves rook-ceph in an uninstallable state.