### PR TITLE
Set explicit path to python interpreter

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -16,6 +16,7 @@ local_tmp=/tmp
 remote_tmp=/tmp
 forks = 25
 force_valid_group_names = ignore
+ansible_python_interpreter = /usr/bin/python3
 
 [ssh_connection]
 pipelining = True


### PR DESCRIPTION
On the latest Ubuntu 18.04.5 images from MAAS, the `/usr/bin/python` binary seems to be missing. Since we have updated to use python3, and Ubuntu explicitly points to the python2 or python3 binaries, this change updates ansible to point to the python3 binary.