### PR TITLE
Add RHEL/CentOS 8 support

### DIFF
--- a/roles/lmod/defaults/main.yml
+++ b/roles/lmod/defaults/main.yml
@@ -1,7 +1,4 @@
 ---
-lmod_rhel_epel_repo_baseurl: "https://download.fedoraproject.org/pub/epel/$releasever/$basearch/"
-lmod_rhel_epel_repo_gpgkey: "https://epel.mirror.constant.com//RPM-GPG-KEY-EPEL-{{ ansible_distribution_major_version }}"
-
 # include some reasonable defaults for module paths
 sm_prefix: "/sw"
 sm_module_root: "{{ sm_prefix }}/modules"

--- a/roles/lmod/tasks/main.yml
+++ b/roles/lmod/tasks/main.yml
@@ -5,8 +5,9 @@
 - name: RedHat | add epel repo
   become: yes
   yum:
-    - name: "epel-release"
-  state: latest
+    name: 
+      - "epel-release"
+    state: latest
   environment: "{{proxy_env if proxy_env is defined else {}}}"
   when: ansible_os_family == "RedHat"
 

--- a/roles/lmod/tasks/main.yml
+++ b/roles/lmod/tasks/main.yml
@@ -3,11 +3,9 @@
 #
 ---
 - name: RedHat | add epel repo
-  yum_repository:
-    name: epel
-    description: EPEL YUM repo
-    baseurl: "{{ lmod_rhel_epel_repo_baseurl }}"
-    gpgkey: "{{ lmod_rhel_epel_repo_gpgkey }}"
+  yum:
+    - name: "epel-release"
+  state: latest
   environment: "{{proxy_env if proxy_env is defined else {}}}"
   when: ansible_os_family == "RedHat"
 

--- a/roles/lmod/tasks/main.yml
+++ b/roles/lmod/tasks/main.yml
@@ -3,6 +3,7 @@
 #
 ---
 - name: RedHat | add epel repo
+  become: yes
   yum:
     - name: "epel-release"
   state: latest

--- a/roles/nfs/tasks/client.yml
+++ b/roles/nfs/tasks/client.yml
@@ -20,11 +20,17 @@
   tags:
     - nfs
 
-- name: rhel | install management prereq
+- name: rhel 7 | install management prereq
   yum:
     name: "libsemanage-python"
     state: present
-  when: ansible_os_family == "RedHat"
+  when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "7"
+
+- name: rhel 8 | install management prereq
+  yum:
+    name: "python3-libsemanage"
+    state: present
+  when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "8"
 
 - name: rhel | enable nfs home directory usage
   seboolean:

--- a/roles/nvidia-cuda/defaults/main.yml
+++ b/roles/nvidia-cuda/defaults/main.yml
@@ -17,8 +17,6 @@ cuda_dgx_a100_version: "cuda-toolkit-11-0"
 cuda_toolkit_add_profile_script: yes
 
 # RedHat family
-nvidia_driver_rhel_epel_repo_baseurl: "https://download.fedoraproject.org/pub/epel/$releasever/$basearch/"
-nvidia_driver_rhel_epel_repo_gpgkey: "https://epel.mirror.constant.com//RPM-GPG-KEY-EPEL-{{ ansible_distribution_major_version }}"
 nvidia_driver_rhel_cuda_repo_baseurl: "https://developer.download.nvidia.com/compute/cuda/repos/{{ _rhel_repo_dir }}/"
 nvidia_driver_rhel_cuda_repo_gpgkey: "https://developer.download.nvidia.com/compute/cuda/repos/{{ _rhel_repo_dir }}/7fa2af80.pub"
 

--- a/roles/nvidia-cuda/tasks/install-redhat.yml
+++ b/roles/nvidia-cuda/tasks/install-redhat.yml
@@ -1,10 +1,8 @@
 ---
 - name: RedHat | add epel repo
-  yum_repository:
-    name: epel
-    description: EPEL YUM repo
-    baseurl: "{{ nvidia_driver_rhel_epel_repo_baseurl }}"
-    gpgkey: "{{ nvidia_driver_rhel_epel_repo_gpgkey }}"
+  yum:
+    - name: "epel-release"
+  state: latest
   environment: "{{proxy_env if proxy_env is defined else {}}}"
 
 - name: RedHat | add CUDA repo

--- a/roles/nvidia-cuda/tasks/install-redhat.yml
+++ b/roles/nvidia-cuda/tasks/install-redhat.yml
@@ -2,8 +2,9 @@
 - name: RedHat | add epel repo
   become: yes
   yum:
-    - name: "epel-release"
-  state: latest
+    name: 
+      - "epel-release"
+    state: latest
   environment: "{{proxy_env if proxy_env is defined else {}}}"
 
 - name: RedHat | add CUDA repo

--- a/roles/nvidia-cuda/tasks/install-redhat.yml
+++ b/roles/nvidia-cuda/tasks/install-redhat.yml
@@ -1,5 +1,6 @@
 ---
 - name: RedHat | add epel repo
+  become: yes
   yum:
     - name: "epel-release"
   state: latest

--- a/roles/nvidia-dgx/defaults/main.yml
+++ b/roles/nvidia-dgx/defaults/main.yml
@@ -1,5 +1,3 @@
-epel_baseurl: "https://download.fedoraproject.org/pub/epel/$releasever/$basearch/"
-epel_gpgkey: "https://epel.mirror.constant.com//RPM-GPG-KEY-EPEL-{{ ansible_distribution_major_version }}"
 nvidia_dgx_rhel_baseurl: "https://international.download.nvidia.com/dgx/repos/{{ dgx_repo_dir }}/"
 nvidia_dgx_rhel_gpgkey: "https://international.download.nvidia.com/dgx/repos/RPM-GPG-KEY-dgx-cosmos-support"
 

--- a/roles/nvidia-dgx/tasks/redhat.yml
+++ b/roles/nvidia-dgx/tasks/redhat.yml
@@ -3,11 +3,10 @@
   include_vars: redhat.yml
 
 - name: Add epel repo
-  yum_repository:
-    name: epel
-    description: EPEL YUM repo
-    baseurl: "{{ epel_baseurl }}"
-    gpgkey: "{{ epel_gpgkey }}"
+  yum:
+    name: 
+      - "epel-release"
+    state: latest
 
 - name: Add DGX repo
   yum_repository:

--- a/roles/nvidia-hpc-sdk/defaults/main.yml
+++ b/roles/nvidia-hpc-sdk/defaults/main.yml
@@ -45,6 +45,6 @@ hpcsdk_download_url: "https://developer.download.nvidia.com/hpc-sdk/{{ hpcsdk_ve
 
 # Directories for download
 hpcsdk_temp_dir: "/tmp/hpc-sdk-install"
-hpcsdk_dest_download_path: "{{ hpcsdk_temp_dir }}/nvhpc.tar.gz"
+hpcsdk_dest_download_path: "{{ hpcsdk_temp_dir }}/{{ hpcsdk_download_name }}.tar.gz"
 hpcsdk_clean_up_tarball_after_extract: true
 hpcsdk_clean_up_temp_dir: true

--- a/roles/nvidia-hpc-sdk/tasks/main.yml
+++ b/roles/nvidia-hpc-sdk/tasks/main.yml
@@ -25,17 +25,12 @@
   - "{{ hpcsdk_temp_dir }}"
   - "{{ hpcsdk_install_dir }}"
 
-- name: check for downloaded nvidia hpc sdk
-  command: /usr/bin/test -e {{ hpcsdk_dest_download_path }}
-  ignore_errors: True
-  register: nvidia_hpc_sdk
-
 - name: download nvidia hpc sdk
   get_url:
     url: "{{ hpcsdk_download_url }}"
     dest: "{{ hpcsdk_dest_download_path }}"
     mode: "0444"
-  when: nvidia_hpc_sdk == False
+    force: no
 
 - name: extract archive
   unarchive:

--- a/roles/nvidia-hpc-sdk/tasks/main.yml
+++ b/roles/nvidia-hpc-sdk/tasks/main.yml
@@ -30,7 +30,6 @@
     url: "{{ hpcsdk_download_url }}"
     dest: "{{ hpcsdk_dest_download_path }}"
     mode: "0444"
-    force: no
 
 - name: extract archive
   unarchive:

--- a/roles/nvidia-hpc-sdk/tasks/main.yml
+++ b/roles/nvidia-hpc-sdk/tasks/main.yml
@@ -25,11 +25,17 @@
   - "{{ hpcsdk_temp_dir }}"
   - "{{ hpcsdk_install_dir }}"
 
+- name: check for downloaded nvidia hpc sdk
+  command: /usr/bin/test -e {{ hpcsdk_dest_download_path }}
+  ignore_errors: True
+  register: nvidia_hpc_sdk
+
 - name: download nvidia hpc sdk
   get_url:
     url: "{{ hpcsdk_download_url }}"
     dest: "{{ hpcsdk_dest_download_path }}"
     mode: "0444"
+  when: nvidia_hpc_sdk == False
 
 - name: extract archive
   unarchive:

--- a/roles/nvidia-ml/defaults/main.yml
+++ b/roles/nvidia-ml/defaults/main.yml
@@ -1,8 +1,6 @@
 nvidia_ml_package_state: present
 nvidia_cudnn_package_version: ''
 nvidia_nccl_package_version: ''
-epel_baseurl: "https://download.fedoraproject.org/pub/epel/$releasever/$basearch/"
-epel_gpgkey: "https://epel.mirror.constant.com//RPM-GPG-KEY-EPEL-{{ ansible_distribution_major_version }}"
 rhel_nvidiaml_gpgkey: "https://developer.download.nvidia.com/compute/machine-learning/repos/{{ rhel_repo_dir }}/7fa2af80.pub"
 rhel_nvidiaml_baseurl: "https://developer.download.nvidia.com/compute/machine-learning/repos/{{ rhel_repo_dir }}/"
 ubuntu_nvidiaml_gpgkey: "https://developer.download.nvidia.com/compute/machine-learning/repos/{{ ubuntu_repo_dir }}/7fa2af80.pub"

--- a/roles/nvidia-ml/tasks/redhat-pre-install.yml
+++ b/roles/nvidia-ml/tasks/redhat-pre-install.yml
@@ -1,10 +1,9 @@
 ---
 - name: add epel repo
-  yum_repository:
-    name: epel
-    description: EPEL YUM repo
-    baseurl: "{{ epel_baseurl }}"
-    gpgkey: "{{ epel_gpgkey }}"
+  yum:
+    name: 
+      - "epel-release"
+    state: latest
 
 - name: add repo
   yum_repository:

--- a/roles/slurm/defaults/main.yml
+++ b/roles/slurm/defaults/main.yml
@@ -1,6 +1,3 @@
-epel_baseurl: "https://download.fedoraproject.org/pub/epel/$releasever/$basearch/"
-epel_gpgkey: "https://epel.mirror.constant.com//RPM-GPG-KEY-EPEL-{{ ansible_distribution_major_version }}"
-
 slurm_build_dir: /opt/deepops/build/slurm
 hwloc_build_dir: /opt/deepops/build/hwloc
 pmix_build_dir: /opt/deepops/build/pmix

--- a/roles/slurm/tasks/setup-role.yml
+++ b/roles/slurm/tasks/setup-role.yml
@@ -12,9 +12,8 @@
     - always
 
 - name: add epel repo
-  yum_repository:
-    name: epel
-    description: EPEL YUM repo
-    baseurl: "{{ epel_baseurl }}"
-    gpgkey: "{{ epel_gpgkey }}"
+  yum:
+    name: 
+      - "epel-release"
+    state: latest
   when: ansible_os_family == "RedHat"


### PR DESCRIPTION
RHEL/CentOS 8 EPEL repository urls do not follow the same structure as RHEL/CentOS 7 EPEL repository. Mostly just modify existing yum_repository with static url & key methods with yum install epel-release method. This provides the proper create epel.repo functions on RHEL 7 and RHEL 8.

Some package names are different between 7 & 8 requiring additional ansible_distribution_major_version checks.