### PR TITLE
Fix epilog fail due to /tmp busy

### DIFF
--- a/roles/slurm/templates/etc/slurm/epilog.d/80-exclusive-tmpfiles
+++ b/roles/slurm/templates/etc/slurm/epilog.d/80-exclusive-tmpfiles
@@ -1,8 +1,11 @@
 #!/usr/bin/env bash
 set -ex
 
+tmpfs_mounted="$(findmnt /tmp | grep ' tmpfs ' | cat)"
+tmpfs_infstab="$(grep '/tmp ' /etc/fstab | grep ' tmpfs ' | cat)"
+
 # Cleanup /tmp
-if findmnt /tmp && grep "/tmp " /etc/fstab; then
+if [ ! -z "$tmpfs_mounted" ] && [ ! -z "$tmpfs_infstab" ]; then
     umount /tmp
     mount /tmp
 else


### PR DESCRIPTION
The check make sure the `/tmp` is mounted as `tmpfs` before issuing a cleanup via remount. Fixes also issue where the epilog failed due to `/tmp` being mounted, but not as `tmpfs`, which resulted in `/tmp` busy exits.

Signed-off-by: Iztok Lebar Bajec <ilb@fri.uni-lj.si>