### PR TITLE
Fix OpenMPI config flag on CentOS

### DIFF
--- a/config.example/group_vars/slurm-cluster.yml
+++ b/config.example/group_vars/slurm-cluster.yml
@@ -119,7 +119,7 @@ hpcsdk_install_in_path: false
 slurm_cluster_install_openmpi: false
 openmpi_version: 4.0.4
 openmpi_install_prefix: "/usr/local"
-openmpi_configure: "./configure --prefix={{ openmpi_install_prefix }} --disable-dependency-tracking --disable-getpwuid --with-pmix={{ pmix_install_prefix }} --with-hwloc={{ hwloc_install_prefix }} --with-pmi={{ slurm_install_prefix }} --with-slurm={{ slurm_install_prefix }}"
+openmpi_configure: "./configure --prefix={{ openmpi_install_prefix }} --disable-dependency-tracking --disable-getpwuid --with-pmix={{ pmix_install_prefix }} --with-hwloc={{ hwloc_install_prefix }} --with-pmi={{ slurm_install_prefix }} --with-slurm={{ slurm_install_prefix }} --with-libevent=/usr"
 
 ################################################################################
 # Open OnDemand                                                                #


### PR DESCRIPTION
Building OpenMPI on CentOS with an external PMIx requires that we explicitly specify the location of libevent, even when it's in the
system paths.