### PR TITLE
[Slurm Cluster] Make reboot wait time configurable when rebooting during Slurm setup

### DIFF
--- a/roles/slurm/defaults/main.yml
+++ b/roles/slurm/defaults/main.yml
@@ -66,6 +66,9 @@ slurm_oversubscribe: "NO"
 # Default: <not included>
 # slurm_default_job_timelimit: 
 
+# Maximum time to wait for Slurm compute nodes to reboot during playbook setup
+slurm_node_reboot_timeout: 600
+
 # Set up prolog and epilog
 slurm_enable_prolog_epilog: true
 

--- a/roles/slurm/tasks/compute.yml
+++ b/roles/slurm/tasks/compute.yml
@@ -30,6 +30,7 @@
       command: update-grub
     - name: reboot after updating grub config
       reboot:
+        reboot_timeout: "{{ slurm_node_reboot_timeout }}"
   when: update_grub.changed and ansible_os_family == "Debian"
 
 - name: update grub
@@ -38,6 +39,7 @@
       command: grub2-mkconfig -o /boot/grub2/grub.cfg
     - name: reboot after updating grub config
       reboot:
+        reboot_timeout: "{{ slurm_node_reboot_timeout }}"
   when: update_grub.changed and ansible_os_family == "RedHat"
 
 - name: create sysconfig dir


### PR DESCRIPTION
The default is 600 seconds, but this is a tight limit for some node types with very long POST times.

## Test plan

This is a little tricky to reproducibly test 😄  But setting this value to a much shorter value (like 2 s) with a virtual cluster should demonstrate the functionality by timing out too soon.