### PR TITLE
Add default for docker_install

### DIFF
--- a/playbooks/container/docker.yml
+++ b/playbooks/container/docker.yml
@@ -11,12 +11,12 @@
   tasks:
     - name: include kubespray task to set facts required for docker role
       include: ../../submodules/kubespray/roles/kubernetes/preinstall/tasks/0040-set_facts.yml
-      when: docker_install
+      when: docker_install | default('yes')
     - name: remove docker overrides, specifically to deal with conflicting options from DGX OS
       file:
         path: /etc/systemd/system/docker.service.d/docker-override.conf
         state: absent
-      when: docker_install
+      when: docker_install | default('yes')
 
 - hosts: "{{ hostlist | default('all') }}"
   become: true
@@ -30,7 +30,7 @@
     fallback_ips: []
   roles:
     - role: kubespray-defaults
-      when: docker_install
+      when: docker_install | default('yes')
     - role: "../../submodules/kubespray/roles/container-engine/docker"
-      when: docker_install
+      when: docker_install | default('yes')
   environment: "{{ proxy_env if proxy_env is defined else {} }}"

--- a/playbooks/container/nvidia-docker.yml
+++ b/playbooks/container/nvidia-docker.yml
@@ -8,18 +8,18 @@
     - name: install custom facts module
       include_role:
         name: facts
-      when: docker_install
+      when: docker_install | default('yes')
 
     - name: remove docker overrides, specifically to deal with conflicting options from DGX OS
       file:
         path: /etc/systemd/system/docker.service.d/docker-override.conf
         state: absent
-      when: docker_install
+      when: docker_install | default('yes')
 
     - name: install nvidia-docker
       include_role:
         name: nvidia.nvidia_docker
       when:
         - ansible_local['gpus']['count'] and (ansible_distribution == "Ubuntu" or ansible_os_family == "RedHat")
-        - docker_install
+        - docker_install | default('yes')
   environment: "{{ proxy_env if proxy_env is defined else {} }}"


### PR DESCRIPTION
Set a default for the new `docker_install` var in case one forgets to update existing config with new vars.

I'm open to NOT doing this since changing the default means changing it in all of these files in addition to the configuration. I think we already have several other variables that have this problem if one doesn't update configuration.