### PR TITLE
Enable Slurm cluster to split functions of controller, login, and monitoring node

### DIFF
--- a/config.example/group_vars/slurm-cluster.yml
+++ b/config.example/group_vars/slurm-cluster.yml
@@ -100,6 +100,9 @@ spack_default_packages:
 - "cuda@10.2.89"
 - "openmpi@3.1.6 +cuda +pmi schedulers=auto"
 
+# Which host should we run installs on for software going into the NFS share?
+sm_install_host: "slurm-master[0]"
+
 ################################################################################
 # NVIDIA HPC SDK                                                               #
 ################################################################################

--- a/config.example/group_vars/slurm-cluster.yml
+++ b/config.example/group_vars/slurm-cluster.yml
@@ -174,4 +174,4 @@ slurm_enable_monitoring: true
 
 # Inventory host groups where cluster monitoring services will be installed
 # (Prometheus, Grafana, etc)
-slurm_monitoring_group: "slurm-master[0]"
+slurm_monitoring_group: "slurm-master"

--- a/config.example/group_vars/slurm-cluster.yml
+++ b/config.example/group_vars/slurm-cluster.yml
@@ -16,7 +16,6 @@ slurm_password: ReplaceWithASecurePasswordInTheVault
 slurm_db_password: AlsoReplaceWithASecurePasswordInTheVault
 #slurm_max_job_timelimit: INFINITE
 #slurm_default_job_timelimit:
-slurm_enable_monitoring: true
 
 # Ensure hosts file generation only runs across slurm cluster
 hosts_add_ansible_managed_hosts_groups: ["slurm-cluster"]
@@ -167,3 +166,12 @@ slurm_health_check_program: "/usr/sbin/nhc"
 #
 # For documentation on the file format, see:
 # https://github.com/mej/nhc/blob/master/README.md
+
+################################################################################
+# Monitoring stack                                                             #
+################################################################################
+slurm_enable_monitoring: true
+
+# Inventory host groups where cluster monitoring services will be installed
+# (Prometheus, Grafana, etc)
+slurm_monitoring_group: "slurm-master[0]"

--- a/docs/slurm-cluster/README.md
+++ b/docs/slurm-cluster/README.md
@@ -109,3 +109,9 @@ See the documentation on [software modules](./software-modules.md) for informati
 
 ## Pyxis, Enroot, and Singularity
 [Pyxis](https://github.com/NVIDIA/pyxis) and [Enroot](https://github.com/NVIDIA/enroot) are installed by default and can be disabled by setting `slurm_install_enroot` and `slurm_install_pyxis` to no. Singularity can be installed by setting the `slurm_cluster_install_singularity` variable to yes before running the `slurm-cluster.yml` playbook.
+
+## Large deployments
+
+To minimize the requirements for the cluster management services, DeepOps deploys a single Slurm head node for cluster management, shared filesystems, and user login.
+However, for larger deployments, it often makes sense to run these functions on multiple separate machines.
+For instructions on separating these functions, see the [large deployment guide](./large-deployments.md).

--- a/docs/slurm-cluster/large-deployments.md
+++ b/docs/slurm-cluster/large-deployments.md
@@ -1,0 +1,149 @@
+# Deploying Slurm on large clusters
+
+To minimize hardware requirements for cluster management services, DeepOps deploys a single Slurm head node by default.
+This head node provides multiple servies to the rest of the cluster, including:
+
+* Slurm controller and database
+* NFS shared filesystem
+* User logins
+* Monitoring services
+
+However, on larger clusters, it often makes sense to run these functions on multiple separate machines.
+DeepOps provides support for running these functions on separate machines using a combination of changes to the Ansible inventory file, and setting Ansible variables to specify where these functions should run.
+
+## Separate login nodes
+
+The most common case in which you will want to add additional service nodes, is to separate the user login node from the Slurm controller node.
+This provides a level of isolation between user activity and the Slurm cluster services, so that user activity is less likely to negatively impact the cluster services.
+Multiple login nodes may also be deployed to allow you to provide services to a larger number of users, or for high availability.
+
+Separate user login nodes need to have the Slurm packages installed, but should not run any Slurm services such as `slurmd` or `slurmctld`.
+In DeepOps, this can be accomplished by adding these machines to the `slurm-cluster` inventory group, but not to the `slurm-master` or `slurm-node` groups.
+
+For example, the following inventory file can be used to set up a cluster with one controller, two login nodes, and two compute nodes.
+
+```
+[slurm-master]
+slurm-controller01
+
+[slurm-login]
+slurm-login01
+slurm-login02
+
+[slurm-node]
+slurm-compute01
+slurm-compute02
+
+[slurm-cluster:children]
+slurm-master
+slurm-login
+slurm-node
+```
+
+## Separate monitoring node
+
+| Variable | Default value |
+| -------- | ------------- |
+| `slurm_monitoring_group` | `slurm-master` |
+
+The Slurm monitoring services are deployed to whichever hosts are specified in the variable `slurm_monitoring_group`.
+This should be the name of an Ansible inventory hostgroup with one node.
+In the default configuration, we run the monitoring services on the Slurm controller node.
+
+Note that in order to correctly monitor Slurm, the monitoring node must have Slurm installed and have access to the cluster.
+As with the login nodes, the easiest way to do this is to add the monitoring node to the `slurm-cluster` group, but not to `slurm-master` or `slurm-node`.
+
+So, for example, the following inventory file should allow a monitoring node to be deployed:
+
+```
+[slurm-master]
+slurm-controller01
+
+[slurm-monitoring]
+slurm-mon01
+
+[slurm-node]
+slurm-compute01
+slurm-compute02
+
+[slurm-cluster:children]
+slurm-master
+slurm-monitoring
+slurm-node
+``` 
+
+With the following variable configured:
+
+```
+slurm_monitoring_group: "slurm-monitoring"
+```
+
+## Separate NFS server
+
+Our Slurm cluster deployment relies on a shared NFS filesystem across the cluster.
+One machine is used to run the NFS server, and all other machines in the cluster are NFS clients.
+We specify these machines using these variables:
+
+| Variable | Default value |
+| -------- | ------------- |
+| `nfs_server_group` | `slurm-master[0]` |
+| `nfs_client_group` | `slurm-master[1:],slurm-node` |
+
+To change this topology, you can change these variables to run the NFS server and client playbooks on a different set of hosts.
+
+### Example: NFS on login node, with separate Slurm controller
+
+Inventory:
+
+```
+[slurm-master]
+slurm-controller01
+
+[slurm-login]
+slurm-login01
+
+[slurm-node]
+slurm-compute01
+slurm-compute02
+
+[slurm-cluster:children]
+slurm-master
+slurm-login
+slurm-node
+```
+
+Variables:
+
+```
+nfs_server_group: "slurm-login[0]"
+nfs_client_group: "slurm-master,slurm-node"
+```
+
+### Example: NFS on separate machine not in the Slurm cluster 
+
+In many cases, large deployments will have pre-existing NFS filesystems available which DeepOps should mount.
+In this case, we can choose not to deploy an NFS server, but instead simply configure all nodes as clients.
+
+In order to disable NFS server deployment, you should set:
+
+```
+slurm_enable_nfs_server: false
+```
+
+Then, to configure all hosts to mount from one or more external serveris, configure:
+
+```
+nfs_client_group: "slurm-cluster"
+
+nfs_mounts:
+- mountpoint: /home
+  server: external-nfs-server-01.example.com
+  path: /export/home
+  options: async,vers=3
+- mountpoint: /shared
+  server: external-nfs-server-02.example.com
+  path: /export/shared
+  options: async,vers=3
+```
+
+Where the parameters to `nfs_mounts` should be adjusted based on your local environment.

--- a/playbooks/slurm-cluster.yml
+++ b/playbooks/slurm-cluster.yml
@@ -65,12 +65,15 @@
 
 # Install monitoring services
 - include: slurm-cluster/prometheus.yml
+  vars:
     hostlist: "{{ slurm_monitoring_group | default('slurm-master[0]') }}"
   when: slurm_enable_monitoring
 - include: slurm-cluster/grafana.yml
+  vars:
     hostlist: "{{ slurm_monitoring_group | default('slurm-master[0]') }}"
   when: slurm_enable_monitoring
 - include: slurm-cluster/prometheus-slurm-exporter.yml
+  vars:
     hostlist: 'slurm-master[0]'
   when: slurm_enable_monitoring
 

--- a/playbooks/slurm-cluster.yml
+++ b/playbooks/slurm-cluster.yml
@@ -62,7 +62,7 @@
 # Install the NVIDIA HPC SDK
 - include: nvidia-software/nvidia-hpc-sdk.yml
   vars:
-    hostlist: "{{ sm_install_host }}"
+    hostlist: "{{ sm_install_host | default('slurm-master[0]')}}"
   when: slurm_install_hpcsdk
 
 # Install monitoring services

--- a/playbooks/slurm-cluster.yml
+++ b/playbooks/slurm-cluster.yml
@@ -72,12 +72,12 @@
   vars:
     hostlist: "{{ slurm_monitoring_group | default('slurm-master[0]') }}"
   when: slurm_enable_monitoring
-- include: slurm-cluster/prometheus-slurm-exporter.yml
-  vars:
-    hostlist: 'slurm-master[0]'
-  when: slurm_enable_monitoring
 
 # Install monitoring exporters
+- include: slurm-cluster/prometheus-slurm-exporter.yml
+  vars:
+    hostlist: "{{ slurm_monitoring_group | default('slurm-master[0]') }}"
+  when: slurm_enable_monitoring
 - include: slurm-cluster/prometheus-node-exporter.yml
   when: slurm_enable_monitoring
 - include: slurm-cluster/nvidia-dcgm-exporter.yml

--- a/playbooks/slurm-cluster.yml
+++ b/playbooks/slurm-cluster.yml
@@ -60,7 +60,9 @@
   when: slurm_install_lmod
 
 # Install the NVIDIA HPC SDK
-- include: nvidia-software/nvidia-hpc-sdk.yml hostlist=slurm-master[0]
+- include: nvidia-software/nvidia-hpc-sdk.yml
+  vars:
+    hostlist: "{{ sm_install_host }}"
   when: slurm_install_hpcsdk
 
 # Install monitoring services

--- a/playbooks/slurm-cluster.yml
+++ b/playbooks/slurm-cluster.yml
@@ -63,13 +63,18 @@
 - include: nvidia-software/nvidia-hpc-sdk.yml hostlist=slurm-master[0]
   when: slurm_install_hpcsdk
 
-# Install monitoring tools
-- include: slurm-cluster/prometheus.yml hostlist=slurm-master[0]
+# Install monitoring services
+- include: slurm-cluster/prometheus.yml
+    hostlist: "{{ slurm_monitoring_group | default('slurm-master[0]') }}"
   when: slurm_enable_monitoring
-- include: slurm-cluster/grafana.yml hostlist=slurm-master[0]
+- include: slurm-cluster/grafana.yml
+    hostlist: "{{ slurm_monitoring_group | default('slurm-master[0]') }}"
   when: slurm_enable_monitoring
-- include: slurm-cluster/prometheus-slurm-exporter.yml hostlist=slurm-master[0]
+- include: slurm-cluster/prometheus-slurm-exporter.yml
+    hostlist: 'slurm-master[0]'
   when: slurm_enable_monitoring
+
+# Install monitoring exporters
 - include: slurm-cluster/prometheus-node-exporter.yml
   when: slurm_enable_monitoring
 - include: slurm-cluster/nvidia-dcgm-exporter.yml

--- a/playbooks/slurm-cluster/slurm.yml
+++ b/playbooks/slurm-cluster/slurm.yml
@@ -23,6 +23,15 @@
         name: slurm
         tasks_from: build
 
+# Configure slurm.conf on all nodes
+- hosts: slurm-cluster
+  become: yes
+  roles:
+    - name: slurm
+      vars:
+        user: "{{ ansible_env.SUDO_USER | default(ansible_env.USER) }}"
+        slurm_workflow_build: no
+
 # Set up slurm controller
 - hosts: slurm-master
   become: yes

--- a/roles/prometheus-slurm-exporter/defaults/main.yml
+++ b/roles/prometheus-slurm-exporter/defaults/main.yml
@@ -12,3 +12,5 @@ grafana_svc_name: "docker.grafana.service"
 grafana_data_dir: /var/lib/grafana
 grafana_cfg_dashboard_path: "{{ grafana_data_dir }}/dashboards"
 grafana_user_id: 472
+
+slurm_exporter_host_group: "{{ slurm_monitoring_group | default('slurm-master') }}"

--- a/roles/prometheus-slurm-exporter/templates/slurm-exporter.yml.j2
+++ b/roles/prometheus-slurm-exporter/templates/slurm-exporter.yml.j2
@@ -1,3 +1,3 @@
-- targets: [{{ groups['slurm-master'][0] | zip_longest([], fillvalue=':8080') | map('join') | join(',') }}]
+- targets: [{{ groups['slurm-master'] | zip_longest([], fillvalue=':8080') | map('join') | join(',') }}]
   labels:
     module: slurm-exporter

--- a/roles/prometheus-slurm-exporter/templates/slurm-exporter.yml.j2
+++ b/roles/prometheus-slurm-exporter/templates/slurm-exporter.yml.j2
@@ -1,3 +1,3 @@
-- targets: [{{ groups['slurm-master'] | zip_longest([], fillvalue=':8080') | map('join') | join(',') }}]
+- targets: [{{ groups[slurm_exporter_host_group] | zip_longest([], fillvalue=':8080') | map('join') | join(',') }}]
   labels:
     module: slurm-exporter

--- a/roles/slurm/tasks/main.yml
+++ b/roles/slurm/tasks/main.yml
@@ -15,9 +15,13 @@
 - include: compute.yml
   when: is_compute
 
+- include: misc-node.yml
+  when: (not is_compute) and (not is_controller)
+
 - include: shmfix.yml
   when: is_compute and slurm_fix_shm
 
 - include: undrain.yml
+  when: is_compute
 
 - include: build-cleanup.yml

--- a/roles/slurm/tasks/misc-node.yml
+++ b/roles/slurm/tasks/misc-node.yml
@@ -1,0 +1,30 @@
+---
+# Configure nodes that are neither running controller services, nor slurmd.
+# Examples include login nodes or CI nodes.
+
+- name: create slurm directories
+  file:
+    path: "{{ item }}"
+    state: directory
+    owner: slurm
+    mode: 0755
+  with_items:
+    - "{{ slurm_config_dir }}"
+
+- name: configure slurm.conf
+  template:
+    src: "{{ slurm_conf_template }}"
+    dest: "{{ slurm_config_dir }}/slurm.conf"
+  tags:
+  - config
+
+- name: ensure all slurm services are stopped
+  service:
+    name: "{{ item }}"
+    state: stopped
+    enabled: no
+  with_items:
+  - slurmctld
+  - slurmd
+  - slurmdbd
+  ignore_errors: yes

--- a/virtual/vars_files/virt_slurm.yml
+++ b/virtual/vars_files/virt_slurm.yml
@@ -10,4 +10,4 @@ slurm_allow_ssh_user:
 # Perform cleanup tasks during the install to minimize disk space impact
 hpcsdk_clean_up_tarball_after_extract: true
 hpcsdk_clean_up_temp_dir: true
-slurm_build_dir_cleanup: true
+slurm_build_dir_cleanup: false


### PR DESCRIPTION
Currently DeepOps will deploy a single Slurm "head node" which is used for the monitoring stack, the Slurm controller, and the user login node. However, for larger deployments, most clusters will want to split these functions onto multiple machines.

This PR enables splitting these functions with the following changes:

* Adds logic to `slurm` role to enable installing Slurm and adding `slurm.conf` on nodes, but not starting any Slurm daemons on them.
* Adds an option to the `slurm-cluster.yml` playbook so that a different host group can be specified for the monitoring services.
* Moves the Slurm dashboard into the `grafana` role instead of installing it with the `slurm-exporter`, as that workflow assumes they're on the same node
* Run the `prometheus-slurm-exporter` on the monitoring node. Assumes that the monitoring node has the Slurm tools installed and access to run `sinfo`, `squeue`, etc.

In the default case, the original behavior where all services run on the same machine will still be used. See test plan below for how to configure separate nodes.

## Test plan

Configured a virtual cluster with the following inventory. Note that the added groups (`slurm-login` and `slurm-metric`) aren't required names here: `slurm-metric` is defined so we can identify the node that will run the monitoring services, and `slurm-login` is just a convenience group so it's not part of the node or controller groups.

```
[slurm-master]
virtual-slurm01

[slurm-node]
virtual-gpu01
virtual-cpu01

[slurm-login]
virtual-login01

[slurm-metric]
virtual-metric01

[slurm-cluster:children]
slurm-master
slurm-node
slurm-login
slurm-metric
```

And then define the following config values:

```
slurm_monitoring_group: "slurm-metric"
nfs_client_group: "slurm-master[1:],slurm-node,slurm-login,slurm-metric"
sm_install_host: "slurm-login[0]"
```

Ran the Slurm cluster playbook to turn up the cluster, then ran the following tests:

### Confirm separate Slurm controller node running services

```
vagrant@virtual-slurm01:~$ sinfo
PARTITION AVAIL  TIMELIMIT  NODES  STATE NODELIST
batch*       up   infinite      2   idle virtual-cpu01,virtual-gpu01
vagrant@virtual-slurm01:~$ systemctl is-active slurmctld
active
vagrant@virtual-slurm01:~$ systemctl is-active slurmdbd
active
vagrant@virtual-slurm01:~$ sudo docker ps
CONTAINER ID        IMAGE                               COMMAND                  CREATED             STATUS              PORTS               NAMES
51e896b1f2fc        quay.io/prometheus/node-exporter    "/bin/node_exporter …"   2 minutes ago       Up 2 minutes                            docker.node-exporter.service
5a0237e87ed5        deepops/prometheus-slurm-exporter   "/usr/bin/prometheus…"   26 minutes ago      Up 26 minutes                           docker.slurm-exporter.service
```

### Confirm login node works for job submit and doesn't have Slurm services

```
vagrant@virtual-login01:~$ sinfo
PARTITION AVAIL  TIMELIMIT  NODES  STATE NODELIST
batch*       up   infinite      2   idle virtual-cpu01,virtual-gpu01
vagrant@virtual-login01:~$ srun -n4 hostname
virtual-gpu01
virtual-gpu01
virtual-cpu01
virtual-cpu01
vagrant@virtual-login01:~$ systemctl is-active slurmctld
inactive
vagrant@virtual-login01:~$ systemctl is-active slurmdbd
inactive
vagrant@virtual-login01:~$ systemctl is-active slurmd
inactive
vagrant@virtual-login01:~$ sudo docker ps
CONTAINER ID        IMAGE                              COMMAND                  CREATED             STATUS              PORTS               NAMES
164d36ecb7a5        quay.io/prometheus/node-exporter   "/bin/node_exporter …"   2 minutes ago       Up 2 minutes                            docker.node-exporter.service
```

### Confirm metrics node is running monitoring services

```
vagrant@virtual-metric01:~$ sudo docker ps
CONTAINER ID        IMAGE                               COMMAND                  CREATED             STATUS              PORTS               NAMES
c836c69c98e0        prom/prometheus                     "/bin/prometheus --c…"   20 minutes ago      Up 20 minutes                           docker.prometheus.service
5bc7baf2a78e        deepops/prometheus-slurm-exporter   "/usr/bin/prometheus…"   30 minutes ago      Up 30 minutes                           docker.slurm-exporter.service
41fd4da0c84a        quay.io/prometheus/node-exporter    "/bin/node_exporter …"   About an hour ago   Up About an hour                        docker.node-exporter.service
cbef5af25b79        grafana/grafana                     "/run.sh"                2 hours ago         Up 2 hours                              docker.grafana.service
```

### Confirm metrics collection is functioning

Take a look at Grafana on the monitoring node and confirm the dashboard is getting data.

![image](https://user-images.githubusercontent.com/279339/99460696-8f366900-28ed-11eb-8c4c-7ab99492e71c.png)

![image](https://user-images.githubusercontent.com/279339/99460763-aecd9180-28ed-11eb-9463-bf9e04cde4f7.png)
