### PR TITLE
[Slurm Cluster Prometheus] Use a persistent volume for Prometheus metrics

### DIFF
--- a/roles/prometheus/defaults/main.yml
+++ b/roles/prometheus/defaults/main.yml
@@ -1,6 +1,7 @@
 prometheus_config_dir: /etc/prometheus
 prometheus_container: "prom/prometheus"
 prometheus_svc_name: "docker.prometheus.service"
+prometheus_docker_volume_name: "deepops_prometheus_metrics"
 prometheus_state: started
 prometheus_enabled: yes
 

--- a/roles/prometheus/tasks/main.yml
+++ b/roles/prometheus/tasks/main.yml
@@ -18,6 +18,19 @@
     mode: 0644
   notify: restart prometheus
 
+- name: install pip
+  package:
+    name: python3-pip
+
+- name: install docker libraries
+  pip:
+    name: docker
+
+- name: create a persistent docker volume for metrics
+  docker_volume:
+    name: "{{ prometheus_docker_volume_name }}"
+    state: "present"
+
 - name: install systemd unit file
   template:
     src: templates/docker.prometheus.service.j2

--- a/roles/prometheus/templates/docker.prometheus.service.j2
+++ b/roles/prometheus/templates/docker.prometheus.service.j2
@@ -9,7 +9,7 @@ Restart=always
 ExecStartPre=-/usr/bin/docker stop %n
 ExecStartPre=-/usr/bin/docker rm %n
 ExecStartPre=/usr/bin/docker pull {{ prometheus_container }}
-ExecStart=/usr/bin/docker run --rm --network host --name %n -v {{ prometheus_config_dir }}:/etc/prometheus {{ prometheus_container }}
+ExecStart=/usr/bin/docker run --rm --network host --name %n -v {{ prometheus_config_dir }}:/etc/prometheus -v {{ prometheus_docker_volume_name }}:/prometheus {{ prometheus_container }}
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Currently our Prometheus container doesn't store its metrics in a persistent volume. This will cause the metrics history to disappear if we remove and re-create the container. This PR configures a persistent volume by default to store these metrics.

## Test plan

1. Install Prometheus using `playbooks/slurm-cluster/prometheus.yml`
1. Use `docker volume ls` to check that a new volume `deepops_prometheus_metrics` should exist
1. Use `systemctl status docker.prometheus.service` to check that the `docker run` command uses the volume