### PR TITLE
[Slurm cluster] Document use of static files for large deployments

### DIFF
--- a/docs/slurm-cluster/large-deployments.md
+++ b/docs/slurm-cluster/large-deployments.md
@@ -40,7 +40,7 @@ These include:
 | ---- | ---------------- | -------- | ---------------- |
 | `/etc/hosts` | `hosts_file_src` | List of hosts and IP addresses in the cluster | [hosts file manual](https://man7.org/linux/man-pages/man5/hosts.5.html) |
 | `/etc/slurm/slurm.conf` | `slurm_conf_template` | Slurm scheduler configuration | [Slurm configurator](https://slurm.schedmd.com/configurator.easy.html) |
-| `/etc/nhc/nhc.conf` | `nhc_conf_template` | Node Health Check configuration | [NHC documentation](https://github.com/mej/nhc/blob/master/README.md) |
+| `/etc/nhc/nhc.conf` | `nhc_config_template` | Node Health Check configuration | [NHC documentation](https://github.com/mej/nhc/blob/master/README.md) |
 | `/etc/prometheus/endpoints/node-exporter.yml` | `node_exporter_conf_template` | Prometheus endpoints for node-exporter | [Sample targets config](https://prometheus.io/docs/prometheus/latest/getting_started/#configure-prometheus-to-monitor-the-sample-targets) |
 | `/etc/prometheus/endpoints/dcgm-exporter.yml` | `nvidia_dcgm_exporter_conf_template` | Prometheus endpoints for dcgm-exporter | [Sample targets config](https://prometheus.io/docs/prometheus/latest/getting_started/#configure-prometheus-to-monitor-the-sample-targets) |
 | `/etc/prometheus/endpoints/slurm-exporter.yml` | `slurm_exporter_conf_template` | Prometheus endpoints for slurm-exporter | [Sample targets config](https://prometheus.io/docs/prometheus/latest/getting_started/#configure-prometheus-to-monitor-the-sample-targets) |

--- a/docs/slurm-cluster/large-deployments.md
+++ b/docs/slurm-cluster/large-deployments.md
@@ -1,5 +1,15 @@
 # Recommendations for deploying Slurm on large clusters
 
+The default configuration for a DeepOps Slurm cluster is well-suited for fast deployment with a minimum of hardware and little user configuration.
+This is very useful for small clusters and getting online quickly, but doesn't always fit when deploying larger clusters at scale.
+
+When building a larger cluster, there are several changes to the default Slurm workflow which are helpful to consider.
+These include:
+
+* [Cache container pulls from external registries](#cache-container-pulls-from-external-registries)
+* [Manually generate static files for cluster-wide configuration](#manually-generate-static-files-for-cluster-wide-configuration)
+* [Separate specific functions on different hardware](#separate-specific-functions-on-different-hardware)
+
 ## Cache container pulls from external registries
 
 Running container-based workloads on large compute clusters will generally require every node to pull a copy of the container image from the container registry.
@@ -9,6 +19,34 @@ If the registry is local, and the network connection is not the bottleneck, this
 
 DeepOps provides support for deploying a caching proxy to reduce pulls from upstream container registries.
 For more information, see the doc on the [NGINX-based container registry proxy](../container/nginx-docker-cache.md).
+
+
+## Manually generate static files for cluster-wide configuration
+
+Some of the configuration files used in a Slurm cluster require information about all the nodes in the cluster.
+This information may include the names of all the hosts in the cluster, their IP addresses, or other facts about the hardware.
+Two examples of this are the `/etc/hosts` file and the `slurm.conf` file.
+
+When DeepOps generates these files, it does so by contacting every host, gathering data about how they're configured, and publishing all the collected information to every host where the files are being generated.
+This works well on small clusters, but it can be slow or unreliable on larger clusters, where it's not uncommon for one or more hosts to be down or unreachable.
+When running on even 10 hosts, these files can be a frequent source of Ansible failures.
+
+In these cases, it may make sense to manually generate static configuration files, and configure DeepOps to use the static files instead of generating them on the fly.
+For most of these files, DeepOps provides Ansible variables which you can use to set the source path for a static version of the file.
+
+These include:
+
+| File | Ansible variable | Function | How to configure |
+| ---- | ---------------- | -------- | ---------------- |
+| `/etc/hosts` | `hosts_file_src` | List of hosts and IP addresses in the cluster | [hosts file manual](https://man7.org/linux/man-pages/man5/hosts.5.html) |
+| `/etc/slurm/slurm.conf` | `slurm_conf_template` | Slurm scheduler configuration | [Slurm configurator](https://slurm.schedmd.com/configurator.easy.html) |
+| `/etc/nhc/nhc.conf` | `nhc_conf_template` | Node Health Check configuration | [NHC documentation](https://github.com/mej/nhc/blob/master/README.md) |
+| `/etc/prometheus/endpoints/node-exporter.yml` | `node_exporter_conf_template` | Prometheus endpoints for node-exporter | [Sample targets config](https://prometheus.io/docs/prometheus/latest/getting_started/#configure-prometheus-to-monitor-the-sample-targets) |
+| `/etc/prometheus/endpoints/dcgm-exporter.yml` | `nvidia_dcgm_exporter_conf_template` | Prometheus endpoints for dcgm-exporter | [Sample targets config](https://prometheus.io/docs/prometheus/latest/getting_started/#configure-prometheus-to-monitor-the-sample-targets) |
+| `/etc/prometheus/endpoints/slurm-exporter.yml` | `slurm_exporter_conf_template` | Prometheus endpoints for slurm-exporter | [Sample targets config](https://prometheus.io/docs/prometheus/latest/getting_started/#configure-prometheus-to-monitor-the-sample-targets) |
+
+In many cases, a good way to get started with one of these files is to run DeepOps once, find the generated file, and then use it as a starting point for your static file.
+ 
 
 ## Separate specific functions on different hardware
 

--- a/roles/nvidia-dcgm-exporter/defaults/main.yml
+++ b/roles/nvidia-dcgm-exporter/defaults/main.yml
@@ -6,6 +6,7 @@ nvidia_dcgm_enabled: yes
 
 prometheus_config_dir: /etc/prometheus
 prometheus_cfg_endpoint_dir: "{{ prometheus_config_dir }}/endpoints"
+nvidia_dcgm_exporter_conf_template: "dcgm-exporter.yml.j2"
 
 has_gpus: false
 

--- a/roles/nvidia-dcgm-exporter/tasks/main.yml
+++ b/roles/nvidia-dcgm-exporter/tasks/main.yml
@@ -11,7 +11,7 @@
 
 - name: install config file
   template:
-    src: templates/dcgm-exporter.yml.j2
+    src: "{{ nvidia_dcgm_exporter_conf_template }}"
     dest: "{{ prometheus_cfg_endpoint_dir }}/dcgm-exporter.yml"
     owner: root
     group: root

--- a/roles/prometheus-node-exporter/defaults/main.yml
+++ b/roles/prometheus-node-exporter/defaults/main.yml
@@ -6,5 +6,6 @@ node_exporter_enabled: yes
 
 prometheus_config_dir: /etc/prometheus
 prometheus_cfg_endpoint_dir: "{{ prometheus_config_dir }}/endpoints"
+node_exporter_conf_template: "node-exporter.yml.j2"
 
 node_exporter_max_cpu: "0.5"

--- a/roles/prometheus-node-exporter/tasks/main.yml
+++ b/roles/prometheus-node-exporter/tasks/main.yml
@@ -11,7 +11,7 @@
 
 - name: install config file
   template:
-    src: templates/node-exporter.yml.j2
+    src: "{{ node_exporter_conf_template }}"
     dest: "{{ prometheus_cfg_endpoint_dir }}/node-exporter.yml"
     owner: root
     group: root

--- a/roles/prometheus-slurm-exporter/defaults/main.yml
+++ b/roles/prometheus-slurm-exporter/defaults/main.yml
@@ -7,6 +7,7 @@ slurm_install_prefix: /usr/local
 
 prometheus_config_dir: /etc/prometheus
 prometheus_cfg_endpoint_dir: "{{ prometheus_config_dir }}/endpoints"
+slurm_exporter_conf_template: "slurm-exporter.yml.j2"
 
 grafana_svc_name: "docker.grafana.service"
 grafana_data_dir: /var/lib/grafana

--- a/roles/prometheus-slurm-exporter/tasks/main.yml
+++ b/roles/prometheus-slurm-exporter/tasks/main.yml
@@ -11,7 +11,7 @@
 
 - name: install config file
   template:
-    src: templates/slurm-exporter.yml.j2
+    src: "{{ slurm_exporter_conf_template }}"
     dest: "{{ prometheus_cfg_endpoint_dir }}/slurm-exporter.yml"
     owner: root
     group: root


### PR DESCRIPTION
Some files, like `/etc/hosts` and `/etc/slurm/slurm.conf`, are frequent problems when generating configuration during a DeepOps run. This is because they depend on gathering facts for all the nodes in the cluster, and sometimes these nodes are down!

When deploying large clusters, we often find it helpful to create static versions of those files and deploy those instead.

This PR:

* Documents when and how to create static files
* Adds this capability to a few monitoring files that didn't have it yet

## Test plan

* Read the doc changes and verify it makes sense!
* CI run should pass without problems for the monitoring playbooks