### PR TITLE
Looks like with the move from python2 to python3 we no longer need sshpass

### DIFF
--- a/playbooks/k8s-cluster.yml
+++ b/playbooks/k8s-cluster.yml
@@ -42,18 +42,6 @@
   tags:
     - bootstrap
 
-# Install 'sshpass' program for: https://github.com/ansible/ansible/issues/56629
-- hosts: all
-  gather_facts: true
-  tasks:
-    - name: install sshpass
-      package:
-        name: sshpass
-        state: present
-  environment: "{{proxy_env if proxy_env is defined else {}}}"
-  tags:
-    - bootstrap
-
 # Install Kubernetes
 # for configuration, see: config/group_vars/k8s-cluster.yml
 - include: ../submodules/kubespray/cluster.yml


### PR DESCRIPTION
We had a comment in `k8s-cluster.yml` indicating that sshpass was only needed due to a Python2 bug. With the move to Python3 I am removing this line.

We may want to remove this from `setup.sh` as well.