### PR TITLE
Add playbook to disable cloud init

### DIFF
--- a/config.example/group_vars/all.yml
+++ b/config.example/group_vars/all.yml
@@ -239,3 +239,6 @@ deepops_venv: '{{ deepops_dir }}/venv'
 # OpenMPI
 # Playbook: openmpi
 openmpi_version: 4.0.3
+
+# Disable cloud-init
+deepops_disable_cloud_init: true

--- a/playbooks/generic/disable-cloud-init.yml
+++ b/playbooks/generic/disable-cloud-init.yml
@@ -1,0 +1,41 @@
+---
+# Many provisioning systems, especially for Ubuntu, will include cloud-init
+# as part of the initial setup process for networking and other configuration.
+#
+# However, DeepOps attempts to manage many of the same files, which can lead to
+# conflicts and some components breaking under certain circumstances. /etc/hosts
+# is a good example of a file that both systems try to manage.
+#
+# This playbook disables cloud-init to prevent DeepOps and cloud-init from
+# stepping on each other. This playbook is not enabled by default, but you can
+# enable it by setting `deepops_disable_cloud_init: true` in your config.
+
+- hosts: "{{ hostlist | default('all') }}" 
+  become: true
+  tasks:
+
+  - name: check if /etc/cloud is present
+    when: deepops_disable_cloud_init
+    stat:
+      path: "/etc/cloud"
+    register: etc_cloud
+
+  - name: disable generator for setting cloud-init target
+    when: deepops_disable_cloud_init
+    file:
+      path: "/etc/cloud/cloud-init.disabled"
+      owner: "root"
+      group: "root"
+      mode: "0644"
+      state: "touch"
+
+  - name: disable all systemd services
+    when: deepops_disable_cloud_init
+    service:
+      name: "{{ item }}"
+      state: stopped
+      enabled: no
+    with_items:
+    - "cloud-init"
+    - "cloud-config"
+    - "cloud-final"

--- a/playbooks/generic/disable-cloud-init.yml
+++ b/playbooks/generic/disable-cloud-init.yml
@@ -7,8 +7,7 @@
 # is a good example of a file that both systems try to manage.
 #
 # This playbook disables cloud-init to prevent DeepOps and cloud-init from
-# stepping on each other. This playbook is not enabled by default, but you can
-# enable it by setting `deepops_disable_cloud_init: true` in your config.
+# stepping on each other.
 
 - hosts: "{{ hostlist | default('all') }}" 
   become: true

--- a/playbooks/generic/disable-cloud-init.yml
+++ b/playbooks/generic/disable-cloud-init.yml
@@ -21,7 +21,7 @@
     register: etc_cloud
 
   - name: disable generator for setting cloud-init target
-    when: deepops_disable_cloud_init
+    when: deepops_disable_cloud_init and etc_cloud.stat.exists
     file:
       path: "/etc/cloud/cloud-init.disabled"
       owner: "root"
@@ -31,6 +31,7 @@
 
   - name: disable all systemd services
     when: deepops_disable_cloud_init
+    ignore_errors: yes
     service:
       name: "{{ item }}"
       state: stopped

--- a/playbooks/k8s-cluster.yml
+++ b/playbooks/k8s-cluster.yml
@@ -29,6 +29,10 @@
   tags:
     - bootstrap
 
+# Disable cloud-init
+- include: generic/disable-cloud-init.yml
+  when: deepops_disable_cloud_init
+
 # Configure Chrony (NTP) sync
 - include: generic/chrony-client.yml
   when: chrony_install

--- a/playbooks/slurm-cluster.yml
+++ b/playbooks/slurm-cluster.yml
@@ -8,6 +8,10 @@
 - include: bootstrap/bootstrap-ssh.yml
 - include: bootstrap/bootstrap-sudo.yml
 
+# Disable cloud-init
+- include: generic/disable-cloud-init.yml
+  when: deepops_disable_cloud_init
+
 # Configure hostnames, /etc/hosts
 - include: generic/hosts.yml
 


### PR DESCRIPTION
This PR could be alternatively titled, "cloud-init destroyed my `/etc/hosts` on a MaaS-provisioned instance and it made me sad".

`cloud-init` is a really handy tool for automatically configuring newly-provisioned machines. It's used in a variety of cloud providers, and also used by local provisioning systems like Canonical's [MaaS](https://maas.io/). Unfortunately, `cloud-init` doesn't just run when a machine is first provisioned. It also runs on every reboot, and in its default configuration it manages `/etc/hosts` and a bunch of other files.

This can interact poorly with DeepOps, especially if you're building a Slurm cluster... because we set up our custom `/etc/hosts` file, then reboot the nodes when we install the GPU driver or make changes to Grub. Then after the reboot, `cloud-init` will reset the hosts file to its desired version. Now our `/etc/hosts` is gone and services like Slurm and NFS may no longer function. 😭 

(`cloud-init` also manages [a bunch of other settings](https://cloudinit.readthedocs.io/en/latest/topics/modules.html) with respect to Grub, SSH, Apt, and other tools that DeepOps may want to make changes to. The hosts file was just the one that frustrated me enough to write a playbook!)

This PR adds a playbook which disables `cloud-init` according to [the instructions in its docs](https://cloudinit.readthedocs.io/en/latest/topics/boot.html). It also enables this playbook by default for Slurm and Kubernetes clusters.

## Test plan

1. Provision a new machine that uses `cloud-init`, for example by using MaaS
1. Make a change to `/etc/hosts`
1. Reboot your machine -- your change will be gone...
1. Run `ansible-playbook playbooks/generic/disable-cloud-init.yml`
1. Make a change to `/etc/hosts` and reboot again
1. Observe that your change is still present! 🎉 