### PR TITLE
Migrate short/useful tests from nightlies into regular testing

### DIFF
--- a/workloads/jenkins/Jenkinsfile
+++ b/workloads/jenkins/Jenkinsfile
@@ -51,6 +51,21 @@ pipeline {
              bash -x ./workloads/jenkins/scripts/verify-ingress-config.sh
           '''
 
+          echo "Test Rook+Ceph installation"
+          sh '''
+            timeout 2200 bash -x ./workloads/jenkins/scripts/test-ceph.sh
+          '''
+
+          echo "Test Monitoring installation"
+          sh '''
+            timeout 800 bash -x ./workloads/jenkins/scripts/test-monitoring.sh
+          '''
+
+          echo "Test Dashboard installation"
+          sh '''
+            timeout 180 bash -x ./workloads/jenkins/scripts/test-dashboard.sh
+          '''
+
           echo "Set up Slurm"
           sh '''
             bash -x ./workloads/jenkins/scripts/test-setup-slurm.sh

--- a/workloads/jenkins/Jenkinsfile-multi-nightly
+++ b/workloads/jenkins/Jenkinsfile-multi-nightly
@@ -93,9 +93,14 @@ pipeline {
             timeout 60 bash -x ./workloads/jenkins/scripts/test-slurm-job.sh
           '''
 
+          echo "Test NFS"
+          sh '''
+            timeout 60 bash -x ./workloads/jenkins/scripts/test-slurm-nfs-mount.sh
+          '''
+
           echo "Test MPI"
           sh '''
-            timeout 60 bash -x ./.jenkins-scripts/test-mpi-job.sh
+            timeout 60 bash -x ./workloads/jenkins/scripts/test-mpi-job.sh
           '''
 
           echo "Reset repo and unmunge files"
@@ -189,6 +194,16 @@ pipeline {
           echo "Test Slurm"
           sh '''
             timeout 60 bash -x ./workloads/jenkins/scripts/test-slurm-job.sh
+          '''
+
+          echo "Test NFS"
+          sh '''
+            timeout 60 bash -x ./workloads/jenkins/scripts/test-slurm-nfs-mount.sh
+          '''
+
+          echo "Test MPI"
+          sh '''
+            timeout 60 bash -x ./workloads/jenkins/scripts/test-mpi-job.sh
           '''
         }
       }

--- a/workloads/jenkins/Jenkinsfile-nightly
+++ b/workloads/jenkins/Jenkinsfile-nightly
@@ -93,6 +93,16 @@ pipeline {
             timeout 60 bash -x ./workloads/jenkins/scripts/test-slurm-job.sh
           '''
 
+          echo "Test NFS"
+          sh '''
+            timeout 60 bash -x ./workloads/jenkins/scripts/test-slurm-nfs-mount.sh
+          '''
+
+          echo "Test MPI"
+          sh '''
+            timeout 60 bash -x ./workloads/jenkins/scripts/test-mpi-job.sh
+          '''
+
           echo "Reset repo and unmunge files"
           sh '''
             git reset --hard
@@ -183,12 +193,17 @@ pipeline {
 
           echo "Test Slurm"
           sh '''
-            timeout 60  bash -x ./workloads/jenkins/scripts/test-slurm-job.sh
+            timeout 60 bash -x ./workloads/jenkins/scripts/test-slurm-job.sh
+          '''
+
+          echo "Test NFS"
+          sh '''
+            timeout 60 bash -x ./workloads/jenkins/scripts/test-slurm-nfs-mount.sh
           '''
 
           echo "Test MPI"
           sh '''
-            timeout 60 bash -x ./.jenkins-scripts/test-mpi-job.sh
+            timeout 60 bash -x ./workloads/jenkins/scripts/test-mpi-job.sh
           '''
         }
       }


### PR DESCRIPTION
We've been running these tests in the nightlies for a few months now and they have been very stable and passing (until something breaks). The kubeflow tests are failing on occassion and are not included in this PR, but this will verify rook/ceph, it will install/verify the K8S dashboard, and it will install/verify the monitoring stack. Altogether the tests will take no more than 5 minutes extra.

In addition to that change I've rolled fixes for MPI checks and NFS checks into the nightly tests, until such time when we can update Jenkins to not require mutltiple similar Jenkinsfiles.