### PR TITLE
Update nvidia-docker playbook to set nvidia as default runtime in DGX

### DIFF
--- a/config.example/group_vars/all.yml
+++ b/config.example/group_vars/all.yml
@@ -127,6 +127,15 @@ docker_storage_options: -s overlay2
 #docker_options: "--bip=192.168.99.1/24"
 # Install DeepOps version of Docker on DGX
 docker_override_dgx: false
+
+# Value to override /etc/docker/daemon.json, minimally default runtime required for k8s
+docker_daemon_json_override_dgx:
+  runtimes:
+    nvidia:
+      path: /usr/bin/nvidia-container-runtime
+      runtimeArgs: []
+  default-runtime: nvidia
+
 # Enable docker iptables
 # If this isn't set, containers won't have access to the outside net
 # See https://github.com/kubernetes-sigs/kubespray/issues/2002

--- a/playbooks/container/nvidia-docker.yml
+++ b/playbooks/container/nvidia-docker.yml
@@ -21,4 +21,22 @@
       when:
         - ansible_local['gpus']['count'] and (ansible_distribution == "Ubuntu" or ansible_os_family == "RedHat")
         - ansible_product_name is not search("DGX") or docker_override_dgx
+
+    - name: Override docker daemon json on DGX
+      copy:
+        content: "{{ docker_daemon_json_override_dgx | to_nice_json }}"
+        dest: /etc/docker/daemon.json
+        owner: root
+        group: root
+        mode: 0644
+      when:
+        - ansible_product_name is search("DGX") and docker_daemon_json_override_dgx and docker_override_dgx is false
+
+    - name: reload docker
+      service:
+        name: docker
+        state: reloaded
+      when:
+        - ansible_product_name is search("DGX") and docker_daemon_json_override_dgx and docker_override_dgx is false
+
   environment: "{{ proxy_env if proxy_env is defined else {} }}"


### PR DESCRIPTION
Currently we still need to manually set `nvidia` to be the default container runtime in `/etc/docker/daemon.json`. This can be done as per the below commit.

Or an alternative approach to this would to just set the DGX override to true by default and allow the galaxy role to do the trick:
```sh
#conf/group_vars/all.yml
docker_override_dgx: true
```

I'd prefer this smaller change as it is safer and will not change docker/nvidia-docker versions, however it does somewhat defeate the purpose of the galaxy role.