### PR TITLE
Bump NGC example images to 20.12 and add minimal versions

### DIFF
--- a/src/containers/ngc/README.md
+++ b/src/containers/ngc/README.md
@@ -2,22 +2,68 @@
 
 This directory contains several Dockerfiles for common Deep Learning and Machine Learning frameworks. These serve as an example for extending NGC Docker images.
 
-By default, most NGC containers start a shell prompt. These Dockerfiles are designed to start JupyterLab by default, allowing for easier integration into interactive notebook platforms such as Kubeflow.
+By default, most NGC containers start a shell prompt. This is perfect for local development, but has limitations when deploying containers through an AI orchestrator (such as Kubernetes) or AI workflow platform (such as Kubeflow). The Dockerfiles in this folder are designed to start JupyterLab by default, allowing for easier integration into interactive notebook platforms such as Kubeflow and other [DGX Ready Software Partners](https://www.nvidia.com/en-us/data-center/dgx-pod/).
 
-They also build ontop of the base NGC containers by including additional packages for demos, monitoring, generating graphs, Kubernetes integration, and rendering interactive html5 elements.
+These examples are all based on NGC containers and provide a `Dockerfile-minimal` and `Dockerfile` version. The minimal version has the minimal changes required to deploy a NGC container in Kubeflow. The non-minimal version has a curated set of libraries and packages included that are useful for demos, monitoring, generating graphs, Kubernetes integration, and rendering interactive html5 elements.
 
-Where possible, the package versions in these Dockerfiles are hard-coded to ensure repeatable builds.
+Where possible, the package versions in these Dockerfiles are hard-coded to ensure repeatable builds and consistent execution of the included examples and tutorials.
 
 Additional details about NGC can be found [here](http://ngc.nvidia.com/).
+
+Additional details about the Deep Learning Examples can be found [here](https://github.com/NVIDIA/DeepLearningExamples).
+
+## Building Docker Images
+
+To build all example images run:
+
+```sh
+./build.sh minimal # For minimal images only
+./build.sh # For all images
+```
+
+The full images can be built individually by running:
+
+```sh
+cd tensorflow
+docker build -t tensorflow:deepops-kubeflow .
+```
+
+The minimal images can be built individually by running:
+
+```sh
+cd rapids
+docker build -t rapids:deepops-kubeflow-minimal -f Dockerfile-minimal .
+```
+
+After building the docker images locally, they can be pushed to a private Docker registry.
+
+> *Note:* It is a violation of the [NGC EULA](https://ngc.nvidia.com/legal/terms) to host a Docker image based off an NGC image in a public registry. All examples included in this directory should only be hosted in private registries, such as those provided by [NGC](https://docs.nvidia.com/ngc/ngc-private-registry-user-guide/index.html).
+
+## Kubeflow Integration
+
+As of v1.2.0, Kubeflow requires containers to start Jupyter, VSCode, or anohter web application in order to deploy through Kubeflow Notebooks.
+
+A bare-minimum Dockerfile must define the `FROM`, `ENTRYPOINT`, and `CMD`, similar to below. Note that the `base_url` must be defined for Kubeflow to redirect properly.
+
+```sh
+FROM nvcr.io/nvidia/pytorch:20.12-py3
+
+ENTRYPOINT ["/bin/sh"]
+
+CMD ["-c", "jupyter lab  --notebook-dir=/workspace --ip=0.0.0.0 --no-browser --allow-root --port=8888 --NotebookApp.token='' --NotebookApp.password='' --NotebookApp.allow_origin='*' --NotebookApp.base_url=${NB_PREFIX}"]
+```
+ 
+As a quick-start, several pre-built Kubeflow containers with end-to-end AI workflow tutorial/demo containers can be found on NGC [here](https://ngc.nvidia.com/catalog/containers?query=%20label%3A%22NPN%22&quickFilter=containers).
 
 ## Misc. Notes
 
 * JupyterLab is exposed at port 8888
 * Tensorboard is exposed at port 6006
-* The `WORKDIR` contains the built-in NGC tutorials and example code. This is /workspace in most cases.
+* The RAPIDS container has a different jupyter startup command due to it's use of Conda.
+* The `WORKDIR` contains the built-in NGC tutorials and example code. This is /workspace in most cases (`/rapids` for RAPIDS containers).
 
 ## Included Frameworks
 
-* PyTorch
-* TensorFlow
-* RAPIDS
+* [PyTorch](https://ngc.nvidia.com/catalog/containers/nvidia:pytorch)
+* [TensorFlow](https://ngc.nvidia.com/catalog/containers/nvidia:tensorflow)
+* [RAPIDS](https://ngc.nvidia.com/catalog/containers/nvidia:rapidsai:rapidsai)

--- a/src/containers/ngc/build.sh
+++ b/src/containers/ngc/build.sh
@@ -1,0 +1,16 @@
+#!/bin/bash -e
+for dir in `ls -d */ | sed 's:/::g'`; do
+  cd ${dir}
+
+  echo "Building deepops-${dir}-minimal"
+  docker build -t deepops-${dir}-minimal -f Dockerfile-minimal .
+  docker tag deepops-${dir}-minimal deepops-${dir}-minimal:kubeflow
+
+  if [ "${1}" != "minimal" ]; then
+    echo "Building deepops-${dir}"
+    docker build -t deepops-${dir} -f Dockerfile .
+    docker tag deepops-${dir} deepops-${dir}:kubeflow
+  fi
+
+ cd -
+done

--- a/src/containers/ngc/pytorch/Dockerfile
+++ b/src/containers/ngc/pytorch/Dockerfile
@@ -1,5 +1,8 @@
 # https://ngc.nvidia.com/catalog/containers/nvidia:pytorch
-FROM nvcr.io/nvidia/pytorch:20.01-py3
+FROM nvcr.io/nvidia/pytorch:20.12-py3
+
+# Set to noninteractive for apt-get installs
+ARG DEBIAN_FRONTEND=noninteractive
 
 # Install some extra packages to ease development
 RUN apt-get update && \
@@ -7,21 +10,32 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/*
 
 # Install nodejs, it is a dependency for Jupyter labextensions
-RUN conda install nodejs=10.13.0 && conda clean -yac *
+# xxx RUN conda install -c conda-forge nodejs && conda clean -yac *
 
 # Install the NVIDIA Jupyter Dashboard
-RUN conda install -y -c conda-forge jupyterlab-nvdashboard==0.1.11 && conda clean -yac * && \
-    jupyter labextension install jupyterlab-nvdashboard
+# XXX: Not yet supported by Jupyterlab 3 https://github.com/rapidsai/jupyterlab-nvdashboard/pull/85:
+# RUN source "$NVM_DIR/nvm.sh" && \
+#     conda install -y -c conda-forge jupyterlab-nvdashboard==0.4.0 && conda clean -yac * && \
+#     jupyter labextension install jupyterlab-nvdashboard
 
 # Install ipyvolume for clean HTML5 visualizations
-RUN  conda install -y -c conda-forge ipyvolume==0.5.2 && conda clean -yac * && \
-     jupyter labextension install ipyvolume
+RUN source "$NVM_DIR/nvm.sh" && \
+    conda install -y -c conda-forge ipyvolume==0.5.2 && conda clean -yac * && \
+    jupyter labextension install ipyvolume
 
 # Install toc to build table of ontents in Jupyter, not available through Conda
-RUN jupyter labextension install @jupyterlab/toc
+RUN source "$NVM_DIR/nvm.sh" && \
+    jupyter labextension install @jupyterlab/toc
 
 # Install graphviz for clean graph/node/edge rendering
-RUN  conda install -c conda-forge python-graphviz=0.13.2 graphviz=2.42.3 && conda clean -yac *
+RUN source "$NVM_DIR/nvm.sh" && \
+    conda install -c conda-forge python-graphviz=0.13.2 graphviz=2.42.3 && conda clean -yac *
+
+# Get latest pip updates
+RUN  pip install --upgrade pip
+
+# Download DeepLearningExamples
+RUN cd /workspace && git clone https://github.com/NVIDIA/DeepLearningExamples.git
 
 # Expose Jupyter & Tensorboard
 EXPOSE 8888

--- a/src/containers/ngc/pytorch/Dockerfile-minimal
+++ b/src/containers/ngc/pytorch/Dockerfile-minimal
@@ -1,0 +1,6 @@
+# https://ngc.nvidia.com/catalog/containers/nvidia:pytorch
+FROM nvcr.io/nvidia/pytorch:20.12-py3
+
+# Start Jupyter up by default rather than a shell
+ENTRYPOINT ["/bin/sh"]
+CMD ["-c", "jupyter lab  --notebook-dir=/workspace --ip=0.0.0.0 --no-browser --allow-root --port=8888 --NotebookApp.token='' --NotebookApp.password='' --NotebookApp.allow_origin='*' --NotebookApp.base_url=${NB_PREFIX}"]

--- a/src/containers/ngc/rapids/Dockerfile
+++ b/src/containers/ngc/rapids/Dockerfile
@@ -41,10 +41,6 @@ RUN source activate ${CONDA_ENV} && \
 RUN source activate ${CONDA_ENV} && \
     conda install -c conda-forge dask-kubernetes==0.11.0 && conda clean -yac *
 
-# Download example rapids noebooks
-RUN cd /rapids && git clone https://github.com/rapidsai/notebooks.git && cd notebooks && \
-    git submodule update --init --remote --no-single-branch --depth 1
-
 # Expose Jupyter and Dask ports
 EXPOSE 8888
 EXPOSE 8787

--- a/src/containers/ngc/rapids/Dockerfile
+++ b/src/containers/ngc/rapids/Dockerfile
@@ -1,5 +1,5 @@
 # https://ngc.nvidia.com/catalog/containers/nvidia:rapidsai:rapidsai
-FROM nvcr.io/nvidia/rapidsai/rapidsai:cuda10.1-runtime-ubuntu18.04 
+FROM nvcr.io/nvidia/rapidsai/rapidsai:0.17-cuda11.0-runtime-ubuntu18.04
 
 # RAPIDS is installed using conda and we need to work from this environment
 ENV CONDA_ENV rapids
@@ -10,15 +10,24 @@ RUN source activate ${CONDA_ENV} && \
     apt-get install -y screen unzip git vim htop font-manager && \
     rm -rf /var/lib/apt/*
 
-# Install the NVIDIA Jupyter Dashboard
-RUN source activate ${CONDA_ENV} && \
-    conda install -y -c conda-forge jupyterlab-nvdashboard==0.1.11 && conda clean -yac * && \
-    jupyter labextension install jupyterlab-nvdashboard
+# Install Jupyterlab manager
+RUN source activate $CONDA_ENV && \
+    jupyter labextension install @jupyter-widgets/jupyterlab-manager
 
 # Install ipyvolume for clean HTML5 visualizations
 RUN source activate ${CONDA_ENV} && \
     conda install -y -c conda-forge ipyvolume==0.5.2 && conda clean -yac * && \
     jupyter labextension install ipyvolume
+
+# Add deck.gl Jupyer visualization tools
+RUN source activate $CONDA_ENV && \
+    conda install -y -c conda-forge pydeck && \
+    DECKGL_SEMVER=`python -c "import pydeck; print(pydeck.frontend_semver.DECKGL_SEMVER)"` && \
+    jupyter labextension install @deck.gl/jupyter-widget@$DECKGL_SEMVER
+
+RUN source activate $CONDA_ENV && \
+    conda install -y -c conda-forge ipympl==0.5.8 && \
+    jupyter labextension install jupyter-matplotlib@0.7.4
 
 # Install toc to build table of ontents in Jupyter, not available through Conda
 RUN source activate ${CONDA_ENV} && \
@@ -30,7 +39,11 @@ RUN source activate ${CONDA_ENV} && \
 
 # Install dask_kubernetes for deploying works through K8S and monitoring through Jupyter
 RUN source activate ${CONDA_ENV} && \
-    conda install -c conda-forge dask-kubernetes==0.10.1 && conda clean -yac *
+    conda install -c conda-forge dask-kubernetes==0.11.0 && conda clean -yac *
+
+# Download example rapids noebooks
+RUN cd /rapids && git clone https://github.com/rapidsai/notebooks.git && cd notebooks && \
+    git submodule update --init --remote --no-single-branch --depth 1
 
 # Expose Jupyter and Dask ports
 EXPOSE 8888

--- a/src/containers/ngc/rapids/Dockerfile-minimal
+++ b/src/containers/ngc/rapids/Dockerfile-minimal
@@ -1,0 +1,9 @@
+# https://ngc.nvidia.com/catalog/containers/nvidia:rapidsai:rapidsai
+FROM nvcr.io/nvidia/rapidsai/rapidsai:0.17-cuda10.1-runtime-ubuntu18.04
+
+# RAPIDS is installed using conda and we need to work from this environment
+ENV CONDA_ENV rapids
+
+# Start using the built in RAPIDS conda environment
+ENTRYPOINT ["/bin/sh"]
+CMD ["-c", "/opt/conda/envs/${CONDA_ENV}/bin/jupyter lab  --notebook-dir=/rapids --ip=0.0.0.0 --no-browser --allow-root --port=8888 --NotebookApp.token='' --NotebookApp.password='' --NotebookApp.allow_origin='*' --NotebookApp.base_url=${NB_PREFIX}"]

--- a/src/containers/ngc/tensorflow/Dockerfile
+++ b/src/containers/ngc/tensorflow/Dockerfile
@@ -1,16 +1,20 @@
 # https://ngc.nvidia.com/catalog/containers/nvidia:tensorflow
-FROM nvcr.io/nvidia/tensorflow:20.01-tf1-py3
+FROM nvcr.io/nvidia/tensorflow:20.12-tf1-py3
 
 # Install some extra packages to ease development
 RUN apt-get update && \
     apt-get install -y screen unzip git vim htop font-manager && \
     rm -rf /var/lib/apt/*
 
+# Upgrade to Jupyterlab 3
+RUN  source "$NVM_DIR/nvm.sh" && \
+     pip install jupyterlab
+
 # Installing a Jupyter labextension requires npm and Node.
 # To enable the built-in Node environment we must source the nvm.sh script.
 # Install the NVIDIA Jupyter Dashboard
 RUN  source "$NVM_DIR/nvm.sh" && \
-     pip install jupyterlab-nvdashboard==0.2.0 && \
+     pip install jupyterlab-nvdashboard==0.4.0 && \
      jupyter labextension install jupyterlab-nvdashboard
 
 # Install ipyvolume for clean HTML5 visualizations
@@ -18,16 +22,18 @@ RUN source "$NVM_DIR/nvm.sh" && \
     pip install ipyvolume==0.5.2 && \
     jupyter labextension install ipyvolume
 
-# Install toc to build table of ontents in Jupyter, not available through Conda
-RUN source "$NVM_DIR/nvm.sh" && \
-    jupyter labextension install @jupyterlab/toc
-
 # Install graphviz for clean graph/node/edge rendering
 RUN source "$NVM_DIR/nvm.sh" && \
     apt-get update && \
-    apt-get install -s graphviz=2.40.1-2 && \
-    pip install graphviz==0.13.2 && \
+    apt-get install -s graphviz=2.42.2-3build2 && \
+    pip install graphviz==0.16 && \
     rm -rf /var/lib/apt/*
+
+# Get latest pip updates
+RUN  pip install --upgrade pip
+
+# Download DeepLearningExamples
+RUN cd /workspace && git clone https://github.com/NVIDIA/DeepLearningExamples.git
 
 # Expose Jupyter & Tensorboard
 EXPOSE 8888

--- a/src/containers/ngc/tensorflow/Dockerfile-minimal
+++ b/src/containers/ngc/tensorflow/Dockerfile-minimal
@@ -1,0 +1,6 @@
+# https://ngc.nvidia.com/catalog/containers/nvidia:tensorflow
+FROM nvcr.io/nvidia/tensorflow:20.12-tf1-py3
+
+# Start Jupyter up by default rather than a shell
+ENTRYPOINT ["/bin/sh"]
+CMD ["-c", "jupyter lab  --notebook-dir=/workspace --ip=0.0.0.0 --no-browser --allow-root --port=8888 --NotebookApp.token='' --NotebookApp.password='' --NotebookApp.allow_origin='*' --NotebookApp.base_url=${NB_PREFIX}"]


### PR DESCRIPTION
* Add a build script
* Bump version to 20.12 and adjust jupyter/nvdashboard versions
* Update README
* Add minimal dockerfiles

**Test Plan**
1. Run the build script to build all the new images (~15 minutes)
```sh
cd src/containers/ngc
./build.sh
```

2. Attempt to start each container through the command line. Each should start a Jupyter prompt
3. Optionally, verify they launch through Kubeflow.