### PR TITLE
Slurm high-availability support

### DIFF
--- a/config.example/group_vars/slurm-cluster.yml
+++ b/config.example/group_vars/slurm-cluster.yml
@@ -16,8 +16,6 @@ slurm_password: ReplaceWithASecurePasswordInTheVault
 slurm_db_password: AlsoReplaceWithASecurePasswordInTheVault
 #slurm_max_job_timelimit: INFINITE
 #slurm_default_job_timelimit:
-slurm_controller_host: "{{ groups['slurm-master'][0] }}"
-slurm_compute_hosts: "{{ groups['slurm-node'] }}"
 slurm_enable_monitoring: true
 
 # Ensure hosts file generation only runs across slurm cluster

--- a/config.example/group_vars/slurm-cluster.yml
+++ b/config.example/group_vars/slurm-cluster.yml
@@ -23,6 +23,12 @@ slurm_enable_monitoring: true
 # Ensure hosts file generation only runs across slurm cluster
 hosts_add_ansible_managed_hosts_groups: ["slurm-cluster"]
 
+# Enable Slurm high-availability mode
+# NOTE: The location for Slurm saved state needs to reside in a location shared by all Slurm controller nodes
+#       Ideally this is on external NFS server and not the primary control node, since its failure
+#       would also take down that NFS share
+slurm_enable_ha: false
+slurm_ha_state_save_location: "/sw/slurm"
 
 # Slurm configuration is auto-generated from templates in the `slurm` role.
 # If you want to override any of these files with custom config files, please
@@ -68,8 +74,8 @@ slurm_enable_nfs_server: true
 slurm_enable_nfs_client_nodes: true
 
 # Inventory host groups to use for NFS server or clients
-nfs_server_group: "slurm-master"
-nfs_client_group: "slurm-node"
+nfs_server_group: "slurm-master[0]"
+nfs_client_group: "slurm-master[1:],slurm-node"
 
 ################################################################################
 # SOFTWARE MODULES (SM)                                                        #

--- a/docs/slurm-cluster/README.md
+++ b/docs/slurm-cluster/README.md
@@ -39,6 +39,10 @@ Instructions for deploying a GPU cluster with Slurm
    # (optional) Modify `config/group_vars/*.yml` to set configuration parameters
    ```
 
+   > Note: Multiple hosts can be added to the `slurm-master` group for high-availability. You must also set
+   `slurm_enable_ha: true` in `config/group_vars/slurm-cluster.yml`. For more information about HA Slurm deployments,
+   see: https://slurm.schedmd.com/quickstart_admin.html#HA
+
 4. Verify the configuration.
 
    ```sh

--- a/playbooks/slurm-cluster.yml
+++ b/playbooks/slurm-cluster.yml
@@ -33,11 +33,11 @@
 # Set up NFS filesystem
 - include: generic/nfs-server.yml
   vars:
-    hostlist: "{{ nfs_server_group | default('slurm-master') }}"
+    hostlist: "{{ nfs_server_group | default('slurm-master[0]') }}"
   when: slurm_enable_nfs_server
 - include: generic/nfs-client.yml
   vars:
-    hostlist: "{{ nfs_client_group | default('slurm-node') }}"
+    hostlist: "{{ nfs_client_group | default('slurm-master[1:],slurm-node') }}"
   when: slurm_enable_nfs_client_nodes
 
 # Install DCGM

--- a/playbooks/slurm-cluster.yml
+++ b/playbooks/slurm-cluster.yml
@@ -60,15 +60,15 @@
   when: slurm_install_lmod
 
 # Install the NVIDIA HPC SDK
-- include: nvidia-software/nvidia-hpc-sdk.yml hostlist=slurm-master
+- include: nvidia-software/nvidia-hpc-sdk.yml hostlist=slurm-master[0]
   when: slurm_install_hpcsdk
 
 # Install monitoring tools
-- include: slurm-cluster/prometheus.yml hostlist=slurm-master
+- include: slurm-cluster/prometheus.yml hostlist=slurm-master[0]
   when: slurm_enable_monitoring
-- include: slurm-cluster/grafana.yml hostlist=slurm-master
+- include: slurm-cluster/grafana.yml hostlist=slurm-master[0]
   when: slurm_enable_monitoring
-- include: slurm-cluster/prometheus-slurm-exporter.yml hostlist=slurm-master
+- include: slurm-cluster/prometheus-slurm-exporter.yml hostlist=slurm-master[0]
   when: slurm_enable_monitoring
 - include: slurm-cluster/prometheus-node-exporter.yml
   when: slurm_enable_monitoring

--- a/playbooks/slurm-cluster/easybuild-modules.yml
+++ b/playbooks/slurm-cluster/easybuild-modules.yml
@@ -6,7 +6,10 @@
   roles:
     - name: lmod
 
-- hosts: slurm-master
+- hosts: slurm-master[0]
   roles:
     - name: easy-build
+
+- hosts: slurm-master
+  roles:
     - name: easy-build-packages

--- a/playbooks/slurm-cluster/logging.yml
+++ b/playbooks/slurm-cluster/logging.yml
@@ -1,5 +1,5 @@
 ---
-- hosts: slurm-master
+- hosts: slurm-master[0]
   become: true
   vars:
     elasticsearch_network_host: 0.0.0.0

--- a/playbooks/slurm-cluster/open-ondemand.yml
+++ b/playbooks/slurm-cluster/open-ondemand.yml
@@ -1,5 +1,5 @@
 ---
-- hosts: slurm-master
+- hosts: slurm-master[0]
   become: yes
   roles:
     - {role: ood-wrapper, ood_is_server: yes }

--- a/playbooks/slurm-cluster/slurm-validation.yml
+++ b/playbooks/slurm-cluster/slurm-validation.yml
@@ -1,6 +1,6 @@
 ---
 # Playbook designed to run a NCCL test across all nodes in a cluster of DGX-1s
-- hosts: slurm-master
+- hosts: slurm-master[0]
   vars:
     nccl_test_repo: "deepops/nccl-tests-tf20.06-ubuntu18.04:latest" # Public repository for nccl performance/validation tests
     num_gpus: 8 # A DGX A100 Server has 8 GPUs

--- a/playbooks/slurm-cluster/spack-modules.yml
+++ b/playbooks/slurm-cluster/spack-modules.yml
@@ -5,7 +5,7 @@
   roles:
   - lmod
 
-- hosts: "{{ hostlist | default('slurm-master') }}"
+- hosts: "{{ hostlist | default('slurm-master[0]') }}"
   become: yes
   roles:
   - spack

--- a/roles/prometheus-slurm-exporter/templates/slurm-exporter.yml.j2
+++ b/roles/prometheus-slurm-exporter/templates/slurm-exporter.yml.j2
@@ -1,3 +1,3 @@
-- targets: [{{ groups['slurm-master'] | zip_longest([], fillvalue=':8080') | map('join') | join(',') }}]
+- targets: [{{ groups['slurm-master'][0] | zip_longest([], fillvalue=':8080') | map('join') | join(',') }}]
   labels:
     module: slurm-exporter

--- a/roles/slurm/defaults/main.yml
+++ b/roles/slurm/defaults/main.yml
@@ -28,6 +28,9 @@ slurm_allow_ssh_user: []
 slurm_db_username: slurm
 slurm_db_password: AlsoReplaceWithASecurePasswordInTheVault
 
+slurm_enable_ha: false
+slurm_ha_state_save_location: "/sw/slurm"
+
 is_controller: no
 is_compute: no
 

--- a/roles/slurm/tasks/controller.yml
+++ b/roles/slurm/tasks/controller.yml
@@ -61,6 +61,14 @@
     - /var/spool/slurm/ctld
     - /var/log/slurm
 
+- name: create slurm HA directory
+  file:
+    path: "{{ slurm_ha_state_save_location }}"
+    state: directory
+    owner: slurm
+    mode: 0755
+  when: "{{ slurm_enable_ha }}"
+
 - name: configure slurm.conf
   template:
     src: "{{ slurm_conf_template }}"

--- a/roles/slurm/templates/etc/slurm/slurm.conf
+++ b/roles/slurm/templates/etc/slurm/slurm.conf
@@ -9,12 +9,15 @@
 # See the slurm.conf man page for more information.
 #
 ClusterName={{ slurm_cluster_name }}
-ControlMachine={{ groups["slurm-master"][0] }}
-
-# TODO: configure a HA Slurm clusters with our Ansible Module
-#ControlAddr=
-#BackupController=
-#BackupAddr=
+{% if slurm_enable_ha %}
+{% for node_name in groups['slurm-master'] %}
+SlurmctldHost={{ node_name }}
+{% endfor %}
+StateSaveLocation={{ slurm_ha_state_save_location }}
+{% else %}
+SlurmctldHost={{ groups['slurm-master'][0] }}
+StateSaveLocation=/var/spool/slurm/ctld
+{% endif %}
 
 SlurmUser={{ slurm_username }}
 SlurmctldPort=6817
@@ -22,7 +25,6 @@ SlurmdPort=6818
 AuthType=auth/munge
 #JobCredentialPrivateKey=
 #JobCredentialPublicCertificate=
-StateSaveLocation=/var/spool/slurm/ctld
 SlurmdSpoolDir=/var/spool/slurm/d
 SwitchType=switch/none
 {% if slurm_include_pmix %}

--- a/roles/slurm/templates/etc/slurm/slurm.conf
+++ b/roles/slurm/templates/etc/slurm/slurm.conf
@@ -68,7 +68,7 @@ TaskPlugin=affinity,cgroup
 #UsePAM=
 #
 # TIMERS
-SlurmctldTimeout=300
+SlurmctldTimeout=120
 SlurmdTimeout=300
 InactiveLimit=0
 MinJobAge=300


### PR DESCRIPTION
To test:
* Set `slurm_enable_ha: true` in `config/group_vars/slurm-cluster.yml`
* Add more than one node to the slurm-master group in `config/inventory`

To verify; after deployment, stop the `slurmctld` service on the primary node and verify the backup node has picked up control.

I'm seeing some log messages on the backup controller like: `error: Invalid RPC received 1002 while in standby mode`, but it seems like this is normal during the time between the primary controller going down and the backup taking over. Unfortunately it also seems normal that requests querying the controller are unresponsive during this window (this PR changes it to 120 seconds (the default)).

Open to suggestions since this is a pretty bare-bones implementation.