### PR TITLE
Update `docker run` to use --network instead of --net

### DIFF
--- a/roles/grafana/templates/docker.grafana.service.j2
+++ b/roles/grafana/templates/docker.grafana.service.j2
@@ -9,7 +9,7 @@ Restart=always
 ExecStartPre=-/usr/bin/docker stop %n
 ExecStartPre=-/usr/bin/docker rm %n
 ExecStartPre=/usr/bin/docker pull {{ grafana_container }}
-ExecStart=/usr/bin/docker run --rm --net="host" --name %n -v {{ grafana_config_dir }}:/etc/grafana -v {{ grafana_data_dir }}:/var/lib/grafana {{ grafana_container }}
+ExecStart=/usr/bin/docker run --rm --network="host" --name %n -v {{ grafana_config_dir }}:/etc/grafana -v {{ grafana_data_dir }}:/var/lib/grafana {{ grafana_container }}
 
 [Install]
 WantedBy=multi-user.target

--- a/roles/grafana/templates/docker.grafana.service.j2
+++ b/roles/grafana/templates/docker.grafana.service.j2
@@ -9,7 +9,7 @@ Restart=always
 ExecStartPre=-/usr/bin/docker stop %n
 ExecStartPre=-/usr/bin/docker rm %n
 ExecStartPre=/usr/bin/docker pull {{ grafana_container }}
-ExecStart=/usr/bin/docker run --rm --network="host" --name %n -v {{ grafana_config_dir }}:/etc/grafana -v {{ grafana_data_dir }}:/var/lib/grafana {{ grafana_container }}
+ExecStart=/usr/bin/docker run --rm --network host --name %n -v {{ grafana_config_dir }}:/etc/grafana -v {{ grafana_data_dir }}:/var/lib/grafana {{ grafana_container }}
 
 [Install]
 WantedBy=multi-user.target

--- a/roles/prometheus-node-exporter/templates/docker.node-exporter.service.j2
+++ b/roles/prometheus-node-exporter/templates/docker.node-exporter.service.j2
@@ -9,7 +9,7 @@ Restart=always
 ExecStartPre=-/usr/bin/docker stop %n
 ExecStartPre=-/usr/bin/docker rm %n
 ExecStartPre=/usr/bin/docker pull {{ node_exporter_container }}
-ExecStart=/usr/bin/docker run --rm --net="host" --pid="host" --name %n -v {{ node_exporter_prom_dir }}:/run/prometheus {{ node_exporter_container }} --collector.textfile.directory="{{ node_exporter_prom_dir }}"
+ExecStart=/usr/bin/docker run --rm --network="host" --pid="host" --name %n -v {{ node_exporter_prom_dir }}:/run/prometheus {{ node_exporter_container }} --collector.textfile.directory="{{ node_exporter_prom_dir }}"
 
 [Install]
 WantedBy=multi-user.target

--- a/roles/prometheus-node-exporter/templates/docker.node-exporter.service.j2
+++ b/roles/prometheus-node-exporter/templates/docker.node-exporter.service.j2
@@ -9,7 +9,7 @@ Restart=always
 ExecStartPre=-/usr/bin/docker stop %n
 ExecStartPre=-/usr/bin/docker rm %n
 ExecStartPre=/usr/bin/docker pull {{ node_exporter_container }}
-ExecStart=/usr/bin/docker run --rm --network="host" --pid="host" --name %n -v {{ node_exporter_prom_dir }}:/run/prometheus {{ node_exporter_container }} --collector.textfile.directory="{{ node_exporter_prom_dir }}"
+ExecStart=/usr/bin/docker run --rm --network host --pid="host" --name %n -v {{ node_exporter_prom_dir }}:/run/prometheus {{ node_exporter_container }} --collector.textfile.directory="{{ node_exporter_prom_dir }}"
 
 [Install]
 WantedBy=multi-user.target

--- a/roles/prometheus-slurm-exporter/templates/docker.slurm-exporter.service.j2
+++ b/roles/prometheus-slurm-exporter/templates/docker.slurm-exporter.service.j2
@@ -9,7 +9,7 @@ Restart=always
 ExecStartPre=-/usr/bin/docker stop %n
 ExecStartPre=-/usr/bin/docker rm %n
 ExecStartPre=/usr/bin/docker pull {{ slurm_exporter_container }}
-ExecStart=/usr/bin/docker run --rm --net="host" --name %n -v {{ slurm_install_prefix }}/bin/sdiag:{{ slurm_install_prefix }}/bin/sdiag -v {{ slurm_install_prefix }}/bin/sinfo:{{ slurm_install_prefix }}/bin/sinfo -v {{ slurm_install_prefix }}/bin/squeue:{{ slurm_install_prefix }}/bin/squeue -v /etc/slurm:/etc/slurm:ro -v {{ slurm_install_prefix }}/lib/slurm:{{ slurm_install_prefix }}/lib/slurm:ro -v /etc/hosts:/etc/hosts:ro -v /var/run/munge:/var/run/munge:ro {{ slurm_exporter_container }}
+ExecStart=/usr/bin/docker run --rm --network="host" --name %n -v {{ slurm_install_prefix }}/bin/sdiag:{{ slurm_install_prefix }}/bin/sdiag -v {{ slurm_install_prefix }}/bin/sinfo:{{ slurm_install_prefix }}/bin/sinfo -v {{ slurm_install_prefix }}/bin/squeue:{{ slurm_install_prefix }}/bin/squeue -v /etc/slurm:/etc/slurm:ro -v {{ slurm_install_prefix }}/lib/slurm:{{ slurm_install_prefix }}/lib/slurm:ro -v /etc/hosts:/etc/hosts:ro -v /var/run/munge:/var/run/munge:ro {{ slurm_exporter_container }}
 
 [Install]
 WantedBy=multi-user.target

--- a/roles/prometheus-slurm-exporter/templates/docker.slurm-exporter.service.j2
+++ b/roles/prometheus-slurm-exporter/templates/docker.slurm-exporter.service.j2
@@ -9,7 +9,7 @@ Restart=always
 ExecStartPre=-/usr/bin/docker stop %n
 ExecStartPre=-/usr/bin/docker rm %n
 ExecStartPre=/usr/bin/docker pull {{ slurm_exporter_container }}
-ExecStart=/usr/bin/docker run --rm --network="host" --name %n -v {{ slurm_install_prefix }}/bin/sdiag:{{ slurm_install_prefix }}/bin/sdiag -v {{ slurm_install_prefix }}/bin/sinfo:{{ slurm_install_prefix }}/bin/sinfo -v {{ slurm_install_prefix }}/bin/squeue:{{ slurm_install_prefix }}/bin/squeue -v /etc/slurm:/etc/slurm:ro -v {{ slurm_install_prefix }}/lib/slurm:{{ slurm_install_prefix }}/lib/slurm:ro -v /etc/hosts:/etc/hosts:ro -v /var/run/munge:/var/run/munge:ro {{ slurm_exporter_container }}
+ExecStart=/usr/bin/docker run --rm --network host --name %n -v {{ slurm_install_prefix }}/bin/sdiag:{{ slurm_install_prefix }}/bin/sdiag -v {{ slurm_install_prefix }}/bin/sinfo:{{ slurm_install_prefix }}/bin/sinfo -v {{ slurm_install_prefix }}/bin/squeue:{{ slurm_install_prefix }}/bin/squeue -v /etc/slurm:/etc/slurm:ro -v {{ slurm_install_prefix }}/lib/slurm:{{ slurm_install_prefix }}/lib/slurm:ro -v /etc/hosts:/etc/hosts:ro -v /var/run/munge:/var/run/munge:ro {{ slurm_exporter_container }}
 
 [Install]
 WantedBy=multi-user.target

--- a/roles/prometheus/templates/docker.prometheus.service.j2
+++ b/roles/prometheus/templates/docker.prometheus.service.j2
@@ -9,7 +9,7 @@ Restart=always
 ExecStartPre=-/usr/bin/docker stop %n
 ExecStartPre=-/usr/bin/docker rm %n
 ExecStartPre=/usr/bin/docker pull {{ prometheus_container }}
-ExecStart=/usr/bin/docker run --rm --net="host" --name %n -v {{ prometheus_config_dir }}:/etc/prometheus {{ prometheus_container }}
+ExecStart=/usr/bin/docker run --rm --network="host" --name %n -v {{ prometheus_config_dir }}:/etc/prometheus {{ prometheus_container }}
 
 [Install]
 WantedBy=multi-user.target

--- a/roles/prometheus/templates/docker.prometheus.service.j2
+++ b/roles/prometheus/templates/docker.prometheus.service.j2
@@ -9,7 +9,7 @@ Restart=always
 ExecStartPre=-/usr/bin/docker stop %n
 ExecStartPre=-/usr/bin/docker rm %n
 ExecStartPre=/usr/bin/docker pull {{ prometheus_container }}
-ExecStart=/usr/bin/docker run --rm --network="host" --name %n -v {{ prometheus_config_dir }}:/etc/prometheus {{ prometheus_container }}
+ExecStart=/usr/bin/docker run --rm --network host --name %n -v {{ prometheus_config_dir }}:/etc/prometheus {{ prometheus_container }}
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Had a report that `--net="host"` does not work on CentOS docker 18.09.9. Seems like it might be the double quotes. Switching to `--network` also to be more verbose