### PR TITLE
Ignore errors when copying slurm service files

### DIFF
--- a/roles/slurm/tasks/service-files.yml
+++ b/roles/slurm/tasks/service-files.yml
@@ -8,6 +8,7 @@
     - slurmctld.service
     - slurmdbd.service
   when: is_controller
+  ignore_errors: yes
 
 - name: copy service files
   copy:
@@ -17,3 +18,4 @@
   with_items:
     - slurmd.service
   when: is_compute
+  ignore_errors: yes


### PR DESCRIPTION
When this playbook is run on a cluster where slurm is already installed, it will skip the slurm build. This is good, but if we have cleaned up the build in the mean time then the tasks for copying the slurm service files (which is separate from the build) will fail, killing the whole playbook run.

This change ignores errors on the step where we copy the service files, so that the playbook can run correctly in the case of an already-installed cluster.

It should be safe to ignore errors for copying these files, because if they're absent then the playbook will fail later when we try to start the services.

## Test plan

Run the Slurm cluster playbook with `slurm_build_dir_cleanup: yes`. Then run it a second time! Before this PR, this will fail due to absence of the slurm service files in the build dir; after this PR, it should succeed.