### PR TITLE
[Slurm Cluster] Add a var for alternate nhc sysconfig file

### DIFF
--- a/roles/nhc/defaults/main.yml
+++ b/roles/nhc/defaults/main.yml
@@ -14,6 +14,7 @@ nhc_run_test: false
 nhc_make: "make install"
 
 nhc_config_template: "nhc.conf.j2"
+nhc_sysconfig_template: "sysconfig_nhc.j2"
 
 nhc_force_reinstall: false
 nhc_config: "nhc.conf.j2"

--- a/roles/nhc/tasks/main.yml
+++ b/roles/nhc/tasks/main.yml
@@ -101,7 +101,7 @@
 
 - name: add sysconfig to use slurm
   template:
-    src: "sysconfig_nhc.j2"
+    src: "{{ nhc_sysconfig_template }}"
     dest: "{{ nhc_sysconfig_dir }}/nhc"
     owner: root
     group: root


### PR DESCRIPTION
There are some site-specific customizations that need to happen in `/etc/sysconfig/nhc`, so we should provide a var so the user can override the path for the source file.

## Test plan

Create a static file on the Ansible control node which contains your desired content for `/etc/sysconfig/nhc`, e.g.:

```
PATH=/sbin:/usr/sbin:/bin:/usr/bin:/usr/local/bin
NHC_RM=slurm
SLURM_SINFO=/usr/local/bin/sinfo
SLURM_SCONTROL=/usr/local/bin/scontrol

# Use a longer timeout for the script (default 30s)
TIMEOUT=60

# Use the short hostname when interacting with scheduler
HOSTNAME=$(hostname -s)
```

Set the `nhc_sysconfig_file` to the path of your custom file on the Ansible control node.

Then install NHC using `playbooks/slurm-cluster/nhc.yml` and check that the file in `/etc/sysconfig/nhc` matches your desired contents.