### PR TITLE
Update mig playbook to enable MIG per device rather than all

### DIFF
--- a/playbooks/nvidia-software/nvidia-mig.yml
+++ b/playbooks/nvidia-software/nvidia-mig.yml
@@ -5,6 +5,8 @@
   become: yes
 
   vars:
+    # Blank for none, all for all, and comma seperated list of device index otherwise (1,2,3)
+    deepops_mig_devices: "all"
     nv_services:
       - nvsm
       - nvidia-persistenced
@@ -41,12 +43,23 @@
       tags: enable, disable, never
 
     # Manage MIG
-    - name: enable MIG mode
+    - name: enable MIG mode (all devices)
       command: nvidia-smi -mig 1
       tags: enable, never
-    - name: disable MIG mode
+      when: deepops_mig_devices | default("") == "all"
+    - name: enable MIG mode (per device)
+      command: nvidia-smi -mig 1 -i "{{ deepops_mig_devices }}"
+      tags: enable, never
+      when: deepops_mig_devices | default("") != ""
+    - name: disable MIG mode (all devices)
       command: nvidia-smi -mig 0
       tags: disable, never
+      when: deepops_mig_devices | default("") == "all"
+    - name: disable MIG mode (per device)
+      command: nvidia-smi -mig 0 -i "{{ deepops_mig_devices }}"
+      tags: disable, never
+      when: deepops_mig_devices | default("") != ""
+
 
     # Post-tasks
     - name: wait for MIG stuff to settle down and nvidia-persistenced to start again


### PR DESCRIPTION
Allow MIG to be enabled/disabled on individual devices, not just all.

Introduced a new variable `deepops_mig_devices`. If it is kept at "all" there will be no change. If it is defined or blank there are considered no devices to enable/disable. Otherwise set this to a comma seperated list of device IDs to enable/disable mig on those interfaces.

Having this capability will better allow us to support "mixed" mode in Kubernetes.