### PR TITLE
Update slurm.conf

### DIFF
--- a/roles/slurm/templates/etc/slurm/slurm.conf
+++ b/roles/slurm/templates/etc/slurm/slurm.conf
@@ -80,7 +80,6 @@ SchedulerType=sched/backfill
 #SchedulerAuth=
 SelectType=select/cons_tres
 SelectTypeParameters=CR_Core_Memory,CR_CORE_DEFAULT_DIST_BLOCK,CR_ONE_TASK_PER_CORE
-FastSchedule=1
 #PriorityType=priority/multifactor
 #PriorityDecayHalfLife=14-0
 #PriorityUsageResetPeriod=14-0


### PR DESCRIPTION
removing obsolete FastSchedule=1 option, otherwise it shows up in slurmctl.log
[2020-11-17T07:05:23.840] error: Ignoring obsolete FastSchedule=1 option. Please remove from your configuration.
