### PR TITLE
Fix link to ELK logging doc

### DIFF
--- a/docs/deepops/dgx-pod.md
+++ b/docs/deepops/dgx-pod.md
@@ -379,7 +379,7 @@ The services can be reached from the following addresses:
 
 #### Logging
 
-Follow the [ELK Guide](elk.md) to setup logging in the cluster.
+Follow the [ELK Guide](../k8s-cluster/logging.md) to setup logging in the cluster.
 
 The service can be reached from the following address:
 * Kibana: http://\<kube-master\>:30700


### PR DESCRIPTION
There is no file called elk.md in the repo.  Point to the correct one.