### PR TITLE
Bump nvidia.nvidia_driver role to v1.2.2

### DIFF
--- a/roles/requirements.yml
+++ b/roles/requirements.yml
@@ -18,7 +18,7 @@
   version: "v5.2.6"
 
 - src: nvidia.nvidia_driver
-  version: "v1.2.1"
+  version: "v1.2.2"
 
 - src: nvidia.nvidia_docker
   version: "v1.2.1"


### PR DESCRIPTION
- Addresses a bug with driver install on CentOS/RHEL where there is an
old kernel with no `kernel-headers` package
- Updated documentation in the README