### PR TITLE
Increase security, limit access to slurmdbd.conf

### DIFF
--- a/roles/slurm/tasks/controller.yml
+++ b/roles/slurm/tasks/controller.yml
@@ -82,6 +82,7 @@
   template:
     src: "{{ slurm_dbd_conf_template }}"
     dest: "{{ slurm_config_dir }}/slurmdbd.conf"
+    mode: 0600
   notify:
   - restart slurmdbd
   tags:


### PR DESCRIPTION
According to https://www.hpcsec.com/2019/12/22/cve-2019-19727/, slurmdbd.conf should have strict access permissions as it contains clear text credentials for mysql.

Signed-off-by: Iztok Lebar Bajec <ilb@fri.uni-lj.si>