### PR TITLE
Get Pod GPU metrics working and bump k8s dcgm to 2.1.2

### DIFF
--- a/workloads/services/k8s/dcgm-exporter.yml
+++ b/workloads/services/k8s/dcgm-exporter.yml
@@ -23,11 +23,24 @@ spec:
       nodeSelector:
         hardware-type: NVIDIAGPU
       containers:
-      - image: nvcr.io/nvidia/k8s/dcgm-exporter:2.0.10-2.1.0-rc.1-ubuntu18.04
+      - image: "nvcr.io/nvidia/k8s/dcgm-exporter:2.0.13-2.1.2-ubuntu20.04"
         name: nvidia-dcgm-exporter
+        env:
+        - name: "DCGM_EXPORTER_LISTEN"
+          value: ":9400"
+        - name: "DCGM_EXPORTER_KUBERNETES"
+          value: "true"
         securityContext:
           runAsNonRoot: false
           runAsUser: 0
+        volumeMounts:
+        - name: "pod-gpu-resources"
+          readOnly: true
+          mountPath: "/var/lib/kubelet/pod-resources"
+      volumes:
+      - name: "pod-gpu-resources"
+        hostPath:
+          path: "/var/lib/kubelet/pod-resources"
       tolerations:
         - effect: NoSchedule
           operator: Exists


### PR DESCRIPTION
* Bump dcgm to 2.1.2 from NGC (Ubuntu 20.04)
* Modify dcgm yaml to allow for pod metrics -> This resolves https://github.com/NVIDIA/deepops/issues/395


Test plan:

Testing this change is easy.
1. ./scripts/k8s/deploy_monitoring
2. Create a GPU job with `kubectl create -n default -f workloads/examples/k8s/pytorch-job.yml`
3. Visit Grafana and veriy metrics are coming through the GPU dashboard
4. Visit Prometheus and do a query for `DCGM_FI_DEV_GPU_UTIL`. You should see pod/namespace specific values like shown below:

![image](https://user-images.githubusercontent.com/1010167/102401108-a4a7bd00-3f97-11eb-971b-4481bb70593e.png)

Based off the example here: https://github.com/NVIDIA/gpu-monitoring-tools/blob/master/dcgm-exporter.yaml