### PR TITLE
Ignore warning for - or . in ansible group name

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -15,6 +15,7 @@ bin_ansible_callbacks = True
 local_tmp=/tmp
 remote_tmp=/tmp
 forks = 25
+force_valid_group_names = ignore
 
 [ssh_connection]
 pipelining = True


### PR DESCRIPTION
Everybody always complains about the verbose warnings you get when running the cluster playbook.

This is the official kubespray fix put into PR 4852.