### PR TITLE
Add support for building DGX OS 5 images installable by MAAS

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "kubespray"]
 	path = submodules/kubespray
 	url = https://github.com/kubernetes-incubator/kubespray.git
+[submodule "packer-maas"]
+	path = submodules/packer-maas
+	url = https://github.com/DeepOps/packer-maas.git

--- a/docs/pxe/maas.md
+++ b/docs/pxe/maas.md
@@ -177,3 +177,8 @@ And at this point your should be able to log in using the SSH key you configured
 This is a lot of work for a single machine, but most operations in MAAS can be done in batches.
 It's generally straightforward to auto-discover a large number of hosts at a time,
 then commission them and provision them by selecting them as a group in the Machines interface.
+
+## Creating a DGX OS image installable by MAAS
+
+The official NVIDIA DGX OS version 5.0 and higher is installable by MAAS by creating a custom OS image.
+The code is located in the `submodules/packer-maas` directory. For more information, see: https://github.com/DeepOps/packer-maas/tree/master/dgxos5


### PR DESCRIPTION
This PR adds a new submodule from https://github.com/DeepOps/packer-maas which is a fork that includes support for DGX OS 5.