### PR TITLE
Update nvidia-dgx-firmware role to work with new update container with more verifications

### DIFF
--- a/docs/deepops/dgx-diagnostic-firmware.md
+++ b/docs/deepops/dgx-diagnostic-firmware.md
@@ -1,1 +1,18 @@
-/home/atetelman/repo/sa/deepops/roles/nvidia-dgx-firmware/README.md
+# DGX firmware upgrade, diagnostics, and log collection
+
+The nvidia-dgx-firmware role has been built to perform several administrative tasks.
+
+For DGX-specific clusters it can be used to:
+
+* Gather manifest of currently installed DGX firmware
+* Update DGX firmware
+* Gather IB configuration information
+
+For all GPU clusters it can be used to:
+
+* Run NVSM health checks
+* Run DCGM stress checks
+* Gather log files from all nodes
+
+
+For full usage and details see the role (README)[../../roles/nvidia-dgx-firmware/README.md].

--- a/docs/deepops/dgx-diagnostic-firmware.md
+++ b/docs/deepops/dgx-diagnostic-firmware.md
@@ -1,0 +1,1 @@
+/home/atetelman/repo/sa/deepops/roles/nvidia-dgx-firmware/README.md

--- a/playbooks/nvidia-dgx/nvidia-dgx-diag.yml
+++ b/playbooks/nvidia-dgx/nvidia-dgx-diag.yml
@@ -5,6 +5,8 @@
 
 - hosts: all
   become: yes
+  gather_facts: no
+  strategy: free
   tasks:
     - name: Include NVIDIA DGX Firmware role
       include_role:

--- a/roles/nvidia-dgx-firmware/README.md
+++ b/roles/nvidia-dgx-firmware/README.md
@@ -6,7 +6,7 @@ This role makes use of the NVIDIA DGX firmware container and can be used to:
 
 ## Setup
 
-1) Download the latest DGX firmware container and put it in `src/containers/dgx-firmware`. Keep the original file name. Update the role variables to reflect the version being used. 
+1) Download the latest [DGX firmware container](https://docs.nvidia.com/dgx/dgxa100-fw-container-release-notes/index.html) and put it in `src/containers/dgx-firmware`. Keep the original file name. Update the role variables to reflect the version being used. 
 
 ```yml
 # The Docker repo name
@@ -40,6 +40,17 @@ The default behavior is to collect diagnostics. To disable, change the `run_diag
 
 ```yml
 run_diagnostics: false
+```
+
+Along with general logs and firmware versions, the default behavior will also run `nvsm show health`, `nvsm health dump`, and `dcgmi diag -r 1`. A more extensive dcgmi stress test can be enabled with `dcgmi_stress` and the health dump can be disabled by setting `nvsm_dump_health: false`. These tests can take a long time to complete and be potentially disruptive or fail to complete if there are existing issues. See [the official docs](https://docs.nvidia.com/datacenter/nvsm/nvsm-user-guide/index.html) for additional details. 
+
+
+Logs will be copied locally to `config/logs`. After running the diagnostics, it may be helpful to do a quick scan for issues by running:
+
+```sh
+grep Unhealthy config/logs/*/*nvsm-show-health.log
+cat config/logs/*/*dcgm_diag_1.log
+# cat config/logs/*/*dcgm_diag_3.log # If `dcgm_stress: true`
 ```
 
 ### Collected Information

--- a/roles/nvidia-dgx-firmware/README.md
+++ b/roles/nvidia-dgx-firmware/README.md
@@ -10,10 +10,10 @@ This role makes use of the NVIDIA DGX firmware container and can be used to:
 
 ```yml
 # The Docker repo name
-firmware_update_repo: nvfw-dgx1
+firmware_update_repo: nvfw-dgxa100
 
 # The Docker tag
-firmware_update_tag: 19.10.7
+firmware_update_tag: 20.05.12.5
 ```
 
 2) Change the `nv_mgmt_interface` variable to reflect the systems being collected from.
@@ -22,14 +22,17 @@ firmware_update_tag: 19.10.7
 # The OS/mgmt interface on the server
 nv_mgmt_interface: enp1s0f0 # DGX-1
 # nv_mgmt_interface: enp134s0f0 # DGX-2
+# nv_mgmt_interface: enp225s0f0 # DGX A100
 # nv_mgmt_interface: enp2s0f1 # DGX-Station
 ```
+
+> Note: This role is meant to run on a system running the DGX OS or a system that has had the nvidia-dgx role applied to it.
 
 ## Collect Diagnostics
 
 This role can be used to collect health and configuration information across a cluster. This is useful in verifying the health of a cluster or to debug a known issue. Because this is a debugging tool Ansible will continue executing tasks on all hosts even if some of the tasks fail.
 
-Although this role is meant to be executed against a homogeneous cluster of DGX systems (all DGX-1 or all DGX-2), the majority of the functionality will be effective on any GPU cluster.
+Although this role is meant to be executed against a homogeneous cluster of DGX systems (all DGX-1, all DGX-2, or all DGX A100), the majority of the functionality will be effective on any GPU cluster.
 
 ### Running
 
@@ -71,3 +74,7 @@ ansible-playbook -l slurm-node playbooks/nvidia-dgx/nvidia-dgx-diag.yml
 # update all firmware
 ansible-playbook -l slurm-node playbooks/nvidia-dgx/nvidia-dgx-fw-update.yml
 ```
+
+> Note: This playbook is designed to only allow upgrading of a single component per run; the recommended best-practice is to run `update_fw all`, however when updating individual components it is best to perform some level of manual verificaiton over the logs.
+
+> Note: It is not a requirement, but to resolve any potential issues while staff are on-site it is recommended to reboot all DGX Nodes after extensive firmware and software updates.

--- a/roles/nvidia-dgx-firmware/README.md
+++ b/roles/nvidia-dgx-firmware/README.md
@@ -20,10 +20,10 @@ firmware_update_tag: 20.05.12.5
 
 ```yml
 # The OS/mgmt interface on the server
-nv_mgmt_interface: enp1s0f0 # DGX-1
+# nv_mgmt_interface: enp1s0f0 # DGX-1
 # nv_mgmt_interface: enp134s0f0 # DGX-2
 # nv_mgmt_interface: enp225s0f0 # DGX A100
-# nv_mgmt_interface: enp2s0f1 # DGX-Station
+nv_mgmt_interface: enp2s0f1 # DGX-Station
 ```
 
 > Note: This role is meant to run on a system running the DGX OS or a system that has had the nvidia-dgx role applied to it.
@@ -86,6 +86,6 @@ ansible-playbook -l slurm-node playbooks/nvidia-dgx/nvidia-dgx-diag.yml
 ansible-playbook -l slurm-node playbooks/nvidia-dgx/nvidia-dgx-fw-update.yml
 ```
 
-> Note: This playbook is designed to only allow upgrading of a single component per run; the recommended best-practice is to run `update_fw all`, however when updating individual components it is best to perform some level of manual verificaiton over the logs.
+> Note: This playbook is designed to only allow upgrading of a single component per run; the recommended best-practice is to run `update_fw all`, however when updating individual components it is best to perform some level of manual verification over the logs.
 
 > Note: It is not a requirement, but to resolve any potential issues while staff are on-site it is recommended to reboot all DGX Nodes after extensive firmware and software updates.

--- a/roles/nvidia-dgx-firmware/defaults/main.yml
+++ b/roles/nvidia-dgx-firmware/defaults/main.yml
@@ -6,6 +6,10 @@ update_firmware: false
 load_firmware: false
 clean_firmware: true
 
+# These two actions can take a very long time, and dcgm_stress especially can stress hardware
+dcgm_stress: false
+nvsm_dump_health: true
+
 # The Docker repo name
 firmware_update_repo: nvfw-dgxa100
 

--- a/roles/nvidia-dgx-firmware/defaults/main.yml
+++ b/roles/nvidia-dgx-firmware/defaults/main.yml
@@ -1,9 +1,15 @@
 ---
 
-# Which portions of the role to run
+# Run diagnostics across the cluster (will cause pre and post-update diagnostics if run with update_firmware)
 run_diagnostics: true
+
+# Update the DGX firmware (will also execute post update diagnostics)
 update_firmware: false
-load_firmware: false
+
+# Copy the firmware container and load it into Docker on all nodes
+load_firmware: true
+
+# Remove all log files and any loaded Docker images on all nodes
 clean_firmware: true
 
 # These two actions can take a very long time, and dcgm_stress especially can stress hardware
@@ -28,10 +34,10 @@ local_log_directory: "{{ inventory_dir }}"
 fw_dir: "/tmp/nvfw"
 
 # The OS/mgmt interface on the server
-nv_mgmt_interface: enp1s0f0 # DGX-1
+# nv_mgmt_interface: enp1s0f0 # DGX-1
 # nv_mgmt_interface: enp134s0f0 # DGX-2
 # nv_mgmt_interface: enp2s0f1 # DGX-Station
-# nv_mgmt_interface: enp225s0f0 # DGX A100
+nv_mgmt_interface: enp225s0f0 # DGX A100
 
 # Target_fw can be set to 'all' or something specific (sbios, bmc, etc. - check container release notes on
 # NVIDIA Enterprise support portal for details on valid options)

--- a/roles/nvidia-dgx-firmware/defaults/main.yml
+++ b/roles/nvidia-dgx-firmware/defaults/main.yml
@@ -3,15 +3,18 @@
 # Which portions of the role to run
 run_diagnostics: true
 update_firmware: false
+load_firmware: false
+clean_firmware: true
 
 # The Docker repo name
-firmware_update_repo: nvfw-dgx1
+firmware_update_repo: nvfw-dgxa100
 
 # The Docker tag
-firmware_update_tag: 19.10.7
+firmware_update_tag: 20.10.9
 
 # firmware update container to use and where it is locally stored
 firmware_update_container: "{{ firmware_update_repo }}_{{ firmware_update_tag }}.tar.gz"
+firmware_update_container: "nvfw-dgxa100_20.10.9_201103.tar.gz"
 firmware_container_src_dir: "{{ inventory_dir }}/src/containers/dgx-firmware"
 
 # default log directory is set to the location of your inventory file (./deepops/config/)
@@ -24,6 +27,7 @@ fw_dir: "/tmp/nvfw"
 nv_mgmt_interface: enp1s0f0 # DGX-1
 # nv_mgmt_interface: enp134s0f0 # DGX-2
 # nv_mgmt_interface: enp2s0f1 # DGX-Station
+# nv_mgmt_interface: enp225s0f0 # DGX A100
 
 # Target_fw can be set to 'all' or something specific (sbios, bmc, etc. - check container release notes on
 # NVIDIA Enterprise support portal for details on valid options)

--- a/roles/nvidia-dgx-firmware/files/parse_manifest.py
+++ b/roles/nvidia-dgx-firmware/files/parse_manifest.py
@@ -132,8 +132,10 @@ if argv[1] == 'parse_update_json':
         try:
             lineJson = json.loads(line)
 
-            if 'FirmwareLoadAction' in json.loads(line).keys():
+            if 'FirmwareLoadAction' in json.loads(line).keys(): # Detects if chassis-level power cycle is required
                 fw_update_json = json.loads(line)
+            if 'Reboot required' in lineJson['Message']: # Detects if host-level reboot is required
+                fw_update_json['RebootRequired'] = True
 
             if lineJson['State'] == 'Failed':
                 fw_update_json['State'] = 'Failed'
@@ -148,7 +150,6 @@ if argv[1] == 'parse_update_json':
             if lineJson['State'] == 'Done':
                 fw_update_json['State'] = 'Done'
                 fw_update_json['Message'] = lineJson['Message']
-                break
 
         except Exception as e:
             continue

--- a/roles/nvidia-dgx-firmware/files/parse_manifest.py
+++ b/roles/nvidia-dgx-firmware/files/parse_manifest.py
@@ -1,0 +1,185 @@
+#!/usr/bin/python
+
+import json
+
+from collections import OrderedDict
+from sys import argv
+
+
+def return_json(payload):
+    return(json.dumps(payload,
+                      sort_keys=True,
+                      indent=4
+                      )
+           )
+
+
+if argv[1] == 'update_order':
+
+    fw_manifest = argv[2]
+    ver_manifest = argv[3]
+
+    updateItems = {}
+    updateOrder = OrderedDict()
+
+    with open(fw_manifest) as f:
+        manifest_jsonify = json.load(f)
+
+    with open(ver_manifest) as f:
+        version_jsonify = json.load(f)
+
+    # Grab sequence type info from FW Manifest..
+    for obj in manifest_jsonify:
+        try:
+            for component in manifest_jsonify[obj]['Items']:
+                updateItems[component['CompName']] = \
+                    [
+                        component['Sequence'],
+                        component['CompModel'],
+                        obj
+                    ]
+
+        except KeyError as e:
+            pass
+
+    # Iterate through FW Versioning, write Update Condition to updateItems
+    for item in version_jsonify:
+        for component in version_jsonify[item]['Items']:
+            if not component['IsUpToDate']:
+                try:
+                    updateItems[component['ID']].append({'NeedsUpdate': True})
+                except:
+                    try:
+                        updateItems[component['Model']].append({'NeedsUpdate': True})
+                    except:
+                        continue
+
+            if component['IsUpToDate']:
+                try:
+                    updateItems[component['ID']].append({'NeedsUpdate': False})
+                except:
+                    try:
+                        updateItems[component['Model']].append({'NeedsUpdate': False})
+                    except:
+                        continue
+
+    for i in updateItems:
+        try:
+            needsUpdate = updateItems[i][3]
+            pass
+
+        except IndexError:
+            group = updateItems[i][2]
+
+            for item in version_jsonify[group]['Items']:
+                if not item['IsUpToDate']:
+                    updateItems[i].append({'NeedsUpdate': True})
+
+                    break
+
+                if item['IsUpToDate']:
+                    updateItems[i].append({'NeedsUpdate': False})
+
+                    continue
+
+    for k in updateItems:
+        updateItems[k] = [i for n, i in enumerate(updateItems[k]) if i not in updateItems[k][n + 1:]]
+
+    sortedUpdateItems = sorted(updateItems.items(), key=lambda x: x[1][0])
+
+    try:
+        if argv[4] == 'order_length':
+            count = 0
+            for i in sortedUpdateItems:
+                if i[1][3]['NeedsUpdate']:
+                    count += 1
+
+            print(count - 1)
+            exit(0)
+
+    except IndexError:
+        pass
+
+    itemsToUpdate = OrderedDict()
+
+    for i in sortedUpdateItems:
+        if i[1][3]['NeedsUpdate']:
+            if i[0] == 'MB_CEC':
+                itemsToUpdate[(str(i[0]))] = True
+            elif i[0] == 'Delta_CEC':
+                itemsToUpdate[(str(i[0]))] = True
+            else:
+                itemsToUpdate[str(i[1][2])] = True
+
+    for item in itemsToUpdate:
+        print(item)
+
+    exit(0)
+
+if argv[1] == 'parse_update_json':
+    file_path = argv[2]
+
+    fw_update_json = {
+        'Error': True,
+        'State': 'Unknown',
+        'Action': 'Check Output Log'
+    }
+
+    with open(file_path) as f:
+        fw_update = f.readlines()
+
+    for line in fw_update:
+        try:
+            lineJson = json.loads(line)
+
+            if 'FirmwareLoadAction' in json.loads(line).keys():
+                fw_update_json = json.loads(line)
+
+            if lineJson['State'] == 'Failed':
+                fw_update_json['State'] = 'Failed'
+                fw_update_json['Message'] = lineJson['Message']
+                break
+
+            if lineJson['State'] == 'Canceled':
+                fw_update_json['State'] = 'Canceled'
+                fw_update_json['Message'] = lineJson['Message']
+                break
+
+            if lineJson['State'] == 'Done':
+                fw_update_json['State'] = 'Done'
+                fw_update_json['Message'] = lineJson['Message']
+                break
+
+        except Exception as e:
+            continue
+
+    print(return_json(fw_update_json))
+
+
+if argv[1] == 'parse_versioning':
+    file_path = argv[2]
+
+    manifest_json = {
+        'ErrorWritingVersioning': True
+    }
+
+    with open(file_path) as f:
+        output_all = f.readlines()
+
+    # Grab JSON from raw output
+    for line in output_all:
+        try:
+            manifest_json = json.loads(line)
+        except ValueError:
+            pass
+    try:
+        if manifest_json['ErrorWritingVersioning']:
+            print('No JSON could be loaded, is the container already running?')
+            exit(1)
+
+    except KeyError:
+        print(json.dumps(manifest_json,
+                         sort_keys=True,
+                         indent=4
+                         )
+              )

--- a/roles/nvidia-dgx-firmware/tasks/check-firmware.yml
+++ b/roles/nvidia-dgx-firmware/tasks/check-firmware.yml
@@ -25,7 +25,6 @@
 - name: Print show_version output (for single node, maybe be different across cluster)
   debug:
     msg: "{{ firmware_versions_response.stdout }}"
-  run_once: true
 
 - name: Register firmware as needing upgrade
   set_fact:

--- a/roles/nvidia-dgx-firmware/tasks/check-firmware.yml
+++ b/roles/nvidia-dgx-firmware/tasks/check-firmware.yml
@@ -1,7 +1,33 @@
 ---
+- name: Set diagnostic type
+  set_fact:
+    run_diagnostics_type: "{{ run_diagnostics_type | default() }}"
 
+- name: Ensure Docker is running
+  service:
+    name: docker
+    state: started
+
+- name: Check firmware manifest
+  shell: "docker run --rm --privileged  -v /:/hostfs {{ firmware_update_repo }}:{{ firmware_update_tag }} show_fw_manifest | tee {{ fw_dir }}/fw-manifests{{ run_diagnostics_type }}.log"
+  register: firmware_manifest
+
+# This is an optimization, checking the firmware versions can take a long time, so unless we are forcing an update only do this once
 - name: Check firmware version
-  command: "docker run --rm --privileged  -v /:/hostfs {{ firmware_update_repo }}:{{ firmware_update_tag }} show_version"
-  register: firmware_versions
-  changed_when: "'no' in firmware_versions.stdout"
-  
+  shell: "docker run --rm --privileged  -v /:/hostfs {{ firmware_update_repo }}:{{ firmware_update_tag }} show_version | tee {{ fw_dir }}/fw-versions{{ run_diagnostics_type }}.log"
+  register: firmware_versions_response
+
+- name: Print show_fw_manifest output
+  debug:
+    msg: "{{ firmware_manifest.stdout }}"
+  run_once: true
+
+- name: Print show_version output (for single node, maybe be different across cluster)
+  debug:
+    msg: "{{ firmware_versions_response.stdout }}"
+  run_once: true
+
+- name: Register firmware as needing upgrade
+  set_fact:
+    firmware_needs_upgrade: "{{ true if 'no' in firmware_versions_response.stdout or force_update else false }}" # TODO: Parse this from Json?
+  changed_when: firmware_needs_upgrade

--- a/roles/nvidia-dgx-firmware/tasks/clean.yml
+++ b/roles/nvidia-dgx-firmware/tasks/clean.yml
@@ -1,4 +1,8 @@
 ---
+# Note: a lot of this is redundant, however we do each step manually in the case of errors to ease debugging and clean up as best as possible
+- name: Starting cleanup step
+  debug:
+    msg: "Starting now"
 
 - name: Remove firmware container image
   command: "docker rmi -f {{ firmware_update_repo }}:{{ firmware_update_tag }}"
@@ -20,4 +24,3 @@
 
 - name: Remove diagnostic directory
   command: "rm -rf {{ fw_dir }}"
-

--- a/roles/nvidia-dgx-firmware/tasks/get-data.yml
+++ b/roles/nvidia-dgx-firmware/tasks/get-data.yml
@@ -1,5 +1,4 @@
 ---
-
 # This is used to generate a spreadsheet mapping NICs/IPs/Hostnames to a cluster of DGX-2s
 - name: Run NVSM human-readable health show
   shell: "osversion=`cat /etc/dgx-release | grep 'DGX_SWBUILD_VERSION'`; host=`hostname`; copper_mac=`ip addr | grep -A 1 enp6s0 | grep link | awk '{print $2}'`; bmc_ip=`sudo ipmitool lan print | grep -i 'IP Address              :' | awk '{print $4}'`; bmc_mac=`sudo ipmitool lan print | grep -i 'MAC Address' | awk '{print $4}'`;host_mac=`ifconfig {{ nv_mgmt_interface }} | grep 'ether' | awk '{print $2}'`;host_ip=`ifconfig {{ nv_mgmt_interface }} | grep 'inet ' | awk '{print $2}'`;data=\"${host_ip},${host_mac},${bmc_ip},${bmc_mac},${copper_mac},${host},${osversion}\";echo ${data}"

--- a/roles/nvidia-dgx-firmware/tasks/get-firmware.yml
+++ b/roles/nvidia-dgx-firmware/tasks/get-firmware.yml
@@ -1,6 +1,0 @@
----
-- name: Get on-board and container firmware versions
-  shell: "docker run --privileged --rm -v /:/hostfs {{ firmware_update_repo }}:{{ firmware_update_tag }} show_version | tee {{ fw_dir }}/fw-versions.log"
-  args:
-    chdir: "{{ fw_dir }}"
-  ignore_errors: yes

--- a/roles/nvidia-dgx-firmware/tasks/get-health.yml
+++ b/roles/nvidia-dgx-firmware/tasks/get-health.yml
@@ -6,7 +6,13 @@
 - name: Run NVSM dump health
   shell: "nvsm dump health"
   become: yes
+  when: nvsm_dump_health
 
 - name: Run quick DCGM diagnostic
   shell: "dcgmi diag -r 1 > {{ fw_dir }}/dcgm_diag_1.log"
   become: yes
+
+- name: Run full DCGM diagnostic
+  shell: "dcgmi diag -r 3 > {{ fw_dir }}/dcgm_diag_3.log"
+  become: yes
+  when: dcgm_stress

--- a/roles/nvidia-dgx-firmware/tasks/get-health.yml
+++ b/roles/nvidia-dgx-firmware/tasks/get-health.yml
@@ -2,15 +2,11 @@
 - name: Run NVSM human-readable health show
   shell: "nvsm show health > {{ fw_dir }}/nvsm-show-health.log"
   become: yes
-  ignore_errors: yes
 
 - name: Run NVSM dump health
   shell: "nvsm dump health"
   become: yes
-  ignore_errors: yes
 
 - name: Run quick DCGM diagnostic
   shell: "dcgmi diag -r 1 > {{ fw_dir }}/dcgm_diag_1.log"
   become: yes
-  ignore_errors: yes
-

--- a/roles/nvidia-dgx-firmware/tasks/get-time.yml
+++ b/roles/nvidia-dgx-firmware/tasks/get-time.yml
@@ -1,5 +1,4 @@
 ---
-
 - name: Get current system time
   shell: "now=$(date '+%Y%m%d-%H%M%S') && echo $now"
   register: current_time

--- a/roles/nvidia-dgx-firmware/tasks/load-image.yml
+++ b/roles/nvidia-dgx-firmware/tasks/load-image.yml
@@ -10,6 +10,7 @@
   register: tarball_local_exists
   delegate_to: 127.0.0.1
   failed_when: not tarball_local_exists.stat.exists
+  run_once: true
 - name: Check if container tarbal exists remotely
   stat:
     path: "{{ fw_dir }}/{{ firmware_update_container }}"

--- a/roles/nvidia-dgx-firmware/tasks/load-image.yml
+++ b/roles/nvidia-dgx-firmware/tasks/load-image.yml
@@ -1,14 +1,56 @@
 ---
+- name: Starting load image step
+  debug:
+    msg: "Starting now"
 
-- name: Copy DGX firmware container tarball to temporary directory on remote node
+# Verify the local container exists, then copy it over if necessary and verify it is loaded into Docker
+- name: Check if container tarbal exists locally
+  stat:
+    path: "{{ firmware_container_src_dir }}/{{ firmware_update_container }}"
+  register: tarball_local_exists
+  delegate_to: 127.0.0.1
+  failed_when: not tarball_local_exists.stat.exists
+- name: Check if container tarbal exists remotely
+  stat:
+    path: "{{ fw_dir }}/{{ firmware_update_container }}"
+  register: tarball_exists
+  failed_when: false
+- name: Copy DGX firmware container tarball to temporary directory on remote node if it is not there
   copy:
     src: "{{ firmware_container_src_dir }}/{{ firmware_update_container }}"
     dest: "{{ fw_dir }}"
-  ignore_errors: yes
+  when: not tarball_exists.stat.exists 
 
+# Verify Remote tarbal is correct before loading it
+- name: Get md5sum of remote tarball
+  stat:
+    path: "{{ fw_dir }}/{{ firmware_update_container }}"
+  register: tarball_exists
+- name: Verify remote and local container tarballs having matching md5sum
+  debug:
+    msg: Containers match
+  failed_when: tarball_exists.stat.checksum != tarball_local_exists.stat.checksum
+
+# Verify Docker is up load the image
+- name: Ensure Docker is running
+  service:
+    name: docker
+    state: started
 # Using 'command' instead of 'docker_image' since docker-py is required to use 'docker_image'
 - name: Load image from archive
   command: "docker load -i {{ firmware_update_container }}"
   args:
     chdir: "{{ fw_dir }}"
   ignore_errors: yes
+  register: load_image_output
+- name: Print the response from the load image command
+  debug:
+    msg: "{{ load_image_output }}"
+
+# Verify the image was loaded
+- name: List available Docker images
+  command: "docker images"
+  register: list_image_output
+- name: Print the response from the list image command
+  debug:
+    msg: "{{ list_image_output }}"

--- a/roles/nvidia-dgx-firmware/tasks/main.yml
+++ b/roles/nvidia-dgx-firmware/tasks/main.yml
@@ -1,18 +1,47 @@
 ---
-
+# Print some debug, make directories, and initialize
+- name: Print debug
+  debug:
+    msg: "run_diagnostics: {{ run_diagnostics }}, load_firmware: {{ load_firmware }}, update_firmware: {{ update_firmware }}
+          Copyng files to {{ fw_dir }} on DGX nodes, running container: {{ firmware_update_repo }}, tag: {{ firmware_update_tag }}"
 - name: Make firmware dir
   file:
     path: "{{ fw_dir }}"
     state: directory
+    mode: '0755'
+- name: Copy Wrapper Script
+  copy:
+    src: parse_manifest.py
+    dest: "{{ fw_dir }}/parse_manifest.py"
+    mode: '0644'
+    force: yes
 
-- include: load-image.yml
+- block:
+  # Run some pre-flight diagnostics pre-firmware update in case things go wrong
+  - include: run-diagnostics.yml
+    vars:
+      run_diagnostics_type: '-pre-check'
+    when:
+      - run_diagnostics
+      - load_firmware or update_firmware
 
-- include: update-firmware.yml
-  vars:
-    force_parameter: ''
-  when: update_firmware
+  # Verify the local container exists, then copy it over if necessary and verify it is loaded into Docker
+  - include: load-image.yml
+    when: load_firmware
 
-- include: run-diagnostics.yml
-  when: run_diagnostics
+  # Update the FW and reboot if necessary
+  - include: update-firmware.yml
+    when: update_firmware
 
+  # Run post-flight diagnostics
+  - include: run-diagnostics.yml
+    vars:
+      run_diagnostics_type: '-post-check'
+    when: run_diagnostics
+
+  always:
+  - include: transfer-logs.yml # In case of failure, this will pull whatever logs were captured; in case of success it will pull the later logs and some pre-flight checks may be overwritten
+
+# Clean up the loaded images and copied files
 - include: clean.yml
+  when: clean_fw

--- a/roles/nvidia-dgx-firmware/tasks/main.yml
+++ b/roles/nvidia-dgx-firmware/tasks/main.yml
@@ -45,3 +45,10 @@
 # Clean up the loaded images and copied files
 - include: clean.yml
   when: clean_fw
+
+# Some FW component upgrades require cleanly shutting down the DGX and doing a full powercycle (typically SBIOS or BMC)
+# Rather than automating this step, we allow the operator to perform a manual powercycle when it is safe to do so
+- name: Tell user to manually power cycle chassis
+  when: nv_fw_power_cycle_needed | default(false)
+  debug:
+    msg: "It is necessary to manually power cycle this DGX using the BMC or ipmitool. Notify Datacenter Operations that the system will be restarted (if necessary), cleanly shutdown the DGX using the 'shutdown' command, and power cycle the server using the BMC IP and ipmitool. FW update message: {{ fw_update_json.Message }}"

--- a/roles/nvidia-dgx-firmware/tasks/main.yml
+++ b/roles/nvidia-dgx-firmware/tasks/main.yml
@@ -1,6 +1,7 @@
 ---
 # Print some debug, make directories, and initialize
 - name: Print debug
+  run_once: true
   debug:
     msg: "run_diagnostics: {{ run_diagnostics }}, load_firmware: {{ load_firmware }}, update_firmware: {{ update_firmware }}
           Copyng files to {{ fw_dir }} on DGX nodes, running container: {{ firmware_update_repo }}, tag: {{ firmware_update_tag }}"

--- a/roles/nvidia-dgx-firmware/tasks/run-diagnostics.yml
+++ b/roles/nvidia-dgx-firmware/tasks/run-diagnostics.yml
@@ -1,7 +1,11 @@
 ---
+- name: Starting diagnostics step
+  debug:
+    msg: "Starting now"
 
-- include: get-firmware.yml
+- include: check-firmware.yml
+  ignore_errors: true
 - include: get-health.yml
+  ignore_errors: true
 - include: get-ib.yml
-- include: transfer-logs.yml
-
+  ignore_errors: true

--- a/roles/nvidia-dgx-firmware/tasks/transfer-logs.yml
+++ b/roles/nvidia-dgx-firmware/tasks/transfer-logs.yml
@@ -14,14 +14,14 @@
     flat: yes
   ignore_errors: yes
 
-- name: Copy fw versions log file to local machine
+- name: Copy pre-check fw versions log file to local machine
   fetch:
     src: "{{ fw_dir }}/fw-versions-pre-check.log"
     dest: "{{ local_log_directory }}/logs/{{ inventory_hostname }}/{{ inventory_hostname }}-{{ current_time.stdout }}-fw-version-pre-check.log"
     flat: yes
   ignore_errors: yes
 
-- name: Copy fw versions log file to local machine
+- name: Copy post-check fw versions log file to local machine
   fetch:
     src: "{{ fw_dir }}/fw-versions-post-check.log"
     dest: "{{ local_log_directory }}/logs/{{ inventory_hostname }}/{{ inventory_hostname }}-{{ current_time.stdout }}-fw-version-post-check.log"

--- a/roles/nvidia-dgx-firmware/tasks/transfer-logs.yml
+++ b/roles/nvidia-dgx-firmware/tasks/transfer-logs.yml
@@ -1,7 +1,6 @@
 ---
 - include: get-time.yml
 
-
 # nvsm does not allow you to specify a dump location, so we search /tmp for the last dump
 - name: Get name of the latest dumpfile from nvsm
   shell: "ls -taA1 /tmp | grep nvsm-health.*tar.* | head -n 1"
@@ -11,7 +10,35 @@
 - name: Copy fw versions log file to local machine
   fetch:
     src: "{{ fw_dir }}/fw-versions.log"
+    dest: "{{ local_log_directory }}/logs/{{ inventory_hostname }}/{{ inventory_hostname }}-{{ current_time.stdout }}-fw-version-pre-check.log"
+    flat: yes
+  ignore_errors: yes
+
+- name: Copy fw manifest log file to local machine
+  fetch:
+    src: "{{ fw_dir }}/fw-versions.log"
+    dest: "{{ local_log_directory }}/logs/{{ inventory_hostname }}/{{ inventory_hostname }}-{{ current_time.stdout }}-fw-version-post-check.log"
+    flat: yes
+  ignore_errors: yes
+
+- name: Copy fw versions log file to local machine
+  fetch:
+    src: "{{ fw_dir }}/fw-versions.log"
+    dest: "{{ local_log_directory }}/logs/{{ inventory_hostname }}/{{ inventory_hostname }}-{{ current_time.stdout }}-fw-version-post-check.log"
+    flat: yes
+  ignore_errors: yes
+
+- name: Copy fw versions log file to local machine
+  fetch:
+    src: "{{ fw_dir }}/fw-versions.log"
     dest: "{{ local_log_directory }}/logs/{{ inventory_hostname }}/{{ inventory_hostname }}-{{ current_time.stdout }}-fw-version.log"
+    flat: yes
+  ignore_errors: yes
+
+- name: Copy fw update log file to local machine
+  fetch:
+    src: "{{ fw_dir }}/fw-update.json"
+    dest: "{{ local_log_directory }}/logs/{{ inventory_hostname }}/{{ inventory_hostname }}-{{ current_time.stdout }}-fw-update.json"
     flat: yes
   ignore_errors: yes
 

--- a/roles/nvidia-dgx-firmware/tasks/transfer-logs.yml
+++ b/roles/nvidia-dgx-firmware/tasks/transfer-logs.yml
@@ -11,14 +11,14 @@
   ignore_errors: yes
   fetch:
     src: "{{ fw_dir }}/{{ item }}"
-    des: "{{ local_log_directory }}/logs/{{ inventory_hostname }}/{{ inventory_hostname }}-{{ current_time.stdout }}-{{ item }}"
+    dest: "{{ local_log_directory }}/logs/{{ inventory_hostname }}/{{ inventory_hostname }}-{{ current_time.stdout }}-{{ item }}"
     flat: yes
   with_items:
     - "fw-manifests.log"
     - "fw-versions-pre-check.log"
     - "{{ inventory_hostname }}.log"
     - "fw-versions-post-check.log"
-    -  "fw-versions.log"
+    - "fw-versions.log"
     - "fw-update.json"
     - "{{ nvsm_dump_file.stdout }}"
     - "nvsm-show-health.log"

--- a/roles/nvidia-dgx-firmware/tasks/transfer-logs.yml
+++ b/roles/nvidia-dgx-firmware/tasks/transfer-logs.yml
@@ -7,23 +7,23 @@
   register: nvsm_dump_file
   ignore_errors: yes
 
+- name: Copy fw manifest log file to local machine
+  fetch:
+    src: "{{ fw_dir }}/fw-manifests.log"
+    dest: "{{ local_log_directory }}/logs/{{ inventory_hostname }}/{{ inventory_hostname }}-{{ current_time.stdout }}-fw-version-manifests.log"
+    flat: yes
+  ignore_errors: yes
+
 - name: Copy fw versions log file to local machine
   fetch:
-    src: "{{ fw_dir }}/fw-versions.log"
+    src: "{{ fw_dir }}/fw-versions-pre-check.log"
     dest: "{{ local_log_directory }}/logs/{{ inventory_hostname }}/{{ inventory_hostname }}-{{ current_time.stdout }}-fw-version-pre-check.log"
     flat: yes
   ignore_errors: yes
 
-- name: Copy fw manifest log file to local machine
-  fetch:
-    src: "{{ fw_dir }}/fw-versions.log"
-    dest: "{{ local_log_directory }}/logs/{{ inventory_hostname }}/{{ inventory_hostname }}-{{ current_time.stdout }}-fw-version-post-check.log"
-    flat: yes
-  ignore_errors: yes
-
 - name: Copy fw versions log file to local machine
   fetch:
-    src: "{{ fw_dir }}/fw-versions.log"
+    src: "{{ fw_dir }}/fw-versions-post-check.log"
     dest: "{{ local_log_directory }}/logs/{{ inventory_hostname }}/{{ inventory_hostname }}-{{ current_time.stdout }}-fw-version-post-check.log"
     flat: yes
   ignore_errors: yes
@@ -60,6 +60,13 @@
   fetch:
     src: "{{ fw_dir }}/dcgm_diag_1.log"
     dest: "{{ local_log_directory }}/logs/{{ inventory_hostname }}/{{ inventory_hostname }}-{{ current_time.stdout }}-dcgm_diag_1.log"
+    flat: yes
+  ignore_errors: yes
+
+- name: Copy dcgm-3 diag log file to local machine
+  fetch:
+    src: "{{ fw_dir }}/dcgm_diag_3.log"
+    dest: "{{ local_log_directory }}/logs/{{ inventory_hostname }}/{{ inventory_hostname }}-{{ current_time.stdout }}-dcgm_diag_3.log"
     flat: yes
   ignore_errors: yes
 

--- a/roles/nvidia-dgx-firmware/tasks/transfer-logs.yml
+++ b/roles/nvidia-dgx-firmware/tasks/transfer-logs.yml
@@ -32,6 +32,13 @@
     flat: yes
   ignore_errors: yes
 
+- name: Copy /var/log/dmesg to local machine
+  fetch:
+    src: /var/log/dmesg
+    dest: "{{ local_log_directory }}/logs/{{ inventory_hostname }}/{{ inventory_hostname }}-{{ current_time.stdout }}-dmesg"
+    flat: yes
+  ignore_errors: yes
+
 - name: Copy /var/log/nvidia-fw.log to local machine
   fetch:
     src: /var/log/nvidia-fw.log

--- a/roles/nvidia-dgx-firmware/tasks/transfer-logs.yml
+++ b/roles/nvidia-dgx-firmware/tasks/transfer-logs.yml
@@ -7,68 +7,23 @@
   register: nvsm_dump_file
   ignore_errors: yes
 
-- name: Copy fw manifest log file to local machine
-  fetch:
-    src: "{{ fw_dir }}/fw-manifests.log"
-    dest: "{{ local_log_directory }}/logs/{{ inventory_hostname }}/{{ inventory_hostname }}-{{ current_time.stdout }}-fw-version-manifests.log"
-    flat: yes
+- name: Copy over all log files, etc.
   ignore_errors: yes
-
-- name: Copy pre-check fw versions log file to local machine
   fetch:
-    src: "{{ fw_dir }}/fw-versions-pre-check.log"
-    dest: "{{ local_log_directory }}/logs/{{ inventory_hostname }}/{{ inventory_hostname }}-{{ current_time.stdout }}-fw-version-pre-check.log"
+    src: "{{ fw_dir }}/{{ item }}"
+    des: "{{ local_log_directory }}/logs/{{ inventory_hostname }}/{{ inventory_hostname }}-{{ current_time.stdout }}-{{ item }}"
     flat: yes
-  ignore_errors: yes
-
-- name: Copy post-check fw versions log file to local machine
-  fetch:
-    src: "{{ fw_dir }}/fw-versions-post-check.log"
-    dest: "{{ local_log_directory }}/logs/{{ inventory_hostname }}/{{ inventory_hostname }}-{{ current_time.stdout }}-fw-version-post-check.log"
-    flat: yes
-  ignore_errors: yes
-
-- name: Copy fw versions log file to local machine
-  fetch:
-    src: "{{ fw_dir }}/fw-versions.log"
-    dest: "{{ local_log_directory }}/logs/{{ inventory_hostname }}/{{ inventory_hostname }}-{{ current_time.stdout }}-fw-version.log"
-    flat: yes
-  ignore_errors: yes
-
-- name: Copy fw update log file to local machine
-  fetch:
-    src: "{{ fw_dir }}/fw-update.json"
-    dest: "{{ local_log_directory }}/logs/{{ inventory_hostname }}/{{ inventory_hostname }}-{{ current_time.stdout }}-fw-update.json"
-    flat: yes
-  ignore_errors: yes
-
-- name: Copy health dump log file to local machine
-  fetch:
-    src: "/tmp/{{ nvsm_dump_file.stdout }}"
-    dest: "{{ local_log_directory }}/logs/{{ inventory_hostname }}/{{ inventory_hostname }}-{{ current_time.stdout }}-{{ nvsm_dump_file.stdout }}"
-    flat: yes
-  ignore_errors: yes
-
-- name: Copy show health log file to local machine
-  fetch:
-    src: "{{ fw_dir }}/nvsm-show-health.log"
-    dest: "{{ local_log_directory }}/logs/{{ inventory_hostname }}/{{ inventory_hostname }}-{{ current_time.stdout }}-nvsm-show-health.log"
-    flat: yes
-  ignore_errors: yes
-
-- name: Copy dcgm diag log file to local machine
-  fetch:
-    src: "{{ fw_dir }}/dcgm_diag_1.log"
-    dest: "{{ local_log_directory }}/logs/{{ inventory_hostname }}/{{ inventory_hostname }}-{{ current_time.stdout }}-dcgm_diag_1.log"
-    flat: yes
-  ignore_errors: yes
-
-- name: Copy dcgm-3 diag log file to local machine
-  fetch:
-    src: "{{ fw_dir }}/dcgm_diag_3.log"
-    dest: "{{ local_log_directory }}/logs/{{ inventory_hostname }}/{{ inventory_hostname }}-{{ current_time.stdout }}-dcgm_diag_3.log"
-    flat: yes
-  ignore_errors: yes
+  with_items:
+    - "fw-manifests.log"
+    - "fw-versions-pre-check.log"
+    - "{{ inventory_hostname }}.log"
+    - "fw-versions-post-check.log"
+    -  "fw-versions.log"
+    - "fw-update.json"
+    - "{{ nvsm_dump_file.stdout }}"
+    - "nvsm-show-health.log"
+    - "dcgm_diag_1.log"
+    - "dcgm_diag_3.log"
 
 - name: Copy /var/log/syslog to local machine
   fetch:
@@ -84,9 +39,3 @@
     flat: yes
   ignore_errors: yes
 
-- name: Copy ib/mlx to local machine
-  fetch:
-    src: "{{ fw_dir }}/{{ inventory_hostname }}.log"
-    dest: "{{ local_log_directory }}/logs/{{ inventory_hostname }}/{{ inventory_hostname }}-{{ current_time.stdout }}-ib-mlx.log"
-    flat: yes
-  ignore_errors: yes

--- a/roles/nvidia-dgx-firmware/tasks/update-firmware.yml
+++ b/roles/nvidia-dgx-firmware/tasks/update-firmware.yml
@@ -1,50 +1,55 @@
 ---
+- name: Starting firmware update step
+  debug:
+    msg: "Starting now"
 
 - include: check-firmware.yml
 
-- name: Check if force update requested
-  set_fact:
-    force_parameter: '-f'
-  when: force_update
+- block:
+  - name: Stop NVSM_CORE before updating # TODO: BUG: Due to bug in current container workflow
+    service:
+      name: nvsm-core
+      state: stopped
 
-- name: Update firmware if required
-  block:
-    - name: Update firmware if required
-      command: "docker run --rm -ti --privileged -v /:/hostfs -e auto=1 -e COLUMNS=200 -e LINES=300 {{ firmware_update_repo }}:{{ firmware_update_tag }} set_flags AUTO=1 update_fw {{ force_parameter }} {{ target_fw }}"
-      register: update_output
-      when:
-        - "'no' in firmware_versions.stdout"
-      failed_when: "'fail' in update_output.stdout"
-  rescue:
-    - name: Show failure message
-      debug:
-        var: update_output.stdout
-    - include: transfer-logs.yml
+  - name: Check if force update requested
+    set_fact:
+      force_parameter: "{{ '-f' if force_update else '' }}"
+
+  - name: Update firmware if required
+    shell: "docker run --rm -ti --privileged -v /:/hostfs -e NVSM_MODE=1 {{ firmware_update_repo }}:{{ firmware_update_tag }} set_flags AUTO=1 update_fw {{ target_fw }} {{ force_parameter }} > {{ fw_dir }}/fw-update.json" 
+
+  - name: "Parse FW Update output"
+    command: "python3 {{ fw_dir }}/parse_manifest.py parse_update_json {{ fw_dir }}/fw-update.json"
+    register: update_output
+  - name: To json
+    set_fact:
+      fw_update_json: "{{ update_output.stdout }}"
+  - name: Register reboot as required
+    set_fact:
+       reboot_required: "{{ true if 'rebootHard\": true' in fw_update_json else false }}"
+
+  when:
+    - firmware_needs_upgrade | default(false)
 
 - name: Reboot if necessary
   shell: sleep 2 && /sbin/shutdown -r now "Reboot required"
   async: 1
   poll: 0
-  when: " 'no' in firmware_versions.stdout and 'reboot required: yes' in update_output.stdout"
-  changed_when: False
+  when:
+    - reboot_required | default(false)
 
-- name: Wait for server to reboot
+- name: Wait for server to reboot (if required)
   wait_for_connection:
     delay=15
     timeout={{ reboot_timeout }}
-  when: " 'no' in firmware_versions.stdout and 'reboot required: yes' in update_output.stdout"
 
-- name: Ensure firmware was updated and everything is up-to-date. Skip if force update was used.
-  block:
-    - include: check-firmware.yml
-    - name: "Ensure all fw versions are up-to-date after the update - skip if force update was used or specific target fw was updated"
-      debug:
-        msg: ""
-      failed_when: "'no' in firmware_versions.stdout"
-  when: "target_fw == 'all' and force_parameter == '' and not 'fail' in update_output.stdout"
-  rescue:
-    - name: Show debug information for firmware update mismatch
-      debug:
-        var: firmware_versions.stdout
-    - include: transfer-logs.yml
+- name: Print Debug
+  debug:
+    msg: Host is online
 
+- name: Start NVSM_CORE after completion  # TODO: BUG: Due to bug in current container workflow
+  service:
+    name: nvsm-core
+    state: started
+
+- include: verify-firmware.yml

--- a/roles/nvidia-dgx-firmware/tasks/update-firmware.yml
+++ b/roles/nvidia-dgx-firmware/tasks/update-firmware.yml
@@ -6,11 +6,6 @@
 - include: check-firmware.yml
 
 - block:
-  - name: Stop NVSM_CORE before updating # TODO: BUG: Due to bug in current container workflow
-    service:
-      name: nvsm-core
-      state: stopped
-
   - name: Check if force update requested
     set_fact:
       force_parameter: "{{ '-f' if force_update else '' }}"
@@ -26,7 +21,8 @@
       fw_update_json: "{{ update_output.stdout }}"
   - name: Register reboot as required
     set_fact:
-       reboot_required: "{{ true if 'rebootHard\": true' in fw_update_json else false }}"
+       reboot_required: true
+    when: fw_update_json.RebootRequired == true
 
   when:
     - firmware_needs_upgrade | default(false)
@@ -38,6 +34,12 @@
   when:
     - reboot_required | default(false)
 
+# TODO: This script does not handle the case of a chassis-levl power cycle being required with ipmitool 
+- name: Tell user to manually power cycle chassis
+  when: fw_update_json.FirmwareLoadAction == "DC Power Cycle"
+  debug:
+    msg: "It is necessary to manually power cycle this DGX using the BMC or ipmitool. FW update message: {{ fw_update_json.Message }}"
+
 - name: Wait for server to reboot (if required)
   wait_for_connection:
     delay=15
@@ -46,10 +48,5 @@
 - name: Print Debug
   debug:
     msg: Host is online
-
-- name: Start NVSM_CORE after completion  # TODO: BUG: Due to bug in current container workflow
-  service:
-    name: nvsm-core
-    state: started
 
 - include: verify-firmware.yml

--- a/roles/nvidia-dgx-firmware/tasks/update-firmware.yml
+++ b/roles/nvidia-dgx-firmware/tasks/update-firmware.yml
@@ -35,8 +35,13 @@
     - reboot_required | default(false)
 
 # TODO: This script does not handle the case of a chassis-levl power cycle being required with ipmitool 
-- name: Tell user to manually power cycle chassis
+
+- name: Register power cycle required
   when: fw_update_json.FirmwareLoadAction == "DC Power Cycle"
+  set_fact:
+    nv_fw_power_cycle_needed: true
+- name: Tell user to manually power cycle chassis
+  when: nv_fw_power_cycle_needed | default(false)
   debug:
     msg: "It is necessary to manually power cycle this DGX using the BMC or ipmitool. FW update message: {{ fw_update_json.Message }}"
 

--- a/roles/nvidia-dgx-firmware/tasks/verify-firmware.yml
+++ b/roles/nvidia-dgx-firmware/tasks/verify-firmware.yml
@@ -1,0 +1,26 @@
+---
+- name: "Parse FW Update output"
+  command: "python3 {{ fw_dir }}/parse_manifest.py parse_update_json {{ fw_dir }}/fw-update.json"
+  register: result
+
+- name: To json
+  set_fact:
+    fw_update_json: "{{ result.stdout }}"
+
+- name: "FW Update Check"
+  debug:
+    msg: "FW Update Success"
+  when: fw_update_json.State != "Success"
+
+- name: Ensure firmware was updated and everything is up-to-date. Skip if force update was used.
+  block:
+    - include: check-firmware.yml
+    - name: "Ensure all fw versions are up-to-date after the update - skip if force update was used or specific target fw was updated"
+      debug:
+        msg: ""
+      failed_when: firmware_needs_upgrade | default(true)
+      when: target_fw == 'all' and force_parameter == '' and fw_update_json.State == "Success" # If we forced it or didn't upgrade everything this check would always fail # TODO: parse from json
+  rescue:
+    - name: Show debug information for firmware update mismatch
+      debug:
+        var: firmware_versions_response.stdout


### PR DESCRIPTION
**Updates:**
* Bump versions, new container introduces a proper automated version complete with json output
* Use proper docker run with automation flags instead of the hacky `-it` with formatting that was necessary
* Add md5sum checksums to container tarball before any updates
* Update readme
* Add json parsing tool to get status from the output of the new container
* Add some debug
* Collapse some of the playbooks and improve tagging/error ignoring

**TODOS:**
* In general this is complete, but there are still a few cases where we check firmware versions or attempt to update a few more times than necessary. This only wastes a little bit of time and I'd rather have more verification/debug steps than less when dealing with firmware upgrades.

* Some of the variables also have generic names and could use a rename to start with `nv_dgx_fw`

**Testing plan:**

- [x] Verify `playbooks/nvidia-dgx/nvidia-dgx-diag.yml` collects all logs
- [x] Verify `playbooks/nvidia-dgx/nvidia-dgx-fw-update.yml` works when no updates are needed (by running the same update container twice)
- [x] Verify `playbooks/nvidia-dgx/nvidia-dgx-fw-update.yml` works when updates are needed (by using a new container or downgrading, then upgrading)
- [x] Verify `playbooks/nvidia-dgx/nvidia-dgx-fw-update.yml` works when no updates areforced (by setting `force_firmware` with a single component)
- [x] Verify `playbooks/nvidia-dgx/nvidia-dgx-fw-update.yml` works when updating only a single compontent (by setting `target_fw`)


