### PR TITLE
Add custom culling/reaping config for Kubeflow Notebooks containers

### DIFF
--- a/scripts/k8s/deploy_kubeflow.sh
+++ b/scripts/k8s/deploy_kubeflow.sh
@@ -189,13 +189,15 @@ function stand_up() {
      exit 1
   fi
 
+  # Copy over DeepOps custom configurations & bugfixes
+  cp -r workloads/services/k8s/kubeflow-install/ config/
   sed -i '/metadata:.*/a\  ClusterName: cluster.local' ${CONFIG_FILE} # BUGFIX: Need to add the ClusterName for proper deletion:https://github.com/kubeflow/kubeflow/issues/4815
 
   # Update Kubeflow with the NGC containers and NVIDIA configurations
   # BUG: Commented out until NGC containers add Kubeflow support, see https://github.com/NVIDIA/deepops/tree/master/src/containers/ngc
   # ${SCRIPT_DIR}/update_kubeflow_config.py
 
-  # XXX: Add potential CONFIG customizations here before applying
+  # XXX: Add potential CONFIG customizations here before applying (these can be checked in to workloads/services/k8s/kubeflow-install/)
   ${KFCTL} apply -V -f ${CONFIG_FILE}
   popd
 }

--- a/workloads/services/k8s/kubeflow-install/kustomize/notebook-controller/kustomization.yaml
+++ b/workloads/services/k8s/kubeflow-install/kustomize/notebook-controller/kustomization.yaml
@@ -1,0 +1,20 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+bases:
+- base
+commonLabels:
+  app.kubernetes.io/component: notebook-controller
+  app.kubernetes.io/name: notebook-controller
+configMapGenerator:
+- behavior: merge
+  envs:
+  - overlays/istio/params.env
+  name: parameters
+generatorOptions:
+  disableNameSuffixHash: true
+kind: Kustomization
+namespace: kubeflow
+patchesStrategicMerge:
+- overlays/istio/deployment.yaml
+- overlays/application/culling.yaml
+resources:
+- overlays/application/application.yaml

--- a/workloads/services/k8s/kubeflow-install/kustomize/notebook-controller/overlays/application/culling.yaml
+++ b/workloads/services/k8s/kubeflow-install/kustomize/notebook-controller/overlays/application/culling.yaml
@@ -1,0 +1,20 @@
+# See GitHub for more details: https://github.com/kubeflow/kubeflow/pull/3856
+# Automatically shutdown Jupyter Notebook containers if idle
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: deployment
+spec:
+  template:
+    spec:
+      containers:
+      - name: manager        
+        env:
+          - name: ENABLE_CULLING
+            value: "false" # Off by default
+          - name: IDLE_TIME
+            value: "1440" # 1 day        
+          - name: CULLING_CHECK_PERIOD
+            value: "5"        
+          - name: CLUSTER_DOMAIN
+            value: "cluster.local"        


### PR DESCRIPTION
* Add a new mechanism to the Kubeflow deployment script that allows kustomize overlays be saved in the `workloads` directory
* Add a default configuration example for notebook culling (default is set to off)