### PR TITLE
Attempt to address different showmount path in centos/ubuntu for jenkins

### DIFF
--- a/workloads/jenkins/scripts/test-slurm-nfs-mount.sh
+++ b/workloads/jenkins/scripts/test-slurm-nfs-mount.sh
@@ -2,13 +2,26 @@
 set -e
 
 source workloads/jenkins/scripts/jenkins-common.sh
-ssh -v \
-	-o "StrictHostKeyChecking no" \
-	-o "UserKnownHostsFile /dev/null" \
-	-l vagrant \
-	-i "${HOME}/.ssh/id_rsa" \
-	"10.0.0.5${GPU01}" \
-	"showmount -e | grep home"
+
+# showmount path is different between centos and ubuntu
+if [ "${DEEPOPS_VAGRANT_OS}" == "centos" ]; then
+	ssh -v \
+		-o "StrictHostKeyChecking no" \
+		-o "UserKnownHostsFile /dev/null" \
+		-l vagrant \
+		-i "${HOME}/.ssh/id_rsa" \
+		"10.0.0.5${GPU01}" \
+		"/usr/sbin/showmount -e | grep home"
+else
+	ssh -v \
+		-o "StrictHostKeyChecking no" \
+		-o "UserKnownHostsFile /dev/null" \
+		-l vagrant \
+		-i "${HOME}/.ssh/id_rsa" \
+		"10.0.0.5${GPU01}" \
+		"showmount -e | grep home"
+fi
+
 
 ssh -v \
 	-o "StrictHostKeyChecking no" \


### PR DESCRIPTION
Our CentOS nightly run in Jenkins is failing on `test-slurm-nfs-mount.sh` because it can't find `showmount`:

```
debug1: Sending command: showmount -e | grep home
bash: showmount: command not found
```

I suspect the issue here is that `showmount` isn't in the default PATH for this SSH command. Unfortunately, Ubuntu and CentOS put `showmount` in different locations...

This change to the test adds a conditional for the CentOS case and swaps to use the absolute path `/usr/sbin/showmount` in the CentOS case.

Unfortunately this only shows up in our nightly Jenkins test so this is difficult to test 😢 