### PR TITLE
Fix Lmod install on Ubuntu 20.04

### DIFF
--- a/roles/lmod/tasks/main.yml
+++ b/roles/lmod/tasks/main.yml
@@ -67,7 +67,9 @@
     ln -s -f /usr/lib/x86_64-linux-gnu/lua/5.1/posix_c.so /usr/lib/x86_64-linux-gnu/lua/5.1/posix.so
     ln -s -f /usr/lib/x86_64-linux-gnu/lua/5.2/posix_c.so /usr/lib/x86_64-linux-gnu/lua/5.2/posix.so
     ln -s -f /usr/lib/x86_64-linux-gnu/lua/5.3/posix_c.so /usr/lib/x86_64-linux-gnu/lua/5.3/posix.so
-  when: ansible_os_family == "Debian"
+  when: 
+    - ansible_distribution == 'Ubuntu'
+    - ansible_distribution_version == '18.04'
 
 - name: "unset previous lmod setup"
   shell: unset MODULEPATH_ROOT


### PR DESCRIPTION
The `lua-posix` package in Ubuntu 20.04 does not have the same packaging bug as the packge in 18.04. So we only make the symlink on 18.04.

This will conflict with #711 