### PR TITLE
Fix incorrect paths in k8s deploy ingress script

### DIFF
--- a/scripts/k8s/deploy_ingress.sh
+++ b/scripts/k8s/deploy_ingress.sh
@@ -3,10 +3,10 @@ set -x
 
 # Get absolute path for script and root
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-ROOT_DIR="${SCRIPT_DIR}/.."
+ROOT_DIR="${SCRIPT_DIR}/../.."
 CHART_VERSION="1.22.1"
 
-./scripts/install_helm.sh
+./scripts/k8s/install_helm.sh
 
 # Allow overriding the app name with an env var
 app_name="${NGINX_INGRESS_APP_NAME:-nginx-ingress}"


### PR DESCRIPTION
The script to deploy the ingress controller had a couple bad paths after the re-org PR