### PR TITLE
Fix for all GPUs visible when ssh on slurm compute node

### DIFF
--- a/roles/slurm/tasks/compute.yml
+++ b/roles/slurm/tasks/compute.yml
@@ -145,3 +145,11 @@
     marker: "# {mark} ANSIBLE MANAGED BLOCK (ansible-role-slurm)"
   tags:
     - config
+
+- name: comment out pam_systemd.so as it conflicts with pam_slurm_adapt.so, see https://slurm.schedmd.com/pam_slurm_adopt.html
+  replace:
+    path: /etc/pam.d/common-session
+    regexp: '^([^#].*pam_systemd.so.*)'
+    replace: '# \1 # ANSIBLE MANAGED (ansible-role-slurm)'
+  tags:
+    - config

--- a/roles/slurm/tasks/compute.yml
+++ b/roles/slurm/tasks/compute.yml
@@ -151,5 +151,6 @@
     path: /etc/pam.d/common-session
     regexp: '^([^#].*pam_systemd.so.*)'
     replace: '# \1 # ANSIBLE MANAGED (ansible-role-slurm)'
+  when: ansible_distribution == 'Ubuntu'
   tags:
     - config


### PR DESCRIPTION
As mentioned in https://slurm.schedmd.com/pam_slurm_adopt.html, "The pam_systemd module will conflict with pam_slurm_adopt, so you need to disable it in all files that are included in sshd or system-auth (e.g. password-auth, common-session, etc.)." 

Without disabling it, when a user started a job, they could ssh to the compute node and while there see all GPUs that are installed on the system even though their job did not specifically request for them.

Signed-off-by: Iztok Lebar Bajec <ilb@fri.uni-lj.si>