### PR TITLE
Add build dependencies for NHC

### DIFF
--- a/roles/nhc/tasks/main.yml
+++ b/roles/nhc/tasks/main.yml
@@ -26,6 +26,14 @@
     nhc_build: false
   when: nhc_check.rc == 0 and not nhc_force_reinstall
 
+- name: install build dependencies
+  apt:
+    name: "{{ item }}"
+    state: present
+    update_cache: yes
+  with_items: "{{ nhc_build_deps }}"
+  when: ansible_distribution == 'Ubuntu'
+
 - name: ensure build dir exists
   file:
     path: "{{ nhc_build_dir }}"

--- a/roles/nhc/vars/ubuntu.yml
+++ b/roles/nhc/vars/ubuntu.yml
@@ -1,5 +1,3 @@
 ---
 nhc_build_deps:
   - build-essential
-
-nhc_ssh_daemon: "sshd:"


### PR DESCRIPTION
Several of our roles which build packages from source don't specify the 'build-essential' package on Ubuntu which is required to build. Since NHC is first in the slurm-cluster playlist, I hit the failure there first :) but we'll eventually need to add this same fix to the other roles, like OpenMPI.