### PR TITLE
Update the run gpu test to use a container that still exists

### DIFF
--- a/workloads/jenkins/scripts/run-gpu-job.sh
+++ b/workloads/jenkins/scripts/run-gpu-job.sh
@@ -23,7 +23,7 @@ fi
 
 # Occassionally this gpu-test fails and/or hangs. To ease debugging of this we run a describe several seconds into the launch.
 sleep 10 && kubectl describe pods gpu-test &
-timeout 300 kubectl run gpu-test --rm -t -i --restart=Never --image=nvidia/cuda --limits=nvidia.com/gpu=1 -- nvidia-smi
+timeout 300 kubectl run gpu-test --rm -t -i --restart=Never --image=nvcr.io/nvidia/cuda:10.1-base-ubuntu18.04 --limits=nvidia.com/gpu=1 -- nvidia-smi
 
 # Run multi-GPU test
 if [ ${DEEPOPS_FULL_INSTALL} ]; then


### PR DESCRIPTION
The latest tag was dropped from the CUDA image on NGC and DockerHub. This change pegs it to a specific version so that the test can run.