### PR TITLE
Fix for #732; apt update fails due to GPG error

### DIFF
--- a/roles/nvidia-cuda/defaults/main.yml
+++ b/roles/nvidia-cuda/defaults/main.yml
@@ -25,4 +25,4 @@ nvidia_driver_rhel_cuda_repo_gpgkey: "https://developer.download.nvidia.com/comp
 # Ubuntu
 nvidia_driver_ubuntu_cuda_repo_gpgkey_url: "https://developer.download.nvidia.com/compute/cuda/repos/{{ _ubuntu_repo_dir }}/7fa2af80.pub"
 nvidia_driver_ubuntu_cuda_repo_gpgkey_id: "7fa2af80"
-nvidia_driver_ubuntu_cuda_repo_baseurl: "http://developer.download.nvidia.com/compute/cuda/repos/{{ _ubuntu_repo_dir }}"
+nvidia_driver_ubuntu_cuda_repo_baseurl: "https://developer.download.nvidia.com/compute/cuda/repos/{{ _ubuntu_repo_dir }}"


### PR DESCRIPTION
Note that the galaxy scripts should be updated as well.

Signed-off-by: Iztok Lebar Bajec <ilb@fri.uni-lj.si>