### PR TITLE
Set ROOT_DIR correctly in a few places

### DIFF
--- a/scripts/airgap/build_offline_cache.sh
+++ b/scripts/airgap/build_offline_cache.sh
@@ -2,7 +2,7 @@
 set -ex
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-ROOT_DIR="${SCRIPT_DIR}/.."
+ROOT_DIR="${SCRIPT_DIR}/../.."
 DEEPOPS_CONFIG_DIR="${DEEPOPS_CONFIG_DIR:-${ROOT_DIR}/config.example}"
 DEST_DIR="/tmp/deepops"
 TARBALL="/tmp/deepops-archive.tar"

--- a/scripts/k8s/deploy_ingress.sh
+++ b/scripts/k8s/deploy_ingress.sh
@@ -6,7 +6,7 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 ROOT_DIR="${SCRIPT_DIR}/../.."
 CHART_VERSION="1.22.1"
 
-./scripts/k8s/install_helm.sh
+${SCRIPT_DIR}/install_helm.sh
 
 # Allow overriding the app name with an env var
 app_name="${NGINX_INGRESS_APP_NAME:-nginx-ingress}"

--- a/scripts/k8s/deploy_kubeflow.sh
+++ b/scripts/k8s/deploy_kubeflow.sh
@@ -2,7 +2,7 @@
 
 # Get the DeepOps root_dir and config_dir
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-ROOT_DIR="${SCRIPT_DIR}/.."
+ROOT_DIR="${SCRIPT_DIR}/../.."
 CONFIG_DIR="${ROOT_DIR}/config"
 
 # Specify credentials for the default user.

--- a/scripts/k8s/deploy_loadbalancer.sh
+++ b/scripts/k8s/deploy_loadbalancer.sh
@@ -3,7 +3,7 @@ set -x
 
 # Get absolute path for script and root
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-ROOT_DIR="${SCRIPT_DIR}/.."
+ROOT_DIR="${SCRIPT_DIR}/../.."
 
 # Allow overriding config dir to look in
 DEEPOPS_CONFIG_DIR=${DEEPOPS_CONFIG_DIR:-"${ROOT_DIR}/config"}

--- a/scripts/k8s/verify_gpu.sh
+++ b/scripts/k8s/verify_gpu.sh
@@ -10,7 +10,7 @@ export CLUSTER_VERIFY_EXPECTED_PODS=${CLUSTER_VERIFY_EXPECTED_PODS:-}
 export CLUSTER_VERIFY_JOB=tests/cluster-gpu-test-job.yml
 # Ensure we start in the correct working directory
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-ROOT_DIR="${SCRIPT_DIR}/.."
+ROOT_DIR="${SCRIPT_DIR}/../.."
 cd "${ROOT_DIR}" || exit 1
 TESTS_DIR=$ROOT_DIR/tests
 


### PR DESCRIPTION
Make ROOT_DIR correct in a few remaining locations.


Honestly, I think there is an issue here. Currently SCRIPT_DIR points to .`/scripts/k8s/` in most of the DeepOps script. That is why this general change to ROOT_DIR was necessary. We either need this PR or another more general PR setting SCRIPT_DIR to `./scripts/` and including `k8s` in any script paths.