### PR TITLE
NHC support for Ubuntu 20.04 sshd check

### DIFF
--- a/roles/nhc/tasks/main.yml
+++ b/roles/nhc/tasks/main.yml
@@ -1,4 +1,17 @@
 ---
+- name: "gather os specific variables"
+  include_vars: "{{ item }}"
+  with_first_found:
+    - files:
+      - "{{ ansible_distribution|lower }}-{{ ansible_distribution_version }}.yml"
+      - "{{ ansible_distribution|lower }}.yml"
+      - "{{ ansible_os_family|lower }}.yml"
+      paths:
+      - ../vars
+      skip: true
+  tags:
+    - always
+
 - name: default to building NHC
   set_fact:
     nhc_build: true

--- a/roles/nhc/templates/nhc.conf.j2
+++ b/roles/nhc/templates/nhc.conf.j2
@@ -17,7 +17,7 @@
 {% endfor %}
 
 # Check that expected processes are running
- {{ ansible_hostname }} || check_ps_service -u root -d daemon sshd
+ {{ ansible_hostname }} || check_ps_service -u root -d {{ nhc_ssh_daemon }} sshd
  {{ ansible_hostname }} || check_ps_service -u root slurmd
 
 {% if ansible_local.gpus.count > 0 %}

--- a/roles/nhc/templates/nhc.conf.j2
+++ b/roles/nhc/templates/nhc.conf.j2
@@ -17,7 +17,7 @@
 {% endfor %}
 
 # Check that expected processes are running
- {{ ansible_hostname }} || check_ps_service -u root sshd
+ {{ ansible_hostname }} || check_ps_service -u root -d daemon sshd
  {{ ansible_hostname }} || check_ps_service -u root slurmd
 
 {% if ansible_local.gpus.count > 0 %}

--- a/roles/nhc/vars/main.yml
+++ b/roles/nhc/vars/main.yml
@@ -1,0 +1,2 @@
+---
+nhc_ssh_daemon: "sshd"

--- a/roles/nhc/vars/ubuntu-20.04.yml
+++ b/roles/nhc/vars/ubuntu-20.04.yml
@@ -1,0 +1,2 @@
+---
+nhc_ssh_daemon: "sshd:"


### PR DESCRIPTION
On Ubuntu 20.04, the NHC script which checks for the `sshd` process fails to find the `sshd` service. It appears the `ssh` and `sshd` services are synonymous. This either has to do with the way the `sshd` service shows up when you run `ps`, or the fact that it's an alias for the `ssh` service (or vice versa). Either way, this fix works on both Ubuntu 18.04 and 20.04