### PR TITLE
Rootless docker.

### DIFF
--- a/docs/container/docker-rootless.md
+++ b/docs/container/docker-rootless.md
@@ -1,0 +1,80 @@
+# Rootless Docker
+
+Rootless docker enables unprivileged end-users to utilize docker containers.
+One motivation for this is that typically it is easier to manage unprivileged
+users within HPC clusters such as SLURM. Alternatives, such as Singularity and
+Enroot, also enable an unprivileged user to utilize containerization. The added
+convenience of rootless docker is that if one is working with docker containers
+it would be more straightforward to build and run docker containers instead of
+having to convert to another container format.
+
+Further information about rootless docker can be found here:
+<https://docs.docker.com/engine/security/rootless/>
+
+
+## Installing Rootless Docker
+
+An ansible role and playbook are provided to install rootless docker
+[docker-rootless.yml](../../playbooks/container/docker-rootless.yml).
+The default install location is set via variable `rootlessdocker_install_dir`
+with default setting of `/sw/software/rootless_docker`. Set the variable to a
+different value (use `--extra-vars "rootlessdocker_install_dir=<somepath>"`) if
+a different install location is desired. Run the playbook via ansible command:
+```bash
+ansible-playbook -K --limit slurm-cluster playbooks/container/docker-rootless.yml
+```
+
+## Using Rootless Docker in Slurm
+
+The playbook installs an environment module for loading rootless docker via
+modules. Users with bash shells will see the following modules in a typical
+DeepOps deployed Slurm cluster:
+```
+$ module avail
+
+-------------------------------------------------------------------------- /sw/hpc-sdk/modulefiles ----------------------------------
+   nvhpc/20.7    nvhpc/20.9 (D)    nvhpc-byo-compiler/20.7    nvhpc-byo-compiler/20.9 (D)    nvhpc-nompi/20.7    nvhpc-nompi/20.9 (D)
+
+------------------------------------------------------------------ /sw/software/rootless-docker/modulefiles -------------------------
+   rootless-docker
+
+  Where:
+   D:  Default Module
+```
+
+Once the rootless docker module is loaded scripts "start_rootless_docker.sh"
+and "stop_rootless_docker.sh" will become available (added via PATH). Use
+these scripts to start an stop rootless docker daemon. The commands below
+illustrate how to start and run a rootless docker container on Slurm.
+```
+$ srun --ntasks=1 --gpus-per-task=1 --cpus-per-task=5 --gres-flags=enforce-binding --pty bash
+
+$ module load rootless-docker
+
+$ start_rootless_docker.sh # specify --quiet option to hide rootles docker messages
+
+$ docker run --gpus all -it --rm nvcr.io/nvidia/cuda:11.0-base-ubuntu18.04
+
+root@445bf5cca686:/# echo NGPUS: $(nvidia-smi -L | wc -l)
+NGPUS: 1
+
+root@445bf5cca686:/# exit # exit docker interactive sessions
+exit
+
+$ stop_rootless_docker.sh # Optionally explicitly stop rootless docker. Will be killed on Slurm exit regardless.
+
+$ exit # end slurm session
+exit
+
+```
+
+It is important to be aware that rootless docker runs via user namespace
+remapping. Therefore even though one might appear as root in a docker
+container, files created are owned by the user, and within the container a user
+would not have write/execute permissions to filesystem or executables that the
+user already does not have permission to outside of the container.
+
+
+
+
+

--- a/docs/container/docker-rootless.md
+++ b/docs/container/docker-rootless.md
@@ -24,6 +24,19 @@ a different install location is desired. Run the playbook via ansible command:
 ansible-playbook -K --limit slurm-cluster playbooks/container/docker-rootless.yml
 ```
 
+For networking to properly work with rootless docker the `br_netfilter` kernel
+module should be loaded. Check via:
+```
+$ lsmod | grep br_netfilter
+```
+The `br_netfilter` kernel module is typically installed by default on various
+Linux platforms. If not loaded then load via:
+```
+$ sudo modprobe br_netfilter
+# to load by default on bootup
+$ sudo sh -c 'echo "br_netfilter" > /etc/modules-load.d/br_netfilter.conf'
+```
+
 ## Using Rootless Docker in Slurm
 
 The playbook installs an environment module for loading rootless docker via

--- a/playbooks/container/docker-rootless.yml
+++ b/playbooks/container/docker-rootless.yml
@@ -1,0 +1,5 @@
+---
+- hosts: all
+  become: yes
+  roles:
+    - name: docker-rootless

--- a/playbooks/container/docker-rootless.yml
+++ b/playbooks/container/docker-rootless.yml
@@ -1,18 +1,15 @@
 ---
+- include: ../nvidia-software/nvidia-driver.yml
+
+- include: nvidia-docker.yml
+  vars:
+    nvidia_docker_skip_docker_reload: true
+
+- include: ../slurm-cluster/lmod.yml
+
 - hosts: all
   become: yes
   tasks:
-    - name: install nvidia-docker
-      include_role:
-        name: nvidia.nvidia_docker
-      vars:
-        nvidia_docker_skip_docker_reload: true
-
-    - name: install lmod
-      include_role:
-        name: lmod
-
     - name: install rootless docker
       include_role:
         name: docker-rootless
-

--- a/playbooks/container/docker-rootless.yml
+++ b/playbooks/container/docker-rootless.yml
@@ -5,6 +5,8 @@
     - name: install nvidia-docker
       include_role:
         name: nvidia.nvidia_docker
+      vars:
+        nvidia_docker_skip_docker_reload: true
 
     - name: install lmod
       include_role:

--- a/playbooks/container/docker-rootless.yml
+++ b/playbooks/container/docker-rootless.yml
@@ -1,5 +1,16 @@
 ---
 - hosts: all
   become: yes
-  roles:
-    - name: docker-rootless
+  tasks:
+    - name: install nvidia-docker
+      include_role:
+        name: nvidia.nvidia_docker
+
+    - name: install lmod
+      include_role:
+        name: lmod
+
+    - name: install rootless docker
+      include_role:
+        name: docker-rootless
+

--- a/roles/docker-rootless/defaults/main.yml
+++ b/roles/docker-rootless/defaults/main.yml
@@ -2,4 +2,6 @@
 # Install for rootless docker.
 
 # Directory to install in
+sm_prefix: "/sw"
+sm_software_path: "{{ sm_prefix }}/software"
 rootlessdocker_install_dir: "{{ sm_software_path }}/rootless-docker"

--- a/roles/docker-rootless/defaults/main.yml
+++ b/roles/docker-rootless/defaults/main.yml
@@ -1,0 +1,5 @@
+---
+# Install for rootless docker.
+
+# Directory to install in
+rootlessdocker_install_dir: "{{ sm_software_path }}/rootless-docker"

--- a/roles/docker-rootless/tasks/main.yml
+++ b/roles/docker-rootless/tasks/main.yml
@@ -1,0 +1,73 @@
+---
+
+- name: install dependencies (ubuntu)
+  apt:
+    name:
+    - "uidmap"
+    state: present
+  when: ansible_distribution == "Ubuntu"
+
+- name: install dependencies (Red Hat)
+  yum:
+    name:
+    - "shadow-utils"
+    - "fuse-overlayfs"
+    state: present
+  when: ansible_os_family == "RedHat"
+
+- name: Ensure directory structure exists
+  file:
+    path: '{{ rootlessdocker_install_dir }}/{{ item.path }}'
+    owner: 'root'
+    group: 'root'
+    state: directory
+    mode: '0755'
+  with_filetree: '{{ role_path }}/templates/rootless-docker'
+  when: item.state == 'directory'
+
+- name: Copy over templates.
+  template:
+    src: '{{ item.src }}'
+    dest: '{{ rootlessdocker_install_dir }}/{{ item.path }}'
+    owner: 'root'
+    group: 'root'
+    mode: '{{ item.mode }}'
+    force: no
+  with_filetree: '{{ role_path }}/templates/rootless-docker'
+  when: item.state == 'file'
+
+- name: add rootless docker profile script to source modules
+  template:
+    src: '{{ item }}'
+    dest: '/etc/profile.d/{{ item }}'
+    owner: 'root'
+    group: 'root'
+    mode: '0644'
+    force: no
+  with_items:
+  - 'z96_rootlessdocker_modules.sh'
+
+- name: check if rootless docker already installed successfully
+  stat: 
+    path: '{{ rootlessdocker_install_dir }}/config/install_success'
+  register: rootless_docker_installed
+
+- name: Template setup rootless docker script
+  template:
+    src: '{{ role_path }}/templates/rootless_docker_setup.sh.j2'
+    dest: /tmp/rootless_docker_setup.sh
+    mode: 0755
+  when: not rootless_docker_installed.stat.exists
+
+- name: Execute setup rootless docker script
+  become: true
+  shell:
+    /tmp/rootless_docker_setup.sh
+  args:
+    executable: /bin/bash
+    creates: '{{ rootlessdocker_install_dir }}/config/install_success'
+
+- name: Clean up rootless docker set script
+  file:
+    path: /tmp/rootless_docker_setup.sh
+    state: absent

--- a/roles/docker-rootless/tasks/main.yml
+++ b/roles/docker-rootless/tasks/main.yml
@@ -71,3 +71,14 @@
   file:
     path: /tmp/rootless_docker_setup.sh
     state: absent
+
+- name: Add the br_netfilter module
+  modprobe:
+    name: br_netfilter
+    state: present
+
+- name: Load br_netfilter module at boot
+  lineinfile:
+    path: /etc/modules
+    create: yes
+    line: "br_netfilter"

--- a/roles/docker-rootless/templates/rootless-docker/bin/nvidia-container-runtime-hook
+++ b/roles/docker-rootless/templates/rootless-docker/bin/nvidia-container-runtime-hook
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+/usr/bin/nvidia-container-runtime-hook -config="{{ rootlessdocker_install_dir }}/config/nvidia-container-runtime/config.toml" "$@"

--- a/roles/docker-rootless/templates/rootless-docker/bin/start_rootless_docker.sh
+++ b/roles/docker-rootless/templates/rootless-docker/bin/start_rootless_docker.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+
+quiet=false
+
+usage() {
+cat <<EOF
+Usage: $(basename $0) [-h|--help] [--quiet]
+    Start rootless docker daemon.
+    Example:
+        $(basename $0)
+
+    To ommit rootless docker daemon messages redirect output to dev null or
+    specify quiet option:
+        $(basename $0) > /dev/null 2>&1
+
+    --quiet - Ommit rootless docker messages. Do not use this option when
+        troubleshooting.
+        Default: ${quiet}
+
+    -h|--help - Displays this help.
+
+EOF
+}
+
+
+while getopts ":h-" arg; do
+    case "${arg}" in
+    h ) usage; exit 2 ;;
+    - ) [ $OPTIND -ge 1 ] && optind=$(expr $OPTIND - 1 ) || optind=$OPTIND
+        eval _OPTION="\$$optind"
+        OPTARG=$(echo $_OPTION | cut -d'=' -f2)
+        OPTION=$(echo $_OPTION | cut -d'=' -f1)
+        case $OPTION in
+        --quiet ) larguments=no; quiet=true  ;;
+        --help ) usage; exit 2 ;;
+        esac
+        OPTIND=1
+        shift
+        ;;
+    esac
+done
+
+
+function start_docker_rootless() {
+    # Expects environment vars XDG_RUNTIME_DIR, DOCKER_HOST, and
+    # DOCKER_DATAROOT to be set. Also, rootless docker i.e. docker-rootless.sh
+    # needs to be on the PATH.
+
+    userid=$(id -u)
+
+    # Using dockerd
+    # export XDG_RUNTIME_DIR=/var/tmp/xdg_runtime_dir_${userid}
+    mkdir -p ${XDG_RUNTIME_DIR}
+    # export DOCKER_HOST=unix://${XDG_RUNTIME_DIR}/docker.sock
+
+    dockerd-rootless.sh --experimental \
+      --data-root=${DOCKER_DATAROOT} \
+{% if ansible_distribution == "Ubuntu" %}
+      --storage-driver overlay2 &
+{% elif ansible_os_family == "RedHat" and ansible_distribution_major_version == "8" %}
+      --storage-driver fuse-overlayfs &
+{% else %}
+      --storage-driver vfs &
+{% endif %}
+
+    # Insure that docker daemon started.
+    docker ps >/dev/null
+    while [ $? -ne 0 ]; do
+        docker ps >/dev/null
+    done
+
+}
+
+if [ "$quiet" = true ] ; then
+    start_docker_rootless >/dev/null 2>&1
+else
+    start_docker_rootless
+fi

--- a/roles/docker-rootless/templates/rootless-docker/bin/stop_rootless_docker.sh
+++ b/roles/docker-rootless/templates/rootless-docker/bin/stop_rootless_docker.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+usage() {
+cat <<EOF
+Usage: $(basename $0) [-h|--help]
+    Stop rootless docker daemon.
+    Example:
+        $(basename $0)
+
+    To ommit messages redirect output to dev null.
+        $(basename $0) > /dev/null 2>&1
+
+    -h|--help - Displays this help.
+
+EOF
+}
+
+
+while getopts ":h-" arg; do
+    case "${arg}" in
+    h ) usage; exit 2 ;;
+    - ) [ $OPTIND -ge 1 ] && optind=$(expr $OPTIND - 1 ) || optind=$OPTIND
+        eval _OPTION="\$$optind"
+        OPTARG=$(echo $_OPTION | cut -d'=' -f2)
+        OPTION=$(echo $_OPTION | cut -d'=' -f1)
+        case $OPTION in
+        --help ) usage; exit 2 ;;
+        esac
+        OPTIND=1
+        shift
+        ;;
+    esac
+done
+
+
+function stop_docker_rootless() {
+    pkill -u $USER -f dockerd
+
+    # Check that docker is not working
+    #docker ps  >/dev/null 2>&1
+    #while [ $? -eq 0 ]; do
+    #    docker ps >/dev/null 2>&1
+    #done
+}
+
+stop_docker_rootless

--- a/roles/docker-rootless/templates/rootless-docker/config/nvidia-container-runtime/config.toml
+++ b/roles/docker-rootless/templates/rootless-docker/config/nvidia-container-runtime/config.toml
@@ -1,0 +1,17 @@
+disable-require = false
+#swarm-resource = "DOCKER_RESOURCE_GPU"
+
+[nvidia-container-cli]
+#root = "/run/nvidia/driver"
+#path = "/usr/bin/nvidia-container-cli"
+environment = []
+#debug = "/var/log/nvidia-container-toolkit.log"
+#ldcache = "/etc/ld.so.cache"
+load-kmods = true
+no-cgroups = true
+#no-cgroups = false
+#user = "root:video"
+ldconfig = "@/sbin/ldconfig.real"
+
+[nvidia-container-runtime]
+#debug = "/var/log/nvidia-container-runtime.log"

--- a/roles/docker-rootless/templates/rootless-docker/modulefiles/rootless-docker.lua
+++ b/roles/docker-rootless/templates/rootless-docker/modulefiles/rootless-docker.lua
@@ -16,6 +16,12 @@ Specify "--gpus" option as needed.
 
 To stop/kill the rootless docker daemon call:
   $ stop_docker_rootless.sh
+
+Refer to help of the scripts.
+    $ start_docker_rootless.sh -h
+To run without verbose rootless docker messages run:
+    $ start_docker_rootless.sh --quiet
+
 ]])
 
 

--- a/roles/docker-rootless/templates/rootless-docker/modulefiles/rootless-docker.lua
+++ b/roles/docker-rootless/templates/rootless-docker/modulefiles/rootless-docker.lua
@@ -1,0 +1,31 @@
+help([[
+Setup environment to run rootless docker.
+
+Sets the XDG_RUNTIME_DIR to /var/tmp/xdg_runtime_dir_<userid>
+Sets the DOCKER_HOST to "unix://${XDG_RUNTIME_DIR}/docker.sock"
+Adds the following scripts to the path:
+  start_docker_rootless.sh
+  stop_docker_rootless.sh
+
+
+Start rootless docker daemon by calling:
+  $ start_docker_rootless.sh
+
+Then use regular docker commands i.e. docker run, pull, push, etc.
+Specify "--gpus" option as needed.
+
+To stop/kill the rootless docker daemon call:
+  $ stop_docker_rootless.sh
+]])
+
+
+prepend_path("PATH", "{{ rootlessdocker_install_dir }}/bin")
+
+local userid = capture("id -u")
+local userid = string.gsub(userid, '%s+', '')
+local xdg_runtime_dir = "/var/tmp/xdg_runtime_dir_" .. userid
+local docker_dataroot = "/var/tmp/docker-container-storage-" .. userid
+
+pushenv("XDG_RUNTIME_DIR", xdg_runtime_dir)
+setenv("DOCKER_HOST", "unix://"..xdg_runtime_dir.."/docker.sock")
+setenv("DOCKER_DATAROOT", docker_dataroot)

--- a/roles/docker-rootless/templates/rootless-docker/modulefiles/rootless-docker.lua
+++ b/roles/docker-rootless/templates/rootless-docker/modulefiles/rootless-docker.lua
@@ -18,9 +18,9 @@ To stop/kill the rootless docker daemon call:
   $ stop_docker_rootless.sh
 
 Refer to help of the scripts.
-    $ start_docker_rootless.sh -h
+  $ start_docker_rootless.sh -h
 To run without verbose rootless docker messages run:
-    $ start_docker_rootless.sh --quiet
+  $ start_docker_rootless.sh --quiet
 
 ]])
 

--- a/roles/docker-rootless/templates/rootless_docker_setup.sh.j2
+++ b/roles/docker-rootless/templates/rootless_docker_setup.sh.j2
@@ -49,6 +49,11 @@ fi
 curl -fsSL https://get.docker.com/rootless | \
   SKIP_IPTABLES=1 FORCE_ROOTLESS_INSTALL=1 DOCKER_BIN="{{ rootlessdocker_install_dir }}/bin" sh
 
+installsuccess=false
+if [ $? -eq 0 ] ; then
+  installsuccess=true
+fi
+
 if [ "$cleansubuid" = true ] ; then
   sed -i "/^${userid}:/d" /etc/subuid
 fi
@@ -57,7 +62,7 @@ if [ "$cleansubgid" = true ] ; then
   sed -i "/^${userid}:/d" /etc/subgid
 fi
 
-if [ $? -eq 0 ] ; then
+if [ "$installsuccess" = true ] ; then
   touch "{{ rootlessdocker_install_dir }}/config/install_success"
 else
   echo curl -fsSL https://get.docker.com/rootless \| \

--- a/roles/docker-rootless/templates/rootless_docker_setup.sh.j2
+++ b/roles/docker-rootless/templates/rootless_docker_setup.sh.j2
@@ -1,0 +1,68 @@
+#!/bin/bash
+
+{% if ansible_os_family == "RedHat" %}
+
+mun=$(sysctl -n user.max_user_namespaces 2>/dev/null || echo 0 )
+
+if [ "$mun" -lt "28633" ] ; then
+
+cat <<EOT > /etc/sysctl.d/51-rootless.conf
+user.max_user_namespaces = 28633
+EOT
+sudo sysctl --system
+
+fi
+
+# On RedHat the following might be needed:
+# grubby --update-kernel=ALL --args="namespace.unpriv_enable=1 user_namespace.enable=1"
+
+{% endif %}
+
+configfiledst="{{ rootlessdocker_install_dir }}/config/nvidia-container-runtime/config.toml"
+configfilesrc=/etc/nvidia-container-runtime/config.toml
+
+if [ -f "$configfilesrc" ]; then
+  cp $configfilesrc $configfiledst
+  # delete and set no-cgroups to true
+  sed -i '/^\[nvidia-container-cli\]$/,/^\[/{/no-cgroups/d}' $configfiledst
+  sed -i '/^\[nvidia-container-cli\]$/a no-cgroups = true' $configfiledst
+fi
+
+
+userid=$(id -u)
+largestuid=$(cat /etc/subuid | awk '{split($0,a,":"); print a[2]}' | sort -n | tail -1)
+mysubuid=$(( largestuid + 65536 ))
+cleansubuid=false
+if ! grep "^$(id -un):\|^$(id -u):" /etc/subuid >/dev/null 2>&1; then
+  echo ${userid}:${mysubuid}:65536 >> /etc/subuid
+  cleansubuid=true
+fi
+
+largestgid=$(cat /etc/subgid | awk '{split($0,a,":"); print a[2]}' | sort -n | tail -1)
+mysubgid=$(( largestgid + 65536 ))
+cleansubgid=false
+if ! grep "^$(id -un):\|^$(id -u):" /etc/subgid >/dev/null 2>&1; then
+  echo ${userid}:${mysubgid}:65536 >> /etc/subgid
+  cleansubgid=true
+fi
+
+curl -fsSL https://get.docker.com/rootless | \
+  SKIP_IPTABLES=1 FORCE_ROOTLESS_INSTALL=1 DOCKER_BIN="{{ rootlessdocker_install_dir }}/bin" sh
+
+if [ "$cleansubuid" = true ] ; then
+  sed -i "/^${userid}:/d" /etc/subuid
+fi
+
+if [ "$cleansubgid" = true ] ; then
+  sed -i "/^${userid}:/d" /etc/subgid
+fi
+
+if [ $? -eq 0 ] ; then
+  touch "{{ rootlessdocker_install_dir }}/config/install_success"
+else
+  echo curl -fsSL https://get.docker.com/rootless \| \
+    SKIP_IPTABLES=1 FORCE_ROOTLESS_INSTALL=1 DOCKER_BIN="{{ rootlessdocker_install_dir }}/bin" sh
+  exit 1
+fi
+
+chown root:root {{ rootlessdocker_install_dir }}/bin/*

--- a/roles/docker-rootless/templates/z96_rootlessdocker_modules.sh
+++ b/roles/docker-rootless/templates/z96_rootlessdocker_modules.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+export MODULEPATH="${MODULEPATH:+$MODULEPATH:}{{ rootlessdocker_install_dir }}/modulefiles"


### PR DESCRIPTION
Add ansible scripts to install rootless docker and add a module file for it. Rootless docker can be run within a Slurm cluster unprivileged and respects resource constraints i.e. CPU, GPU allocations etcetera.

TODO: Add documentation.