### PR TITLE
Change Jenkins MPI test to use NVHPC

### DIFF
--- a/virtual/vars_files/virt_slurm.yml
+++ b/virtual/vars_files/virt_slurm.yml
@@ -11,6 +11,3 @@ slurm_allow_ssh_user:
 hpcsdk_clean_up_tarball_after_extract: true
 hpcsdk_clean_up_temp_dir: true
 slurm_build_dir_cleanup: true
-
-# Build OpenMPI locally for testing
-slurm_cluster_install_openmpi: true

--- a/workloads/jenkins/scripts/remote-script-for-mpi.sh
+++ b/workloads/jenkins/scripts/remote-script-for-mpi.sh
@@ -1,0 +1,12 @@
+#!/bin/bash -l
+#
+# Test compiling and running an MPI program using NVIDIA HPC SDK
+
+set -x
+set -euo pipefail
+
+module load nvhpc
+
+mpicc -o "${HOME}/hello" "${HOME}/mpi-hello.c"
+
+srun --mpi=pmix -n2 "${HOME}/hello"

--- a/workloads/jenkins/scripts/test-mpi-job.sh
+++ b/workloads/jenkins/scripts/test-mpi-job.sh
@@ -9,6 +9,14 @@ scp  \
 	workloads/examples/slurm/mpi-hello/mpi-hello.c \
 	"vagrant@10.0.0.5${GPU01}:mpi-hello.c"
 
+# Upload test script
+scp  \
+	-o "StrictHostKeyChecking no" \
+	-o "UserKnownHostsFile /dev/null" \
+	-i "${HOME}/.ssh/id_rsa" \
+	workloads/jenkins/scripts/remote-script-for-mpi.sh \
+	"vagrant@10.0.0.5${GPU01}:remote-script-for-mpi.sh"
+
 # Compile the program
 ssh \
 	-o "StrictHostKeyChecking no" \
@@ -16,13 +24,4 @@ ssh \
 	-l vagrant \
 	-i "${HOME}/.ssh/id_rsa" \
 	"10.0.0.5${GPU01}" \
-	mpicc -o ./mpi-hello mpi-hello.c
-
-# Run with srun
-ssh \
-	-o "StrictHostKeyChecking no" \
-	-o "UserKnownHostsFile /dev/null" \
-	-l vagrant \
-	-i "${HOME}/.ssh/id_rsa" \
-	"10.0.0.5${GPU01}" \
-	srun --mpi=pmix -n 2 '~/mpi-hello'
+	"bash -l /home/vagrant/remote-script-for-mpi.sh"


### PR DESCRIPTION
Change the Jenkins MPI test to use NVHPC instead of our hand-built OpenMPI.

If this works well we can drop the OpenMPI build from our Jenkins tests, since we want to test the NVHPC install anyway.