### PR TITLE
Update bootstrap Python to support CentOS

### DIFF
--- a/playbooks/bootstrap/bootstrap-python.yml
+++ b/playbooks/bootstrap/bootstrap-python.yml
@@ -1,18 +1,16 @@
 ---
 - hosts: all
   become: true
-  gather_facts: False
+  gather_facts: false
   tasks:
-    # Fortunately, python is a dependency of yum. So RedHat systems always have it.
     - name: install python (no proxy)
-      raw: test -e /usr/bin/python3 || (apt -y update && apt install -y python3-minimal)
+      raw: test -e /usr/bin/python3 || (apt -y update && apt install -y python3-minimal) || (yum install -y python3)
       register: output
       changed_when: output.stdout != ""
       when: proxy_env is not defined
 
     - name: install python (using proxy)
-      raw: test -e /usr/bin/python3 || (https_proxy="{{ https_proxy }}" http_proxy="{{ http_proxy }}" apt -y update && https_proxy="{{ https_proxy }}" http_proxy="{{ http_proxy }}" apt install -y python3-minimal)
+      raw: test -e /usr/bin/python3 || (https_proxy="{{ https_proxy }}" http_proxy="{{ http_proxy }}" apt -y update && https_proxy="{{ https_proxy }}" http_proxy="{{ http_proxy }}" apt install -y python3-minimal) || (https_proxy="{{ https_proxy }}" http_proxy="{{ http_proxy }}" yum install -y python3)
       register: output
       changed_when: output.stdout != ""
       when: proxy_env is defined
-


### PR DESCRIPTION
We recently bumped from Python2 to Python3. 

This caused our `bootstrap-python.yml` to start attempting an apt-get install on CentOS systems. This PR fixes that.

Because this is the bootstrap of python, it is possible that we are unable to gather_facts on some systems, so the `ansible_os_distribution` variables cannot be captured/used.

My strategy around this was nesting install commands, which is now passing internal/manual tests.