### PR TITLE
Slurm default to "contain SSH"

### DIFF
--- a/roles/slurm/defaults/main.yml
+++ b/roles/slurm/defaults/main.yml
@@ -15,6 +15,7 @@ slurm_sysconf_dir: /etc/sysconfig
 slurm_install_prefix: /usr/local
 slurm_configure:  './configure --prefix={{ slurm_install_prefix }} --disable-dependency-tracking --disable-debug --disable-x11 --enable-really-no-cray --enable-salloc-kill-cmd --with-hdf5=no --sysconfdir={{ slurm_config_dir }} --enable-pam --with-pam_dir={{ slurm_pam_lib_dir }} --without-shared-libslurm --without-rpath --with-pmix={{ pmix_install_prefix }} --with-hwloc={{ hwloc_install_prefix }}'
 slurm_force_rebuild: no
+slurm_contain_ssh: yes
 
 slurm_cluster_name: deepops
 slurm_username: slurm

--- a/roles/slurm/templates/etc/slurm/slurm.conf
+++ b/roles/slurm/templates/etc/slurm/slurm.conf
@@ -41,7 +41,9 @@ ReturnToService={{ slurm_return_to_service }}
 #PropagateResourceLimitsExcept=
 PropagateResourceLimitsExcept=MEMLOCK
 {% if slurm_contain_ssh is defined %}
-PrologFlags=contain
+PrologFlags=Alloc,Serial,Contain
+{% else %}
+PrologFlags=Alloc,Serial
 {% endif %}
 {% if slurm_enable_prolog_epilog %}
 Prolog={{ slurm_config_dir }}/prolog.sh


### PR DESCRIPTION
Defaults to setting `PrologFlags=contain` in `slurm.conf`. This is required for `pam_slurm_adopt` to work properly.