### PR TITLE
Fixes for CentOS python configuration and required packages

### DIFF
--- a/playbooks/bootstrap/bootstrap-python.yml
+++ b/playbooks/bootstrap/bootstrap-python.yml
@@ -36,7 +36,7 @@
         state: present
       when: (ansible_python.version.major == 2) and (ansible_os_family == "RedHat") and (ansible_distribution_major_version == "7")
 
-    - name: install python 2 libraries on RHEL/CentOS 7
+    - name: install python 2 libraries on EL7
       package:
         name:
         - python-setuptools

--- a/playbooks/bootstrap/bootstrap-python.yml
+++ b/playbooks/bootstrap/bootstrap-python.yml
@@ -1,4 +1,5 @@
 ---
+# Initial bootstrap of Python 3 installation on all hosts
 - hosts: all
   become: true
   gather_facts: false
@@ -14,3 +15,24 @@
       register: output
       changed_when: output.stdout != ""
       when: proxy_env is defined
+
+
+# Install necessary Python packages for future pip and setuptools requirements
+- hosts: all
+  become: true 
+  gather_facts: true
+  tasks:
+    - name: install python 3 libraries if python 3 is present
+      package:
+        name:
+        - python3-setuptools
+        - python3-pip
+        state: present
+      when: ansible_python.version.major == 3
+
+    - name: install python 2 libraries on RHEL/CentOS 7
+      package:
+        name:
+        - python-setuptools
+        - python-pip
+      when: (ansible_python.version.major == 2) and (ansible_os_family == "RedHat") and (ansible_distribution_major_version == 7)

--- a/playbooks/bootstrap/bootstrap-python.yml
+++ b/playbooks/bootstrap/bootstrap-python.yml
@@ -30,9 +30,15 @@
         state: present
       when: ansible_python.version.major == 3
 
+    - name: install epel on EL7
+      package:
+        name: epel-release
+        state: present
+      when: (ansible_python.version.major == 2) and (ansible_os_family == "RedHat") and (ansible_distribution_major_version == "7")
+
     - name: install python 2 libraries on RHEL/CentOS 7
       package:
         name:
         - python-setuptools
         - python-pip
-      when: (ansible_python.version.major == 2) and (ansible_os_family == "RedHat") and (ansible_distribution_major_version == 7)
+      when: (ansible_python.version.major == 2) and (ansible_os_family == "RedHat") and (ansible_distribution_major_version == "7")

--- a/playbooks/k8s-cluster.yml
+++ b/playbooks/k8s-cluster.yml
@@ -53,6 +53,11 @@
 - hosts: all
   gather_facts: true
   tasks:
+    - name: install epel
+      package:
+        name: epel-release
+        state: present
+      when: ansible_os_family == "RedHat"
     - name: install sshpass
       package:
         name: sshpass

--- a/roles/lmod/tasks/main.yml
+++ b/roles/lmod/tasks/main.yml
@@ -28,7 +28,17 @@
     - bash
     - tcsh
     - Lmod
-  when: ansible_os_family == "RedHat"
+  when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "7"
+
+- name: "install packages"
+  become: yes
+  dnf:
+    name:
+    - bash
+    - tcsh
+    - Lmod
+    enablerepo: powertools
+  when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "8"
 
 - name: "mkdir software path"
   become: yes

--- a/roles/nhc/tasks/main.yml
+++ b/roles/nhc/tasks/main.yml
@@ -27,12 +27,10 @@
   when: nhc_check.rc == 0 and not nhc_force_reinstall
 
 - name: install build dependencies
-  apt:
+  package:
     name: "{{ item }}"
     state: present
-    update_cache: yes
   with_items: "{{ nhc_build_deps }}"
-  when: ansible_distribution == 'Ubuntu'
 
 - name: ensure build dir exists
   file:

--- a/roles/nhc/vars/redhat.yml
+++ b/roles/nhc/vars/redhat.yml
@@ -1,0 +1,4 @@
+---
+nhc_build_deps:
+- gcc
+- make

--- a/roles/openshift/tasks/main.yml
+++ b/roles/openshift/tasks/main.yml
@@ -30,5 +30,11 @@
 - name: install openshift python client for k8s_raw module
   yum:
     name: python2-openshift
-  when: ansible_os_family == 'RedHat'
+  when: ansible_os_family == 'RedHat' and ansible_distribution_major_version == "7"
+  environment: "{{proxy_env if proxy_env is defined else {}}}"
+
+- name: install openshift python client for k8s_raw module
+  yum:
+    name: python3-openshift
+  when: ansible_os_family == 'RedHat' and ansible_distribution_major_version == "8"
   environment: "{{proxy_env if proxy_env is defined else {}}}"

--- a/roles/requirements.yml
+++ b/roles/requirements.yml
@@ -24,7 +24,7 @@
   version: "v1.2.1"
 
 - src: https://github.com/NVIDIA/ansible-role-enroot.git
-  version: "v0.3.0"
+  version: "v0.3.2"
 
 - src: geerlingguy.filebeat
   version: "2.0.1"

--- a/roles/slurm/tasks/build.yml
+++ b/roles/slurm/tasks/build.yml
@@ -73,7 +73,15 @@
     state: present
     update_cache: yes
   with_items: "{{ slurm_build_deps }}"
-  when: ansible_os_family == 'RedHat'
+  when: ansible_os_family == 'RedHat' and ansible_distribution_major_version == "7"
+
+- name: install build dependencies
+  dnf:
+    name: "{{ item }}"
+    state: present
+    enablerepo: "powertools"
+  with_items: "{{ slurm_build_deps }}"
+  when: ansible_os_family == 'RedHat' and ansible_distribution_major_version == "8"
 
 - name: remove slurm packages
   apt:

--- a/roles/slurm/tasks/controller.yml
+++ b/roles/slurm/tasks/controller.yml
@@ -21,7 +21,18 @@
     - mailx
     - ssmtp
     - policycoreutils-python
-  when: ansible_os_family == "RedHat"
+  when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "7"
+
+- name: install dependencies
+  dnf:
+    name: "{{ item }}"
+    state: present
+  with_items:
+    - mariadb-server
+    - python3-PyMySQL
+    - mailx
+    - policycoreutils-python-utils
+  when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "8"
 
 - name: Allow mysql to read libaio.so.1
   sefcontext:


### PR DESCRIPTION
## Summary

### Python fix for CentOS 7

We have been trying to use python3 everywhere, but this doesn't work on CentOS 7 because the package management libs only support Python 2.

This PR adds to the `bootstrap-python.yml` playbook to pre-emptively ensure the right libs are installed regardless of our auto-detected Python. This pre-empts unexpected Python errors in later playbooks.

The major downside of this approach is that on CentOS 7, we end up with an unnecessary Python 3 install. We can't easily detect the OS release ahead of time due to the way we're doing the bootstrap without assuming a Python is present. However, given that Python 3 doesn't take much disk space, and is the supported upstream Python anyway, I don't see this as a major issue.

### Misc fixes for CentOS 8

Misc fixes discovered during full testing of Python issues.

- Need build dependencies explicitly installed for NHC
- Need the powertools repo enabled for Slurm build dependencies and lmod install
- Need slightly different list of packages for slurmdbd
- Update to https://github.com/NVIDIA/ansible-role-enroot v0.3.2 for EL8 support
- Need to use python3-openshift instead of python2-openshift

## Test plan

Tested full cluster playbooks for k8s and slurm on each of CentOS 7 and CentOS 8:
- [x] k8s on centos 7
- [x] slurm on centos 7
- [x] k8s on centos 8 (but see the note below)
- [x] slurm on centos 8

Also validate that Ubuntu still works:

- [x] confirm that Jenkins passes for Ubuntu

### Kubernetes on CentOS 8.3

The CentOS 8.3 kernel `4.18.0-240.1.1.el8_3.x86_64` no longer works with Kubespray due to not being able to load a netfilter kernel module (`nf_conntrack_ipv4`):

```
TASK [kubernetes/node : Modprobe nf_conntrack_ipv4 for kernels < 4.19] ***********************************************************************************************************************************************************************
fatal: [virtual-mgmt01]: FAILED! => {"changed": false, "msg": "modprobe: FATAL: Module nf_conntrack_ipv4 not found in directory /lib/modules/4.18.0-240.1.1.el8_3.x86_64\n", "name": "nf_conntrack_ipv4", "params": "", "rc": 1, "state": "present", "stderr": "modprobe: FATAL: Module nf_conntrack_ipv4 not found in directory /lib/modules/4.18.0-240.1.1.el8_3.x86_64\n", "stderr_lines": ["modprobe: FATAL: Module nf_conntrack_ipv4 not found in directory /lib/modules/4.18.0-240.1.1.el8_3.x86_64"], "stdout": "", "stdout_lines": []}
```

This is fixed upstream but not yet in a Kubespray release: https://github.com/kubernetes-sigs/kubespray/pull/6988 . We should plan to update to the latest Kubespray when they release next in 2021.

I confirmed that DeepOps succeeds by explicitly running on CentOS 8.2 which does not have the problematic kernel.