### PR TITLE
Make /etc/hosts behavior more configurable

### DIFF
--- a/config.example/group_vars/all.yml
+++ b/config.example/group_vars/all.yml
@@ -40,6 +40,8 @@ chrony_config_server:
   - 2.pool.ntp.org
   - 3.pool.ntp.org
 
+# Set hostname based on inventory file
+deepops_set_hostname: true
 
 ################################################################################
 # SOFTWARE                                                                     #

--- a/config.example/group_vars/slurm-cluster.yml
+++ b/config.example/group_vars/slurm-cluster.yml
@@ -40,6 +40,7 @@ slurm_ha_state_save_location: "/sw/slurm"
 ################################################################################
 # Optional installs                                                            #
 ################################################################################
+slurm_configure_etc_hosts: yes
 slurm_cluster_install_cuda: yes
 slurm_cluster_install_nvidia_driver: yes
 slurm_cluster_install_singularity: no

--- a/playbooks/generic/hosts.yml
+++ b/playbooks/generic/hosts.yml
@@ -5,6 +5,8 @@
     - name: set /etc/hostname
       hostname:
         name: "{{ inventory_hostname }}"
+      when: "{{ deepops_set_hostname | default(true) }}"
+
     - name: set /etc/hosts
       include_role:
         name: DeepOps.hosts

--- a/playbooks/slurm-cluster.yml
+++ b/playbooks/slurm-cluster.yml
@@ -14,6 +14,9 @@
 
 # Configure hostnames, /etc/hosts
 - include: generic/hosts.yml
+  when: "{{ slurm_configure_etc_hosts | default(true) }}"
+  tags:
+  - set-etc-hosts
 
 # Configure Chrony (NTP) sync
 - include: generic/chrony-client.yml


### PR DESCRIPTION
- Var to enable/disable setting hostname based on inventory
- Var to enable/disable setting up /etc/hosts in slurm-cluster

This is to provide more flexibility for deployments where the hostname is set outside DeepOps (e.g. in a provisioning system like MAAS), and for deployments that already include DNS and therefore don't need an /etc/hosts file.