### PR TITLE
Cast num_nodes as an int for arithmetic operation

### DIFF
--- a/playbooks/slurm-cluster/slurm-validation.yml
+++ b/playbooks/slurm-cluster/slurm-validation.yml
@@ -17,7 +17,7 @@
         num_nodes: "{{ node_out.stdout }}"
     - name: Set cmd variable
       set_fact:
-        cmd: "srun -N {{ num_nodes }} -G {{ num_nodes * num_gpus }} --ntasks-per-node={{ num_gpus }} --mpi=pmix --exclusive  --container-image={{ nccl_test_repo }} all_reduce_perf -b 1M -e 4G -f 2 -g {{ num_gpus }}"
+        cmd: "srun -N {{ num_nodes }} -G {{ num_nodes|int * num_gpus }} --ntasks-per-node={{ num_gpus }} --mpi=pmix --exclusive  --container-image={{ nccl_test_repo }} all_reduce_perf -b 1M -e 4G -f 2 -g {{ num_gpus }}"
     - name: Print node/gpu counts
       debug:
               msg:
@@ -26,7 +26,7 @@
 
     - name: Execute NCCL test across all nodes and GPUs
       shell: >
-              srun -N {{ num_nodes }} -G {{ num_nodes * num_gpus }} --ntasks-per-node={{ num_gpus }} --mpi=pmix --exclusive  --container-image={{ nccl_test_repo }} all_reduce_perf -b 1M -e 4G -f 2 -g {{ num_gpus }}
+              srun -N {{ num_nodes }} -G {{ num_nodes|int * num_gpus }} --ntasks-per-node={{ num_gpus }} --mpi=pmix --exclusive  --container-image={{ nccl_test_repo }} all_reduce_perf -b 1M -e 4G -f 2 -g {{ num_gpus }}
       register: out
     - name: Print results
       debug: 


### PR DESCRIPTION
Since num_nodes is declared as a string (double quotations marks), num_nodes should be cast as an integer before performing arithmetic operation.