### PR TITLE
Correct PromQL query for NVLINK BW in GPU dashboard

### DIFF
--- a/src/dashboards/gpu-dashboard.json
+++ b/src/dashboards/gpu-dashboard.json
@@ -378,7 +378,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(DCGM_FI_DEV_NVLINK_BANDWIDTH_TOTAL{instance=\"$hostname:9400\"}[$__interval]))",
+          "expr": "1e6*sum(DCGM_FI_DEV_NVLINK_BANDWIDTH_TOTAL{instance=\"$hostname:9400\"})",
           "format": "time_series",
           "hide": false,
           "interval": "",


### PR DESCRIPTION
The units for DCGM_FI_DEV_NVLINK_BANDWIDTH_TOTAL are KiB/s, but our current query assumes that they're bytes.

This commit adjusts the PromQL query to remove the rate() function and add an appropriate scaling constant so that the dashboard reports correctly.

Signed-off-by: Adam DeConinck <adeconinck@nvidia.com>