### PR TITLE
Force an apt update before installing python3 in bootstrap

### DIFF
--- a/playbooks/bootstrap/bootstrap-python.yml
+++ b/playbooks/bootstrap/bootstrap-python.yml
@@ -22,6 +22,11 @@
   become: true 
   gather_facts: true
   tasks:
+    - name: force an apt update on Ubuntu
+      apt:
+        update_cache: yes
+      when: ansible_distribution == "Ubuntu"
+
     - name: install python 3 libraries if python 3 is present
       package:
         name:


### PR DESCRIPTION
The Ansible `package` module is generic between Ubuntu and RHEL, but doesn't necessarily do an `apt-get update` before it tries to install. In the case where python3 is already installed, we need to force an `apt-get update` before we move on to install further packages.