### PR TITLE
Allow disabling docker/nvidia-docker install

### DIFF
--- a/config.example/group_vars/all.yml
+++ b/config.example/group_vars/all.yml
@@ -121,12 +121,11 @@ gpu_clock_lock: "1507,1507"
 # Playbook: docker, nvidia-docker, k8s-cluster
 # 
 # For supported Docker versions, see: kubespray/roles/container-engine/docker/vars/*
+docker_install: yes
 docker_version: '19.03'
 docker_dns_servers_strict: no
 docker_storage_options: -s overlay2
 #docker_options: "--bip=192.168.99.1/24"
-# Install DeepOps version of Docker on DGX
-docker_override_dgx: false
 # Enable docker iptables
 # If this isn't set, containers won't have access to the outside net
 # See https://github.com/kubernetes-sigs/kubespray/issues/2002

--- a/playbooks/container/docker.yml
+++ b/playbooks/container/docker.yml
@@ -2,6 +2,8 @@
 - hosts: "{{ hostlist | default('all') }}"
   become: true
   become_method: sudo
+  tags:
+  - docker
   vars_files:
     # include kubespray-defaults here so that we can set the facts using the
     # kubespray 0040-set_facts.yml tasks
@@ -9,17 +11,18 @@
   tasks:
     - name: include kubespray task to set facts required for docker role
       include: ../../submodules/kubespray/roles/kubernetes/preinstall/tasks/0040-set_facts.yml
-    - name: remove docker overrides from DGX OS
+      when: docker_install
+    - name: remove docker overrides, specifically to deal with conflicting options from DGX OS
       file:
         path: /etc/systemd/system/docker.service.d/docker-override.conf
         state: absent
-      tags:
-        - docker
-      when: docker_override_dgx
+      when: docker_install
 
 - hosts: "{{ hostlist | default('all') }}"
   become: true
   become_method: sudo
+  tags:
+  - docker
   vars:
     # override deprecated dockerproject repo; old docker repo broken as of 03.04.2020
     dockerproject_rh_repo_base_url: 'https://download.docker.com/linux/centos/7/$basearch/stable'
@@ -27,8 +30,7 @@
     fallback_ips: []
   roles:
     - role: kubespray-defaults
-      when: ansible_product_name is not search("DGX") or docker_override_dgx
+      when: docker_install
     - role: "../../submodules/kubespray/roles/container-engine/docker"
-      tags: docker
-      when: ansible_product_name is not search("DGX") or docker_override_dgx
+      when: docker_install
   environment: "{{ proxy_env if proxy_env is defined else {} }}"

--- a/playbooks/container/nvidia-docker.yml
+++ b/playbooks/container/nvidia-docker.yml
@@ -20,5 +20,5 @@
         name: nvidia.nvidia_docker
       when:
         - ansible_local['gpus']['count'] and (ansible_distribution == "Ubuntu" or ansible_os_family == "RedHat")
-        - ansible_product_name is not search("DGX") or docker_override_dgx
+        - docker_override_dgx
   environment: "{{ proxy_env if proxy_env is defined else {} }}"

--- a/playbooks/container/nvidia-docker.yml
+++ b/playbooks/container/nvidia-docker.yml
@@ -8,17 +8,18 @@
     - name: install custom facts module
       include_role:
         name: facts
+      when: docker_install
 
-    - name: remove docker overrides from DGX OS
+    - name: remove docker overrides, specifically to deal with conflicting options from DGX OS
       file:
         path: /etc/systemd/system/docker.service.d/docker-override.conf
         state: absent
-      when: docker_override_dgx
+      when: docker_install
 
     - name: install nvidia-docker
       include_role:
         name: nvidia.nvidia_docker
       when:
         - ansible_local['gpus']['count'] and (ansible_distribution == "Ubuntu" or ansible_os_family == "RedHat")
-        - docker_override_dgx
+        - docker_install
   environment: "{{ proxy_env if proxy_env is defined else {} }}"


### PR DESCRIPTION
Adds a flag to disable installation of docker/nvidia docker. On DGX OS, this will erase the default DGX OS docker configuration and install the version from DeepOps.

Notes:
* This does not fix the issue where the DGX OS default docker runtime is not set to 'nvidia' by default.
* This does not affect a 'k8s-cluster' install, which still does its own thing via kubespray