### PR TITLE
Bump Jenkins Kubeflow deployment test timeout

### DIFF
--- a/workloads/jenkins/Jenkinsfile-multi-nightly
+++ b/workloads/jenkins/Jenkinsfile-multi-nightly
@@ -58,7 +58,7 @@ pipeline {
 
           echo "Test Kubeflow installation"
           sh '''
-             timeout 3000 bash -x ./workloads/jenkins/scripts/test-kubeflow.sh
+             timeout 4000 bash -x ./workloads/jenkins/scripts/test-kubeflow.sh
           '''
 
           echo "Test Monitoring installation"
@@ -156,7 +156,7 @@ pipeline {
 
           echo "Test Kubeflow installation"
           sh '''
-             timeout 3000 bash -x ./workloads/jenkins/scripts/test-kubeflow.sh
+             timeout 4000 bash -x ./workloads/jenkins/scripts/test-kubeflow.sh
           '''
 
           echo "Test Monitoring installation"

--- a/workloads/jenkins/Jenkinsfile-nightly
+++ b/workloads/jenkins/Jenkinsfile-nightly
@@ -58,7 +58,7 @@ pipeline {
 
           echo "Test Kubeflow installation"
           sh '''
-             timeout 3000 bash -x ./workloads/jenkins/scripts/test-kubeflow.sh
+             timeout 4000 bash -x ./workloads/jenkins/scripts/test-kubeflow.sh
           '''
 
           echo "Test Monitoring installation"
@@ -151,7 +151,7 @@ pipeline {
 
           echo "Test Kubeflow installation"
           sh '''
-             timeout 3000 bash -x ./workloads/jenkins/scripts/test-kubeflow.sh
+             timeout 4000 bash -x ./workloads/jenkins/scripts/test-kubeflow.sh
           '''
 
           echo "Test Monitoring installation"


### PR DESCRIPTION
* The timeout is currently ~50 minutes (3000s) I bumped it to ~60 minutes (4000s)
* The tests have randomly been failing nightlies. The timing seems very tight, usually finishing in 40m. Occassionally deleting takes a bit longer.