### PR TITLE
Bump GFD to v0.3.0

### DIFF
--- a/roles/nvidia-k8s-gpu-feature-discovery/defaults/main.yml
+++ b/roles/nvidia-k8s-gpu-feature-discovery/defaults/main.yml
@@ -2,5 +2,5 @@
 k8s_gpu_feature_discovery_helm_repo: "https://nvidia.github.io/gpu-feature-discovery"
 k8s_gpu_feature_discovery_chart_name: "nvgfd/gpu-feature-discovery"
 k8s_gpu_feature_discovery_release_name: "gpu-feature-discovery"
-k8s_gpu_feature_discovery_chart_version: "0.2.0"
+k8s_gpu_feature_discovery_chart_version: "0.3.0"
 k8s_gpu_mig_strategy: "mixed"


### PR DESCRIPTION
This GFD version bump addresses some MIG issues.

This helm chart can be upgraded by pulling in this change and re-running thie GFD playbook (https://github.com/NVIDIA/deepops/blob/master/playbooks/k8s-cluster/nvidia-k8s-gpu-feature-discovery.yml).