### PR TITLE
Fix for failing Jenkins script

### DIFF
--- a/workloads/jenkins/scripts/verify-ingress-config.sh
+++ b/workloads/jenkins/scripts/verify-ingress-config.sh
@@ -4,5 +4,11 @@ source workloads/jenkins/scripts/jenkins-common.sh
 cd virtual || exit 1
 
 chmod 755 "$K8S_CONFIG_DIR/artifacts/kubectl"
-nginx_external_ip=$(kubectl get services -l app.kubernetes.io/name=ingress-nginx,app.kubernetes.io/component=controller --no-headers | grep -v admission | awk '{print $4}') # TODO: Come up with a better kubectl command here instead of a grep -v, currently two services have the same Selector
-curl "http://${nginx_external_ip}/" 
+
+master_ip=$(kubectl get nodes -l node-role.kubernetes.io/master= --no-headers -o custom-columns=IP:.status.addresses.*.address | cut -f1 -d, | head -1)
+
+# TODO: Come up with a better kubectl command here instead of a grep -v, currently two services have the same Selector
+ingress_port=$(kubectl get services --no-headers -l app.kubernetes.io/name=ingress-nginx,app.kubernetes.io/component=controller  -o custom-columns=PORT:.spec.ports.*.nodePort | grep -v none | awk -F, '{print $1}')
+
+url="http://${master_ip}:${ingress_port}"
+curl ${url}


### PR DESCRIPTION
Originally this script worked when we were running it with a `-A` flag. When this was removed the positional argument went with it. Will make this more robust when the bug in the comment is resolved.