### PR TITLE
Change nvidia/cuda:latest -> nvcr.io/nvidia/cuda:10.1-base-ubuntu18.04 across the board

### DIFF
--- a/docs/k8s-cluster/README.md
+++ b/docs/k8s-cluster/README.md
@@ -72,7 +72,7 @@ Instructions for deploying a GPU cluster with Kubernetes
    Optionally, test a GPU job to ensure that your Kubernetes setup can tap into GPUs. 
 
    ```sh
-   kubectl run gpu-test --rm -t -i --restart=Never --image=nvidia/cuda --limits=nvidia.com/gpu=1 nvidia-smi
+   kubectl run gpu-test --rm -t -i --restart=Never --image=nvcr.io/nvidia/cuda:10.1-base-ubuntu18.04 --limits=nvidia.com/gpu=1 nvidia-smi
    ```
    
    Optionally, verify all GPU nodes plug-ins in the Kubernetes cluster with following script.

--- a/playbooks/ngc-ready-server.yml
+++ b/playbooks/ngc-ready-server.yml
@@ -43,7 +43,7 @@
     - name: pull CUDA container
       docker_container:
         name: gpu-test-pull
-        image: nvcr.io/nvidia/cuda
+        image: nvcr.io/nvidia/cuda:10.1-base-ubuntu18.04
         auto_remove: yes
         pull: yes
       tags:
@@ -52,7 +52,7 @@
     - name: test CUDA container
       docker_container:
         name: gpu-test
-        image: nvcr.io/nvidia/cuda
+        image: nvcr.io/nvidia/cuda:10.1-base-ubuntu18.04
         detach: no
         command: nvidia-smi -L
       register: cuda

--- a/playbooks/nvidia-egx/egxstack-validation.yml
+++ b/playbooks/nvidia-egx/egxstack-validation.yml
@@ -142,7 +142,7 @@
       ignore_errors: yes
 
     - name: Validating the GPU Operator installation
-      shell: kubectl run gpu-test --rm -t -i --restart=Never --image=nvidia/cuda --limits=nvidia.com/gpu=1 -- nvidia-smi
+      shell: kubectl run gpu-test --rm -t -i --restart=Never --image=nvcr.io/nvidia/cuda:10.1-base-ubuntu18.04 --limits=nvidia.com/gpu=1 -- nvidia-smi
       register: cuda
       ignore_errors: yes
 

--- a/virtual/scripts/setup_k8s.sh
+++ b/virtual/scripts/setup_k8s.sh
@@ -35,7 +35,7 @@ source "${VIRT_DIR}/k8s_environment.sh"
 # Verify that the cluster is up
 file ${K8S_CONFIG_DIR}/artifacts/kubectl && chmod +x ${K8S_CONFIG_DIR}/artifacts/kubectl
 kubectl get nodes
-#kubectl run gpu-test --rm -t -i --restart=Never --image=nvidia/cuda --limits=nvidia.com/gpu=1 -- nvidia-smi
+#kubectl run gpu-test --rm -t -i --restart=Never --image=nvcr.io/nvidia/cuda:10.1-base-ubuntu18.04 --limits=nvidia.com/gpu=1 -- nvidia-smi
 
 # Install helm
 "${ROOT_DIR}/scripts/k8s/install_helm.sh"


### PR DESCRIPTION
NGC removed the cuda:latest tag. We fixed this in the test PR a few days ago and this PR makes the same change in our docs and a few other scripts/playbooks that were using latest.

I did a grep for "nvidia/cuda" in the entire DeepOps repo and addressed any location that was not specifying a tag.