### PR TITLE
Slurm cluster: Don't undrain nodes by default

### DIFF
--- a/roles/slurm/tasks/undrain.yml
+++ b/roles/slurm/tasks/undrain.yml
@@ -10,5 +10,7 @@
     - "{{ groups['slurm-node'] }}"
   environment:
     PATH: '{{ slurm_install_prefix }}/bin:{{ ansible_env.PATH }}'
+  run_once: true
   tags:
+    - never
     - undrain

--- a/virtual/scripts/setup_slurm.sh
+++ b/virtual/scripts/setup_slurm.sh
@@ -39,5 +39,5 @@ ansible-playbook \
 	-i "${VIRT_DIR}/config/inventory" \
 	-l slurm-cluster \
 	-e "@${VIRT_DIR}/vars_files/virt_slurm.yml" ${ansible_extra_args} \
-	--tags undrain
+	--tags undrain \
 	"${ROOT_DIR}/playbooks/slurm-cluster/slurm.yml"

--- a/virtual/scripts/setup_slurm.sh
+++ b/virtual/scripts/setup_slurm.sh
@@ -33,3 +33,11 @@ ansible-playbook \
 	-l slurm-cluster \
 	-e "@${VIRT_DIR}/vars_files/virt_slurm.yml" ${ansible_extra_args} \
 	"${ROOT_DIR}/playbooks/slurm-cluster.yml"
+
+# Un-drain nodes
+ansible-playbook \
+	-i "${VIRT_DIR}/config/inventory" \
+	-l slurm-cluster \
+	-e "@${VIRT_DIR}/vars_files/virt_slurm.yml" ${ansible_extra_args} \
+	--tags undrain
+	"${ROOT_DIR}/playbooks/slurm-cluster/slurm.yml"


### PR DESCRIPTION
## Summary

Currently, our Slurm cluster playbook undrains all the nodes in the cluster as part of the regular Ansible run. We do this to ensure that nodes which were rebooted 

During initial deployment, or for our CI automation, this makes some sense because we want the nodes in idle statement after the initial setup. 

However, when deploying a production cluster, we expect to run the full Ansible playbook several times as we debug node issues or iterate on the cluster configuration. In that context, the undrain step is a problem because it will undo drains due to health check failures or manual troubleshooting. It's also problematic when running on an existing cluster during regular operations, for the same reason. If nodes are rebooted on a production cluster during a playbook run, it makes sense to let the admins undrain them manually afterword.

In addition, our current workflow runs the undrain on every node in the cluster, which is definitely redundant!

This PR makes three main changes:

- Disable undrain by default by adding the `never` tag
- Add the `run_once: true` flag so that undrain is only run on a single node
- Add an explicit undrain run to our virtual cluster `setup_slurm.sh` script so that our CI runs don't have nodes drained due to reboot.

## Test plan

- Run a regular cluster turnup and note that the undrain task doesn't run. Any rebooted nodes remain drained.
- Jenkins CI should still pass