### PR TITLE
Update default HPC-SDK to 20.9

### DIFF
--- a/roles/nvidia-hpc-sdk/defaults/main.yml
+++ b/roles/nvidia-hpc-sdk/defaults/main.yml
@@ -1,19 +1,27 @@
 ---
-hpcsdk_version: "2020_207"
+# Version numbers
+hpcsdk_major_version: "20"
+hpcsdk_minor_version: "9"
+hpcsdk_file_cuda: "11.0"
+hpcsdk_default_cuda: "11.0"
 hpcsdk_arch: "x86_64"
-hpcsdk_cuda: "11.0"
-hpcsdk_download_name: "nvhpc_{{ hpcsdk_version }}_Linux_{{ hpcsdk_arch }}_cuda_{{ hpcsdk_cuda }}"
-hpcsdk_download_url: "https://developer.download.nvidia.com/hpc-sdk/{{ hpcsdk_download_name }}.tar.gz"
 
+# Install in the user PATH and/or install module files
+hpcsdk_install_as_modules: false
+hpcsdk_install_in_path: true
+
+# Construct the download URL
+hpcsdk_file_version: "20{{ hpcsdk_major_version }}_{{ hpcsdk_major_version }}{{hpcsdk_minor_version }}"
+hpcsdk_download_name: "nvhpc_{{ hpcsdk_file_version }}_Linux_{{ hpcsdk_arch }}_cuda_{{ hpcsdk_file_cuda }}"
+hpcsdk_version_dir: "{{ hpcsdk_major_version }}.{{ hpcsdk_minor_version }}"
+hpcsdk_download_url: "https://developer.download.nvidia.com/hpc-sdk/{{ hpcsdk_version_dir }}/{{ hpcsdk_download_name }}.tar.gz"
+
+# Directories for install
 hpcsdk_install_dir: "/sw/hpc-sdk"
 hpcsdk_install_type: "single"
-hpcsdk_default_cuda: "11.0"
-hpcsdk_version_dir: "20.7"
 
+# Directories for download
 hpcsdk_temp_dir: "/tmp/hpc-sdk-install"
 hpcsdk_dest_download_path: "{{ hpcsdk_temp_dir }}/nvhpc.tar.gz"
 hpcsdk_clean_up_tarball_after_extract: false
 hpcsdk_clean_up_temp_dir: false
-
-hpcsdk_install_as_modules: false
-hpcsdk_install_in_path: true

--- a/roles/nvidia-hpc-sdk/defaults/main.yml
+++ b/roles/nvidia-hpc-sdk/defaults/main.yml
@@ -23,5 +23,5 @@ hpcsdk_install_type: "single"
 # Directories for download
 hpcsdk_temp_dir: "/tmp/hpc-sdk-install"
 hpcsdk_dest_download_path: "{{ hpcsdk_temp_dir }}/nvhpc.tar.gz"
-hpcsdk_clean_up_tarball_after_extract: false
-hpcsdk_clean_up_temp_dir: false
+hpcsdk_clean_up_tarball_after_extract: true
+hpcsdk_clean_up_temp_dir: true

--- a/roles/nvidia-hpc-sdk/defaults/main.yml
+++ b/roles/nvidia-hpc-sdk/defaults/main.yml
@@ -1,24 +1,47 @@
 ---
-# Version numbers
+# The HPC SDK is downloaded from a URL that looks like this:
+#   https://developer.download.nvidia.com/hpc-sdk/20.9/nvhpc_2020_209_Linux_x86_64_cuda_11.0.tar.gz
+#
+# And we construct this URL from vars that can be specified in Ansible configuration:
+#   - hpcsdk_major_version: e.g. 20
+#   - hpcsdk_minor_version: e.g. 9
+#   - hpcsdk_file_cuda:     e.g. 11.0
+#   - hpcsdk_arch:          e.g. x86_64
+#
+# Note that the valid choices for hpcsdk_file_cuda are the latest CUDA
+# toolkit supported (e.g. 11.0) or a tarball which includes the last three
+# releases (named multi).
+# 
+# See https://developer.nvidia.com/nvidia-hpc-sdk-downloads for more detail on available downloads.
+
+# Version strings used to construct download URL
 hpcsdk_major_version: "20"
 hpcsdk_minor_version: "9"
 hpcsdk_file_cuda: "11.0"
-hpcsdk_default_cuda: "11.0"
 hpcsdk_arch: "x86_64"
 
-# Install in the user PATH and/or install module files
+# We need to specify the default CUDA toolkit to use during installation.
+# This should usually be the latest CUDA included in the HPC SDK you are
+# installing.
+hpcsdk_default_cuda: "11.0"
+
+# Add HPC SDK modules to the MODULEPATH?
 hpcsdk_install_as_modules: false
+
+# Add HPC SDK to the default user PATH?
 hpcsdk_install_in_path: true
+
+# Directory to install in
+hpcsdk_install_dir: "/sw/hpc-sdk"
+
+# Install type (should usually be "single")
+hpcsdk_install_type: "single"
 
 # Construct the download URL
 hpcsdk_file_version: "20{{ hpcsdk_major_version }}_{{ hpcsdk_major_version }}{{hpcsdk_minor_version }}"
 hpcsdk_download_name: "nvhpc_{{ hpcsdk_file_version }}_Linux_{{ hpcsdk_arch }}_cuda_{{ hpcsdk_file_cuda }}"
 hpcsdk_version_dir: "{{ hpcsdk_major_version }}.{{ hpcsdk_minor_version }}"
 hpcsdk_download_url: "https://developer.download.nvidia.com/hpc-sdk/{{ hpcsdk_version_dir }}/{{ hpcsdk_download_name }}.tar.gz"
-
-# Directories for install
-hpcsdk_install_dir: "/sw/hpc-sdk"
-hpcsdk_install_type: "single"
 
 # Directories for download
 hpcsdk_temp_dir: "/tmp/hpc-sdk-install"


### PR DESCRIPTION
## Summary

* Updates the default HPC SDK to 20.9.
* Restructures version vars so that it's easier to change version in one place and automatically construct the actual URL, paths, etc
* Change default to automatically cleaning up after download

## Test plan

### Test 1: Install 20.9

On a machine that already had HPC SDK 20.7 installed with DeepOps, ran the updated playbook:

```
ansible-playbook -i virtual/config/inventory -l virtual-gpu01 playbooks/nvidia-software/nvidia-hpc-sdk.yml
```

And after it ran, observed that both versions of the SDK are now installed!

```
vagrant@ubuntu1804:/sw/hpc-sdk/Linux_x86_64$ ls -l
total 12
drwxr-xr-x 2 root root 4096 Oct  7 16:08 2020
drwxr-xr-x 9 root root 4096 Oct  7 15:42 20.7
drwxr-xr-x 9 root root 4096 Oct  7 16:07 20.9
```

And that 20.9 is correctly now the default:

```
vagrant@ubuntu1804:/sw/hpc-sdk/Linux_x86_64$ ls 2020/ -l
total 0
lrwxrwxrwx 1 root root 17 Oct  7 16:08 comm_libs -> ../20.9/comm_libs
lrwxrwxrwx 1 root root 17 Oct  7 16:08 compilers -> ../20.9/compilers
lrwxrwxrwx 1 root root 12 Oct  7 16:08 cuda -> ../20.9/cuda
lrwxrwxrwx 1 root root 16 Oct  7 16:08 examples -> ../20.9/examples
lrwxrwxrwx 1 root root 17 Oct  7 16:08 math_libs -> ../20.9/math_libs
lrwxrwxrwx 1 root root 17 Oct  7 16:08 profilers -> ../20.9/profilers
```

### Test 2: Install previous version (20.7)

On a fresh VM, tested installation of HPC SDK 20.7 by setting the major and minor version vars:

```
ansible-playbook -i virtual/config/inventory -l virtual-login01 -e '{"hpcsdk_major_version": "20", "hpcsdk_minor_version": "7"}' playbooks/nvidia-software/nvidia-hpc-sdk.yml
```

Playbook run succeeded, and checking on the VM itself:

```
vagrant@ubuntu1804:~$ ls /sw/hpc-sdk/Linux_x86_64/
2020  20.7
vagrant@ubuntu1804:~$ ls -l /sw/hpc-sdk/Linux_x86_64/2020/
total 0
lrwxrwxrwx 1 root root 17 Oct  8 15:22 comm_libs -> ../20.7/comm_libs
lrwxrwxrwx 1 root root 17 Oct  8 15:22 compilers -> ../20.7/compilers
lrwxrwxrwx 1 root root 12 Oct  8 15:22 cuda -> ../20.7/cuda
lrwxrwxrwx 1 root root 16 Oct  8 15:22 examples -> ../20.7/examples
lrwxrwxrwx 1 root root 17 Oct  8 15:22 math_libs -> ../20.7/math_libs
lrwxrwxrwx 1 root root 17 Oct  8 15:22 profilers -> ../20.7/profilers
```