### PR TITLE
[Slurm Cluster Prometheus Exporters] Limit CPU usage for Prom node exporters

### DIFF
--- a/roles/nvidia-dcgm-exporter/defaults/main.yml
+++ b/roles/nvidia-dcgm-exporter/defaults/main.yml
@@ -8,3 +8,5 @@ prometheus_config_dir: /etc/prometheus
 prometheus_cfg_endpoint_dir: "{{ prometheus_config_dir }}/endpoints"
 
 has_gpus: false
+
+nvidia_dcgm_max_cpu: "0.5"

--- a/roles/nvidia-dcgm-exporter/templates/docker.dcgm-exporter.service.j2
+++ b/roles/nvidia-dcgm-exporter/templates/docker.dcgm-exporter.service.j2
@@ -9,7 +9,7 @@ Restart=always
 ExecStartPre=-/usr/bin/docker stop %n
 ExecStartPre=-/usr/bin/docker rm %n
 ExecStartPre=/usr/bin/docker pull {{ nvidia_dcgm_container }}
-ExecStart=/usr/bin/docker run --rm --name %n -p 9400:9400 {{ nvidia_dcgm_container }}
+ExecStart=/usr/bin/docker run --rm --cpus="{{ nvidia_dcgm_max_cpu }}" --name %n -p 9400:9400 {{ nvidia_dcgm_container }}
 
 [Install]
 WantedBy=multi-user.target

--- a/roles/prometheus-node-exporter/defaults/main.yml
+++ b/roles/prometheus-node-exporter/defaults/main.yml
@@ -6,3 +6,5 @@ node_exporter_enabled: yes
 
 prometheus_config_dir: /etc/prometheus
 prometheus_cfg_endpoint_dir: "{{ prometheus_config_dir }}/endpoints"
+
+node_exporter_max_cpu: "0.5"

--- a/roles/prometheus-node-exporter/templates/docker.node-exporter.service.j2
+++ b/roles/prometheus-node-exporter/templates/docker.node-exporter.service.j2
@@ -9,7 +9,7 @@ Restart=always
 ExecStartPre=-/usr/bin/docker stop %n
 ExecStartPre=-/usr/bin/docker rm %n
 ExecStartPre=/usr/bin/docker pull {{ node_exporter_container }}
-ExecStart=/usr/bin/docker run --rm --network host --pid="host" --name %n -v {{ node_exporter_prom_dir }}:/run/prometheus {{ node_exporter_container }} --collector.textfile.directory="{{ node_exporter_prom_dir }}"
+ExecStart=/usr/bin/docker run --rm --network host --cpus="{{ node_exporter_max_cpu }}"  --pid="host" --name %n -v {{ node_exporter_prom_dir }}:/run/prometheus {{ node_exporter_container }} --collector.textfile.directory="{{ node_exporter_prom_dir }}"
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
When polled at a high rate, the Prometheus node exporters can consume a fair amount of CPU. This change a CPU limit to our docker commands for running the exports so that we can minimize the impact on user jobs.

## Test plan

1. Deploy node exporter with `playbooks/slurm-cluster/prometheus-node-exporter.yml`
1. Deploy DCGM exporter with `playbooks/slurm-cluster/nvidia-dcgm-exporter.yml`
1. Check the resulting containers with `docker inspect` and confirm the CPU limit
1. Check the resource consumption with `top` and confirm they use no more than 50% CPU each