### PR TITLE
ppa:maas/stable no longer exists, point to the latest stable version instead

### DIFF
--- a/config.example/group_vars/all.yml
+++ b/config.example/group_vars/all.yml
@@ -210,7 +210,7 @@ maas_adminusers:
 maas_dns_domain: 'deepops.local'
 maas_region_controller: '192.168.1.1'
 maas_region_controller_url: 'http://{{ maas_region_controller }}:5240/MAAS'
-maas_repo: 'ppa:maas/stable'
+maas_repo: 'ppa:maas/2.8'
 
 # Defines if maas user should generate ssh keys
 # Usable for remote KVM/libvirt power actions


### PR DESCRIPTION
The MAAS team appears to have removed the `stable` PPA, only supporting the version specific repositories (e.g. `paa:maas/2.8`) and some test repositories (such as the in-development CentOS 8 support).

https://launchpad.net/~maas

2.8 is the latest stable version today, so I propose we default to this version in our config.