### PR TITLE
Install DCGM via downloaded packages on non-DGX

### DIFF
--- a/config.example/group_vars/all.yml
+++ b/config.example/group_vars/all.yml
@@ -221,6 +221,22 @@ maas_single_node_install: true
 
 maas_kvm: false
 
+
+################################################################################
+# NVIDIA Datacenter GPU Manager                                                #
+################################################################################
+# DCGM is available through package repositories for DGX, but for other host
+# types you must download from the NVIDIA Developer portal at
+# https://developer.nvidia.com/dcgm
+# To install DCGM, please download the correct package type(s) and set the
+# following variables to a path where the file exists on the Ansible control
+# machine.
+#
+# dcgm_rpm_package: "/tmp/datacenter-gpu-manager.rpm"
+# dcgm_deb_package: "/tmp/datacenter-gpu-manager.deb"
+
+install_dcgm: false
+
 ################################################################################
 # Misc.                                                                        #
 ################################################################################

--- a/config.example/group_vars/all.yml
+++ b/config.example/group_vars/all.yml
@@ -221,22 +221,6 @@ maas_single_node_install: true
 
 maas_kvm: false
 
-
-################################################################################
-# NVIDIA Datacenter GPU Manager                                                #
-################################################################################
-# DCGM is available through package repositories for DGX, but for other host
-# types you must download from the NVIDIA Developer portal at
-# https://developer.nvidia.com/dcgm
-# To install DCGM, please download the correct package type(s) and set the
-# following variables to a path where the file exists on the Ansible control
-# machine.
-#
-# dcgm_rpm_package: "/tmp/datacenter-gpu-manager.rpm"
-# dcgm_deb_package: "/tmp/datacenter-gpu-manager.deb"
-
-install_dcgm: false
-
 ################################################################################
 # Misc.                                                                        #
 ################################################################################

--- a/config.example/group_vars/all.yml
+++ b/config.example/group_vars/all.yml
@@ -222,6 +222,21 @@ maas_single_node_install: true
 maas_kvm: false
 
 ################################################################################
+# NVIDIA Datacenter GPU Manager                                                #
+################################################################################
+# DCGM is available through package repositories for DGX, but for other host
+# types you must download from the NVIDIA Developer portal at
+# https://developer.nvidia.com/dcgm
+# To install DCGM, please download the correct package type(s) and set the
+# following variables to a path where the file exists on the Ansible control
+# machine.
+#
+# dcgm_rpm_package: "/tmp/datacenter-gpu-manager.rpm"
+# dcgm_deb_package: "/tmp/datacenter-gpu-manager.deb"
+
+install_dcgm: false
+
+################################################################################
 # Misc.                                                                        #
 ################################################################################
 # Set /etc/rc.local contents

--- a/config.example/group_vars/slurm-cluster.yml
+++ b/config.example/group_vars/slurm-cluster.yml
@@ -163,18 +163,3 @@ slurm_health_check_program: "/usr/sbin/nhc"
 #
 # For documentation on the file format, see:
 # https://github.com/mej/nhc/blob/master/README.md
-
-################################################################################
-# NVIDIA Datacenter GPU Manager                                                #
-################################################################################
-# DCGM is available through package repositories for DGX, but for other host
-# types you must download from the NVIDIA Developer portal at
-# https://developer.nvidia.com/dcgm
-# To install DCGM, please download the correct package type(s) and set the
-# following variables to a path where the file exists on the Ansible control
-# machine.
-#
-# dcgm_rpm_package: "/tmp/datacenter-gpu-manager.rpm"
-# dcgm_deb_package: "/tmp/datacenter-gpu-manager.deb"
-
-slurm_install_dcgm: false

--- a/config.example/group_vars/slurm-cluster.yml
+++ b/config.example/group_vars/slurm-cluster.yml
@@ -163,3 +163,18 @@ slurm_health_check_program: "/usr/sbin/nhc"
 #
 # For documentation on the file format, see:
 # https://github.com/mej/nhc/blob/master/README.md
+
+################################################################################
+# NVIDIA Datacenter GPU Manager                                                #
+################################################################################
+# DCGM is available through package repositories for DGX, but for other host
+# types you must download from the NVIDIA Developer portal at
+# https://developer.nvidia.com/dcgm
+# To install DCGM, please download the correct package type(s) and set the
+# following variables to a path where the file exists on the Ansible control
+# machine.
+#
+# dcgm_rpm_package: "/tmp/datacenter-gpu-manager.rpm"
+# dcgm_deb_package: "/tmp/datacenter-gpu-manager.deb"
+
+slurm_install_dcgm: false

--- a/docs/slurm-cluster/dcgm.md
+++ b/docs/slurm-cluster/dcgm.md
@@ -14,4 +14,4 @@ Once DCGM has been downloaded, you can install it using DeepOps via the [nvidia-
 
 1. Download the DCGM package and place it on your Ansible control node.
 1. In your DeepOps configuration, set either the `dcgm_deb_package` or `dcgm_rpm_package` variable to the file path of the DCGM package.
-1. Either run the `playbooks/nvidia-software/nvidia-dcgm.yml` playbook directly, or run the `slurm-cluster.yml` playbook with `slurm_install_dcgm: true`.
+1. Either run the `playbooks/nvidia-software/nvidia-dcgm.yml` playbook directly, or run the `slurm-cluster.yml` playbook with `install_dcgm: true`.

--- a/docs/slurm-cluster/dcgm.md
+++ b/docs/slurm-cluster/dcgm.md
@@ -1,0 +1,17 @@
+Installing NVIDIA Datacenter GPU Manager
+========================================
+
+[NVIDIA Datacenter GPU Manager](https://developer.nvidia.com/dcgm) is a suite of tools for managing and monitoring NVIDIA GPUs in cluster environments.
+It includes active health monitoring, comprehensive diagnostics, system alerts and governance policies including power and clock management.
+It can be used standalone by system administrators and easily integrates into cluster management, resource scheduling and monitoring products from NVIDIA partners.
+
+DCGM is included by default for NVIDIA DGX, but must be explicitly downloaded and installed for other systems.
+To download DCGM, you must first register for the NVIDIA developer program,
+after which you should be able to download DCGM from the [NVIDIA developer portal](https://developer.nvidia.com/dcgm).
+DCGM can be downloaded as either an RPM package, for Red Hat and compatible systems; or as a DEB package, for Ubuntu.
+
+Once DCGM has been downloaded, you can install it using DeepOps via the [nvidia-dcgm](../../playbooks/nvidia-software/nvidia-dcgm.yml) playbook.
+
+1. Download the DCGM package and place it on your Ansible control node.
+1. In your DeepOps configuration, set either the `dcgm_deb_package` or `dcgm_rpm_package` variable to the file path of the DCGM package.
+1. Either run the `playbooks/nvidia-software/nvidia-dcgm.yml` playbook directly, or run the `slurm-cluster.yml` playbook with `slurm_install_dcgm: true`.

--- a/playbooks/ngc-ready-server.yml
+++ b/playbooks/ngc-ready-server.yml
@@ -8,6 +8,9 @@
 - include: nvidia-software/nvidia-driver.yml
 - include: container/nvidia-docker.yml
 
+- include: nvidia-software/nvidia-dcgm.yml
+  when: install_dcgm|default(false)
+
 - hosts: all
   become: true
   vars:

--- a/playbooks/nvidia-software/nvidia-dcgm.yml
+++ b/playbooks/nvidia-software/nvidia-dcgm.yml
@@ -1,0 +1,5 @@
+---
+- hosts: "{{ hostlist | default('all') }}"
+  become: true
+  roles:
+  - nvidia-dcgm

--- a/playbooks/slurm-cluster.yml
+++ b/playbooks/slurm-cluster.yml
@@ -40,6 +40,10 @@
     hostlist: "{{ nfs_client_group | default('slurm-node') }}"
   when: slurm_enable_nfs_client_nodes
 
+# Install DCGM
+- include: nvidia-software/nvidia-dcgm.yml hostlist=slurm-node
+  when: slurm_install_dcgm|default(false)
+
 # Install Node Health Check
 - include: slurm-cluster/nhc.yml hostlist=slurm-node
   when: slurm_install_nhc|default(false)

--- a/playbooks/slurm-cluster.yml
+++ b/playbooks/slurm-cluster.yml
@@ -42,7 +42,7 @@
 
 # Install DCGM
 - include: nvidia-software/nvidia-dcgm.yml hostlist=slurm-node
-  when: slurm_install_dcgm|default(false)
+  when: install_dcgm|default(false)
 
 # Install Node Health Check
 - include: slurm-cluster/nhc.yml hostlist=slurm-node

--- a/roles/nvidia-dcgm/defaults/main.yml
+++ b/roles/nvidia-dcgm/defaults/main.yml
@@ -1,0 +1,14 @@
+---
+# DCGM is available through package repositories for DGX, but for other host
+# types you must download from the NVIDIA Developer portal at
+# https://developer.nvidia.com/dcgm
+# To install DCGM, please download the correct package type(s) and set the
+# following variables to a path where the file exists on the Ansible control
+# machine.
+#
+# dcgm_rpm_package: "/tmp/datacenter-gpu-manager.rpm"
+# dcgm_deb_package: "/tmp/datacenter-gpu-manager.deb"
+
+# Location where the packages will be copied on the nodes
+dcgm_rpm_dest_path: "/tmp/datacenter-gpu-manager.rpm"
+dcgm_deb_dest_path: "/tmp/datacenter-gpu-manager.deb"

--- a/roles/nvidia-dcgm/tasks/install-dgx.yml
+++ b/roles/nvidia-dcgm/tasks/install-dgx.yml
@@ -1,0 +1,5 @@
+---
+- name: install DCGM from repos
+  package:
+    name: "datacenter-gpu-manager"
+    state: present

--- a/roles/nvidia-dcgm/tasks/install-redhat.yml
+++ b/roles/nvidia-dcgm/tasks/install-redhat.yml
@@ -1,0 +1,18 @@
+---
+- name: ensure package var is defined
+  fail:
+    msg: "dcgm_rpm_package must be defined with file path to package"
+  when: dcgm_rpm_package is not defined
+
+- name: copy rpm to nodes
+  copy:
+    src: "{{ dcgm_rpm_package }}"
+    dest: "{{ dcgm_rpm_dest_path }}"
+    owner: "root"
+    group: "root"
+    mode: "0644"
+
+- name: install package
+  yum:
+    name: "{{ dcgm_rpm_dest_path }}"
+    state: "present"

--- a/roles/nvidia-dcgm/tasks/install-ubuntu.yml
+++ b/roles/nvidia-dcgm/tasks/install-ubuntu.yml
@@ -1,0 +1,18 @@
+---
+- name: ensure package var is defined
+  fail:
+    msg: "dcgm_deb_package must be defined with file path to package"
+  when: dcgm_deb_package is not defined
+
+- name: copy deb to nodes
+  copy:
+    src: "{{ dcgm_deb_package }}"
+    dest: "{{ dcgm_deb_dest_path }}"
+    owner: "root"
+    group: "root"
+    mode: "0644"
+
+- name: install package
+  apt:
+    deb: "{{ dcgm_deb_dest_path }}"
+    state: "present"

--- a/roles/nvidia-dcgm/tasks/main.yml
+++ b/roles/nvidia-dcgm/tasks/main.yml
@@ -1,0 +1,24 @@
+---
+- name: Check for DGX
+  when: ansible_product_name is search("DGX")
+  set_fact:
+    dcgm_is_dgx: true
+
+- name: DGX tasks
+  when: dcgm_is_dgx
+  include: install-dgx.yml
+
+- name: Ubuntu tasks
+  when: (ansible_distribution == "Ubuntu") and not dcgm_is_dgx
+  include: install-ubuntu.yml
+
+- name: Red Hat family tasks
+  when: (ansible_os_family == "RedHat") and not dcgm_is_dgx
+  include: install-redhat.yml
+
+- name: Start the DCGM service
+  systemd:
+    daemon_reload: yes
+    name: "dcgm"
+    state: "started"
+    enabled: true

--- a/roles/nvidia-dcgm/vars/main.yml
+++ b/roles/nvidia-dcgm/vars/main.yml
@@ -1,0 +1,2 @@
+---
+dcgm_is_dgx: false


### PR DESCRIPTION
DCGM is extremely useful for health checking and diagnostics, but on non-DGX systems it must be explicitly downloaded and installed. We can't download this in DeepOps, because it requires an NVIDIA developer login, but we can provide a pointer and install the package once it's downloaded.

On a DGX, this role will just attempt to install the package from the repositories.

## Test plan

1. Follow the instructions in `docs/slurm-cluster/dcgm.md` to install DCGM and install it.
1. Check that the `datacenter-gpu-manager` package is installed and the `dcgm` service is running.