### PR TITLE
Enable basic syslog forwarding

### DIFF
--- a/config.example/group_vars/k8s-cluster.yml
+++ b/config.example/group_vars/k8s-cluster.yml
@@ -67,7 +67,8 @@ docker_registry_mirrors: "{{ groups['kube-master'] | map('regex_replace', '^(.*)
 ################################################################################
 # Logging with rsyslog                                                         #
 ################################################################################
-kube_enable_rsyslog: true
+kube_enable_rsyslog_server: true
+kube_enable_rsyslog_client: true
 rsyslog_server_hostname: "{{ groups['kube-master'][0] }}"
 rsyslog_client_tcp_host: "{{ rsyslog_server_hostname }}"
 rsyslog_client_group: "k8s-cluster"

--- a/config.example/group_vars/k8s-cluster.yml
+++ b/config.example/group_vars/k8s-cluster.yml
@@ -63,3 +63,11 @@ nfs_exports:
 kube_enable_container_registry: true
 docker_insecure_registries: "{{ groups['kube-master']|map('regex_replace', '^(.*)$', '\\1:5000')|list + ['registry.local:31500']}}"
 docker_registry_mirrors: "{{ groups['kube-master'] | map('regex_replace', '^(.*)$', 'http://\\1:5000') | list }}"
+
+################################################################################
+# Logging with rsyslog                                                         #
+################################################################################
+kube_enable_rsyslog: true
+rsyslog_server_hostname: "{{ groups['kube-master'][0] }}"
+rsyslog_client_tcp_host: "{{ rsyslog_server_hostname }}"
+rsyslog_client_group: "k8s-cluster"

--- a/config.example/group_vars/slurm-cluster.yml
+++ b/config.example/group_vars/slurm-cluster.yml
@@ -200,4 +200,4 @@ slurm_enable_rsyslog_server: true
 slurm_enable_rsyslog_client: true
 rsyslog_server_hostname: "{{ groups['slurm-master'][0] }}"
 rsyslog_client_tcp_host: "{{ rsyslog_server_hostname }}"
-rsyslog_client_group: "slurm-node"
+rsyslog_client_group: "slurm-cluster"

--- a/config.example/group_vars/slurm-cluster.yml
+++ b/config.example/group_vars/slurm-cluster.yml
@@ -192,3 +192,11 @@ slurm_enable_monitoring: true
 # Inventory host groups where cluster monitoring services will be installed
 # (Prometheus, Grafana, etc)
 slurm_monitoring_group: "slurm-master"
+
+################################################################################
+# Logging with rsyslog                                                         #
+################################################################################
+slurm_enable_rsyslog: true
+rsyslog_server_hostname: "{{ groups['slurm-master'][0] }}"
+rsyslog_client_tcp_host: "{{ rsyslog_server_hostname }}"
+rsyslog_client_group: "slurm-node"

--- a/config.example/group_vars/slurm-cluster.yml
+++ b/config.example/group_vars/slurm-cluster.yml
@@ -196,7 +196,8 @@ slurm_monitoring_group: "slurm-master"
 ################################################################################
 # Logging with rsyslog                                                         #
 ################################################################################
-slurm_enable_rsyslog: true
+slurm_enable_rsyslog_server: true
+slurm_enable_rsyslog_client: true
 rsyslog_server_hostname: "{{ groups['slurm-master'][0] }}"
 rsyslog_client_tcp_host: "{{ rsyslog_server_hostname }}"
 rsyslog_client_group: "slurm-node"

--- a/docs/k8s-cluster/README.md
+++ b/docs/k8s-cluster/README.md
@@ -184,7 +184,20 @@ The source for our built-in Grafana dashboards can be found in [src/dashboards](
 
 ### Logging
 
-Follow the [Logging Guide](logging.md) to setup logging in the cluster.
+#### Centralized syslog
+
+To enable syslog forwarding from the cluster nodes to the first Kubernetes controller node, you can set the following variables in your DeepOps configuration:
+
+```
+kube_enable_rsyslog_server: true
+kube_enable_rsyslog_client: true
+```
+
+For more information about our syslog forwarding functionality, please see the [centralized syslog guide](../misc/syslog.md).
+
+#### ELK logging
+
+Follow the [ELK logging Guide](logging.md) to setup logging in the cluster.
 
 The service can be reached from the following address:
 * Kibana: http://\<kube-master\>:30700

--- a/docs/misc/syslog.md
+++ b/docs/misc/syslog.md
@@ -9,7 +9,7 @@ However, for a more full-featured logging solution with search and visualization
 
 In the syslog-based implementation, the first cluster management node is selected as a syslog server and listens on `rsyslog_client_tcp_port` for connections.
 The remaining nodes in the cluster then forward their logs to the selected syslog server.
-Log files for remote nodes are stored on the syslog server in node-specific files under `/var/log/hosts`.
+Log files for remote nodes are stored on the syslog server in node-specific files under `/var/log/deepops-hosts`.
 
 On Slurm clusters, the Slurm daemon logs are additionally ingested by rsyslog and forwarded to the syslog server.
 On Kubernetes clusters, the Kubelet logs are already included in the syslog feed.

--- a/docs/misc/syslog.md
+++ b/docs/misc/syslog.md
@@ -1,0 +1,15 @@
+Centralized logging with syslog
+===============================
+
+Both the Slurm and Kubernetes cluster playbooks include a minimal implementation of centralized cluster logging using rsyslog.
+
+Rsyslog was selected for the minimal cluster logging implementation in order to provide a light-weight solution using software already installed on the nodes.
+This ensures that logs are recorded in one place, making it easier to debug node-specific issues even in the case where the nodes are down or non-responsive.
+However, for a more full-featured logging solution with search and visualization capabilities, we recommend deploying the [ELK stack](../k8s-cluster/logging.md) or other log solution.
+
+In the syslog-based implementation, the first cluster management node is selected as a syslog server and listens on `rsyslog_client_tcp_port` for connections.
+The remaining nodes in the cluster then forward their logs to the selected syslog server.
+Log files for remote nodes are stored on the syslog server in node-specific files under `/var/log/hosts`.
+
+On Slurm clusters, the Slurm daemon logs are ingested by rsyslog and forwarded to the syslog server.
+On Kubernetes clusters, the kubelet logs are currently included in syslog, but pod logs are not imported by default.

--- a/docs/misc/syslog.md
+++ b/docs/misc/syslog.md
@@ -11,5 +11,15 @@ In the syslog-based implementation, the first cluster management node is selecte
 The remaining nodes in the cluster then forward their logs to the selected syslog server.
 Log files for remote nodes are stored on the syslog server in node-specific files under `/var/log/hosts`.
 
-On Slurm clusters, the Slurm daemon logs are ingested by rsyslog and forwarded to the syslog server.
-On Kubernetes clusters, the kubelet logs are currently included in syslog, but pod logs are not imported by default.
+On Slurm clusters, the Slurm daemon logs are additionally ingested by rsyslog and forwarded to the syslog server.
+On Kubernetes clusters, the Kubelet logs are already included in the syslog feed.
+
+
+## Using an external syslog server
+
+If your site already includes a syslog server, you can forward your logs there using the following variables:
+
+* On Slurm: set `slurm_enable_rsyslog_server: false` and `slurm_enable_rsyslog_client: true`
+* On Kubernetes: set `kube_enable_rsyslog_server: false` and `slurm_enable_rsyslog_client: true`
+* Set `rsyslog_client_tcp_host` to the hostname or IP address of your syslog server
+* Set `rsyslog_client_tcp_port` to the port your syslog server listens on for TCP logs

--- a/docs/slurm-cluster/README.md
+++ b/docs/slurm-cluster/README.md
@@ -93,6 +93,19 @@ The services can be reached from the following addresses:
 * Prometheus: http://\<slurm-master\>:9090
 
 
+## Centralized syslog
+
+To enable syslog forwarding from the cluster nodes to the first Slurm controller node, you can set the following variables in your DeepOps configuration:
+
+```
+slurm_enable_rsyslog_server: true
+slurm_enable_rsyslog_client: true
+```
+
+For more information about our syslog forwarding functionality, please see the [centralized syslog guide](../misc/syslog.md).
+ 
+
+
 ## Configuring shared filesystems
 
 For information about configuring a shared NFS filesystem on your Slurm cluster, see the documentation on [Slurm and NFS](./slurm-nfs.md).

--- a/playbooks/generic/rsyslog-client.yml
+++ b/playbooks/generic/rsyslog-client.yml
@@ -1,0 +1,8 @@
+---
+- hosts: "{{ hostlist | default('all') }}"
+  become: yes
+  roles:
+  - rsyslog-client
+  tags:
+  - rsyslog-client
+  - rsyslog

--- a/playbooks/generic/rsyslog-server.yml
+++ b/playbooks/generic/rsyslog-server.yml
@@ -1,0 +1,8 @@
+---
+- hosts: "{{ hostlist | default('all') }}"
+  become: yes
+  roles:
+  - rsyslog-server
+  tags:
+  - rsyslog-server
+  - rsyslog

--- a/playbooks/k8s-cluster.yml
+++ b/playbooks/k8s-cluster.yml
@@ -239,3 +239,12 @@
 
 - include: k8s-cluster/nfs-client-provisioner.yml
   when: k8s_nfs_client_provisioner
+
+- include: generic/rsyslog-server.yml
+  vars:
+    hostlist: "{{ rsyslog_server_hostname | default('kube-master[0]') }}"
+  when: kube_enable_rsyslog|default(true)
+- include: generic/rsyslog-client.yml
+  vars:
+    hostlist: "{{ rsyslog_client_group | default('k8s-cluster') }}"
+  when: kube_enable_rsyslog|default(true)

--- a/playbooks/k8s-cluster.yml
+++ b/playbooks/k8s-cluster.yml
@@ -243,8 +243,8 @@
 - include: generic/rsyslog-server.yml
   vars:
     hostlist: "{{ rsyslog_server_hostname | default('kube-master[0]') }}"
-  when: kube_enable_rsyslog|default(true)
+  when: kube_enable_rsyslog_server|default(true)
 - include: generic/rsyslog-client.yml
   vars:
     hostlist: "{{ rsyslog_client_group | default('k8s-cluster') }}"
-  when: kube_enable_rsyslog|default(true)
+  when: kube_enable_rsyslog_client|default(true)

--- a/playbooks/slurm-cluster.yml
+++ b/playbooks/slurm-cluster.yml
@@ -96,11 +96,11 @@
 - include: generic/rsyslog-server.yml
   vars:
     hostlist: "{{ rsyslog_server_hostname | default('slurm-master[0]') }}"
-  when: slurm_enable_rsyslog|default(true)
+  when: slurm_enable_rsyslog_server|default(true)
 - include: generic/rsyslog-client.yml
   vars:
     hostlist: "{{ rsyslog_client_group | default('slurm-node') }}"
-  when: slurm_enable_rsyslog|default(true)
+  when: slurm_enable_rsyslog_client|default(true)
 
 # Install Singularity
 - include: container/singularity.yml

--- a/playbooks/slurm-cluster.yml
+++ b/playbooks/slurm-cluster.yml
@@ -92,6 +92,16 @@
 - include: slurm-cluster/nvidia-dcgm-exporter.yml
   when: slurm_enable_monitoring
 
+# Set up rsyslog forwarding from compute nodes to head node
+- include: generic/rsyslog-server.yml
+  vars:
+    hostlist: "{{ rsyslog_server_hostname | default('slurm-master[0]') }}"
+  when: slurm_enable_rsyslog|default(true)
+- include: generic/rsyslog-client.yml
+  vars:
+    hostlist: "{{ rsyslog_client_group | default('slurm-node') }}"
+  when: slurm_enable_rsyslog|default(true)
+
 # Install Singularity
 - include: container/singularity.yml
   when: slurm_cluster_install_singularity|default(true)

--- a/roles/rsyslog-client/defaults/main.yml
+++ b/roles/rsyslog-client/defaults/main.yml
@@ -1,0 +1,5 @@
+---
+# Not defined by default, must be defined to configure
+# rsyslog_client_tcp_host: "10.0.0.1"
+
+rsyslog_client_tcp_port: "514"

--- a/roles/rsyslog-client/defaults/main.yml
+++ b/roles/rsyslog-client/defaults/main.yml
@@ -1,5 +1,12 @@
 ---
-# Not defined by default, must be defined to configure
+# The destination host for TCP forwarding of rsyslog messages.
+#
+# Note that this isn't defined by default in this role, and must be defined for
+# forwarding to take place.
+#
+# The DeepOps configuration for Slurm or Kubernetes may define this at the
+# playbook level.
+#
 # rsyslog_client_tcp_host: "10.0.0.1"
 
 rsyslog_client_tcp_port: "514"

--- a/roles/rsyslog-client/handlers/main.yml
+++ b/roles/rsyslog-client/handlers/main.yml
@@ -1,0 +1,5 @@
+---
+- name: restart rsyslog
+  service:
+    name: rsyslog
+    state: restarted

--- a/roles/rsyslog-client/tasks/main.yml
+++ b/roles/rsyslog-client/tasks/main.yml
@@ -1,0 +1,16 @@
+---
+- name: ensure rsyslog is installed
+  package:
+    name: rsyslog
+    state: present
+
+- name: configure syslog forwarding
+  template:
+    src: "99-forward-syslog.conf"
+    dest: "/etc/rsyslog.d/99-forward-syslog.conf"
+    owner: "root"
+    group: "root"
+    mode: "0644"
+  notify:
+  - restart rsyslog
+  

--- a/roles/rsyslog-client/templates/99-forward-syslog.conf
+++ b/roles/rsyslog-client/templates/99-forward-syslog.conf
@@ -1,0 +1,3 @@
+{% if rsyslog_client_tcp_host is defined -%}
+action(type="omfwd" Target="{{ rsyslog_client_tcp_host }}" Port="{{ rsyslog_client_tcp_port }}" Protocol="tcp")
+{% endif -%}

--- a/roles/rsyslog-server/defaults/main.yml
+++ b/roles/rsyslog-server/defaults/main.yml
@@ -1,0 +1,4 @@
+---
+rsyslog_server_tcp_port: 514
+rsyslog_server_udp_port: 514
+rsyslog_enable_journal: yes

--- a/roles/rsyslog-server/defaults/main.yml
+++ b/roles/rsyslog-server/defaults/main.yml
@@ -2,4 +2,4 @@
 rsyslog_server_tcp_port: 514
 rsyslog_server_udp_port: 514
 rsyslog_enable_journal: yes
-rsyslog_log_file_path_pattern: "/var/log/hosts/%HOSTNAME%/%$YEAR%-%$MONTH%-%$DAY%/syslog.log"
+rsyslog_log_file_path_pattern: "/var/log/deepops-hosts/%HOSTNAME%/%$YEAR%-%$MONTH%-%$DAY%/syslog.log"

--- a/roles/rsyslog-server/defaults/main.yml
+++ b/roles/rsyslog-server/defaults/main.yml
@@ -2,3 +2,4 @@
 rsyslog_server_tcp_port: 514
 rsyslog_server_udp_port: 514
 rsyslog_enable_journal: yes
+rsyslog_log_file_path_pattern: "/var/log/hosts/%HOSTNAME%/%$YEAR%-%$MONTH%-%$DAY%/syslog.log"

--- a/roles/rsyslog-server/handlers/main.yml
+++ b/roles/rsyslog-server/handlers/main.yml
@@ -1,0 +1,5 @@
+---
+- name: reload rsyslog
+  service:
+    name: rsyslog
+    state: restarted

--- a/roles/rsyslog-server/tasks/main.yml
+++ b/roles/rsyslog-server/tasks/main.yml
@@ -1,0 +1,15 @@
+---
+- name: ensure rsyslog is installed
+  package:
+    name: rsyslog
+    state: present
+
+- name: configure syslog listener
+  template:
+    src: "01-deepops-listen.conf"
+    dest: "/etc/rsyslog.d/01-deepops-listen.conf"
+    owner: "root"
+    group: "root"
+    mode: "0644"
+  notify:
+  - reload rsyslog

--- a/roles/rsyslog-server/templates/01-deepops-listen.conf
+++ b/roles/rsyslog-server/templates/01-deepops-listen.conf
@@ -1,6 +1,6 @@
 # {{ ansible_managed }}
 # Define ruleset for per-host files
-template(name="perhost" type="string" string="/var/log/hosts/%HOSTNAME%/%$YEAR%-%$MONTH%-%$DAY%/syslog.log")
+template(name="perhost" type="string" string="{{ rsyslog_log_file_path_pattern }}")
 ruleset(name="remote") {
   action(type="omfile" dynafile="perhost")
 }

--- a/roles/rsyslog-server/templates/01-deepops-listen.conf
+++ b/roles/rsyslog-server/templates/01-deepops-listen.conf
@@ -1,4 +1,9 @@
 # {{ ansible_managed }}
+# Define ruleset for per-host files
+template(name="perhost" type="string" string="/var/log/hosts/%HOSTNAME%/%$YEAR%-%$MONTH%-%$DAY%/syslog.log")
+ruleset(name="remote") {
+  action(type="omfile" dynafile="perhost")
+}
 {% if rsyslog_enable_journal -%}
 # Import journal messages into syslog
 module(load="imjournal")
@@ -6,10 +11,10 @@ module(load="imjournal")
 {% if rsyslog_server_tcp_port is defined -%}
 # Accept syslog messages on TCP
 module(load="imtcp")
-input(type="imtcp" port="{{ rsyslog_server_tcp_port }}")
+input(type="imtcp" port="{{ rsyslog_server_tcp_port }}" ruleset="remote")
 {% endif -%}
 {% if rsyslog_server_udp_port -%}
 # Accept syslog messages on UDP
 module(load="imudp")
-input(type="imudp" port="{{ rsyslog_server_udp_port }}")
+input(type="imudp" port="{{ rsyslog_server_udp_port }}" ruleset="remote")
 {% endif -%}

--- a/roles/rsyslog-server/templates/01-deepops-listen.conf
+++ b/roles/rsyslog-server/templates/01-deepops-listen.conf
@@ -1,0 +1,15 @@
+# {{ ansible_managed }}
+{% if rsyslog_enable_journal -%}
+# Import journal messages into syslog
+module(load="imjournal")
+{% endif -%}
+{% if rsyslog_server_tcp_port is defined -%}
+# Accept syslog messages on TCP
+module(load="imtcp")
+input(type="imtcp" port="{{ rsyslog_server_tcp_port }}")
+{% endif -%}
+{% if rsyslog_server_udp_port -%}
+# Accept syslog messages on UDP
+module(load="imudp")
+input(type="imudp" port="{{ rsyslog_server_udp_port }}")
+{% endif -%}

--- a/roles/slurm/handlers/main.yml
+++ b/roles/slurm/handlers/main.yml
@@ -28,3 +28,8 @@
     state: restarted
     enabled: yes
   when: is_compute
+
+- name: restart rsyslog
+  service:
+    name: rsyslog
+    state: restarted

--- a/roles/slurm/tasks/logging.yml
+++ b/roles/slurm/tasks/logging.yml
@@ -1,0 +1,10 @@
+---
+- name: import slurm logs into rsyslog
+  template:
+    src: "etc/rsyslog.d/99-slurm.conf"
+    dest: "/etc/rsyslog.d/99-slurm.conf"
+    owner: "root"
+    group: "root"
+    mode: "0644"
+  notify:
+  - restart rsyslog

--- a/roles/slurm/tasks/main.yml
+++ b/roles/slurm/tasks/main.yml
@@ -21,6 +21,11 @@
 - include: shmfix.yml
   when: is_compute and slurm_fix_shm
 
+- include: logging.yml
+  tags:
+  - rsyslog
+  - logging
+
 - include: undrain.yml
   when: is_compute
 

--- a/roles/slurm/templates/etc/rsyslog.d/99-slurm.conf
+++ b/roles/slurm/templates/etc/rsyslog.d/99-slurm.conf
@@ -1,0 +1,4 @@
+input(type="imfile" File="/var/log/slurm/slurmd.log" Tag="slurmd")
+input(type="imfile" File="/var/log/slurm/prolog-epilog" Tag="slurm-prolog-epilog")
+input(type="imfile" File="/var/log/slurm/slurmctld.log" Tag="slurmctld")
+input(type="imfile" File="/var/log/slurm/slurmdbd.log" Tag="slurmdbd")

--- a/virtual/scripts/setup_k8s.sh
+++ b/virtual/scripts/setup_k8s.sh
@@ -28,6 +28,7 @@ fi
 # Deploy the K8s cluster
 ansible-playbook \
 	-b -i "${VIRT_DIR}/config/inventory" \
+	-e "@${VIRT_DIR}/vars_files/virt_k8s.yml" \
 	${ansible_extra_args} \
 	"${ROOT_DIR}/playbooks/k8s-cluster.yml"
 

--- a/virtual/vars_files/virt_k8s.yml
+++ b/virtual/vars_files/virt_k8s.yml
@@ -1,2 +1,3 @@
 ---
 container_registry_persistence_enabled: false
+rsyslog_client_tcp_host: "{{ groups['kube-master'][0] }}"

--- a/virtual/vars_files/virt_slurm.yml
+++ b/virtual/vars_files/virt_slurm.yml
@@ -12,12 +12,5 @@ hpcsdk_clean_up_tarball_after_extract: true
 hpcsdk_clean_up_temp_dir: true
 slurm_build_dir_cleanup: false
 
-slurm_enable_monitoring: false
-slurm_enable_container_registry: false
-slurm_cluster_install_nvidia_driver: false
-slurm_cluster_install_cuda: false
-slurm_install_hpcsdk: false
-slurm_cluster_install_singularity: false
-slurm_install_enroot: false
-slurm_install_pyxis: false
-slurm_version: "20.11.3"
+# Ensure we use the slurm management node for syslog
+rsyslog_client_tcp_host: "{{ groups['slurm-master'][0] }}"

--- a/workloads/jenkins/Jenkinsfile
+++ b/workloads/jenkins/Jenkinsfile
@@ -61,6 +61,11 @@ pipeline {
              bash -x ./workloads/jenkins/scripts/test-local-registry.sh
           '''
 
+          echo "Verify rsyslog forwarding is working for the k8s cluster"
+          sh '''
+             bash -x ./workloads/jenkins/scripts/test-rsyslog-k8s.sh
+          '''
+
           echo "Test Monitoring installation"
           sh '''
             timeout 800 bash -x ./workloads/jenkins/scripts/test-monitoring.sh
@@ -89,6 +94,11 @@ pipeline {
           echo "Test MPI"
           sh '''
             timeout 60 bash -x ./workloads/jenkins/scripts/test-mpi-job.sh
+          '''
+
+          echo "Verify rsyslog forwarding is working for the slurm cluster"
+          sh '''
+             bash -x ./workloads/jenkins/scripts/test-rsyslog-slurm.sh
           '''
         }
       }

--- a/workloads/jenkins/Jenkinsfile-multi-nightly
+++ b/workloads/jenkins/Jenkinsfile-multi-nightly
@@ -56,6 +56,11 @@ pipeline {
              bash -x ./workloads/jenkins/scripts/test-local-registry.sh
           '''
 
+          echo "Verify rsyslog forwarding is working for the k8s cluster"
+          sh '''
+             bash -x ./workloads/jenkins/scripts/test-rsyslog-k8s.sh
+          '''
+
           echo "Test Kubeflow installation"
           sh '''
              timeout 4000 bash -x ./workloads/jenkins/scripts/test-kubeflow.sh
@@ -101,6 +106,11 @@ pipeline {
           echo "Test MPI"
           sh '''
             timeout 60 bash -x ./workloads/jenkins/scripts/test-mpi-job.sh
+          '''
+
+          echo "Verify rsyslog forwarding is working for the slurm cluster"
+          sh '''
+             bash -x ./workloads/jenkins/scripts/test-rsyslog-slurm.sh
           '''
 
           echo "Reset repo and unmunge files"
@@ -152,6 +162,11 @@ pipeline {
           echo "Verify ingress config"
           sh '''
              bash -x ./workloads/jenkins/scripts/verify-ingress-config.sh
+          '''
+
+          echo "Verify rsyslog forwarding is working for the k8s cluster"
+          sh '''
+             bash -x ./workloads/jenkins/scripts/test-rsyslog-k8s.sh
           '''
 
           echo "Test Kubeflow installation"
@@ -408,6 +423,11 @@ pipeline {
           echo "Test MPI"
           sh '''
             timeout 60 bash -x ./workloads/jenkins/scripts/test-mpi-job.sh
+          '''
+
+          echo "Verify rsyslog forwarding is working for the slurm cluster"
+          sh '''
+             bash -x ./workloads/jenkins/scripts/test-rsyslog-slurm.sh
           '''
         }
       }

--- a/workloads/jenkins/Jenkinsfile-multi-nightly
+++ b/workloads/jenkins/Jenkinsfile-multi-nightly
@@ -216,6 +216,11 @@ pipeline {
             timeout 60 bash -x ./workloads/jenkins/scripts/test-mpi-job.sh
           '''
 
+          echo "Verify rsyslog forwarding is working for the slurm cluster"
+          sh '''
+             bash -x ./workloads/jenkins/scripts/test-rsyslog-slurm.sh
+          '''
+
           echo "Reset repo and unmunge files"
           sh '''
             git reset --hard
@@ -279,6 +284,11 @@ pipeline {
              bash -x ./workloads/jenkins/scripts/test-local-registry.sh
           '''
 
+          echo "Verify rsyslog forwarding is working for the k8s cluster"
+          sh '''
+             bash -x ./workloads/jenkins/scripts/test-rsyslog-k8s.sh
+          '''
+
           echo "Test Kubeflow installation"
           sh '''
              timeout 4000 bash -x ./workloads/jenkins/scripts/test-kubeflow.sh
@@ -324,6 +334,11 @@ pipeline {
           echo "Test MPI"
           sh '''
             timeout 60 bash -x ./workloads/jenkins/scripts/test-mpi-job.sh
+          '''
+
+          echo "Verify rsyslog forwarding is working for the slurm cluster"
+          sh '''
+             bash -x ./workloads/jenkins/scripts/test-rsyslog-slurm.sh
           '''
 
           echo "Reset repo and unmunge files"
@@ -376,6 +391,11 @@ pipeline {
           echo "Verify ingress config"
           sh '''
              bash -x ./workloads/jenkins/scripts/verify-ingress-config.sh
+          '''
+
+          echo "Verify rsyslog forwarding is working for the k8s cluster"
+          sh '''
+             bash -x ./workloads/jenkins/scripts/test-rsyslog-k8s.sh
           '''
 
           echo "Test Kubeflow installation"

--- a/workloads/jenkins/Jenkinsfile-nightly
+++ b/workloads/jenkins/Jenkinsfile-nightly
@@ -56,6 +56,11 @@ pipeline {
              bash -x ./workloads/jenkins/scripts/test-local-registry.sh
           '''
 
+          echo "Verify rsyslog forwarding is working for the k8s cluster"
+          sh '''
+             bash -x ./workloads/jenkins/scripts/test-rsyslog-k8s.sh
+          '''
+
           echo "Test Kubeflow installation"
           sh '''
              timeout 4000 bash -x ./workloads/jenkins/scripts/test-kubeflow.sh
@@ -127,6 +132,11 @@ pipeline {
             timeout 60 bash -x ./workloads/jenkins/scripts/test-mpi-job.sh
           '''
 
+          echo "Verify rsyslog forwarding is working for the slurm cluster"
+          sh '''
+             bash -x ./workloads/jenkins/scripts/test-rsyslog-slurm.sh
+          '''
+
           echo "Reset repo and unmunge files"
           sh '''
             git reset --hard
@@ -176,6 +186,11 @@ pipeline {
           echo "Verify ingress config"
           sh '''
              bash -x ./workloads/jenkins/scripts/verify-ingress-config.sh
+          '''
+
+          echo "Verify rsyslog forwarding is working for the k8s cluster"
+          sh '''
+             bash -x ./workloads/jenkins/scripts/test-rsyslog-k8s.sh
           '''
 
           echo "Test Kubeflow installation"
@@ -469,6 +484,11 @@ pipeline {
           echo "Test MPI"
           sh '''
             timeout 60 bash -x ./workloads/jenkins/scripts/test-mpi-job.sh
+          '''
+
+          echo "Verify rsyslog forwarding is working for the slurm cluster"
+          sh '''
+             bash -x ./workloads/jenkins/scripts/test-rsyslog-slurm.sh
           '''
         }
       }

--- a/workloads/jenkins/scripts/test-rsyslog-k8s.sh
+++ b/workloads/jenkins/scripts/test-rsyslog-k8s.sh
@@ -29,4 +29,4 @@ ssh \
 	-l vagrant \
 	-i "${HOME}/.ssh/id_rsa" \
 	"10.0.0.2${GPU01}" \
-	"sudo grep -R -E '.*virtual-gpu.*${RSYSLOG_TAG}' /var/log/hosts/ | grep -v mgmt"
+	"sudo grep -R -E '.*virtual-gpu.*${RSYSLOG_TAG}' /var/log/deepops-hosts/ | grep -v mgmt"

--- a/workloads/jenkins/scripts/test-rsyslog-k8s.sh
+++ b/workloads/jenkins/scripts/test-rsyslog-k8s.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+source workloads/jenkins/scripts/jenkins-common.sh
+
+# Assuming that we have rsyslog forwarding configured, we should be able to
+# generate a known syslog message on the GPU node and observe it in the logs
+# on the management node
+
+set -ex
+
+RSYSLOG_TAG="deepops_jenkins_k8s"
+RSYSLOG_MESSAGE="test message"
+
+# Generate syslog message on GPU node
+ssh \
+	-o "StrictHostKeyChecking no" \
+	-o "UserKnownHostsFile /dev/null" \
+	-l vagrant \
+	-i "${HOME}/.ssh/id_rsa" \
+	"10.0.0.6${GPU01}" \
+	"logger -t ${RSYSLOG_TAG} ${RSYSLOG_MESSAGE}"
+
+# Sleep for a couple seconds just in case forwarding is slow
+sleep 2
+
+# Check for syslog message on the management node
+ssh \
+	-o "StrictHostKeyChecking no" \
+	-o "UserKnownHostsFile /dev/null" \
+	-l vagrant \
+	-i "${HOME}/.ssh/id_rsa" \
+	"10.0.0.2${GPU01}" \
+	"sudo grep -R -E '.*virtual-gpu.*${RSYSLOG_TAG}' /var/log/hosts/ | grep -v mgmt"

--- a/workloads/jenkins/scripts/test-rsyslog-slurm.sh
+++ b/workloads/jenkins/scripts/test-rsyslog-slurm.sh
@@ -29,4 +29,4 @@ ssh \
 	-l vagrant \
 	-i "${HOME}/.ssh/id_rsa" \
 	"10.0.0.5${GPU01}" \
-	"sudo grep -R -E '.*virtual-gpu.*${RSYSLOG_TAG}' /var/log/hosts/ | grep -v mgmt"
+	"sudo grep -R -E '.*virtual-gpu.*${RSYSLOG_TAG}' /var/log/deepops-hosts/ | grep -v mgmt"

--- a/workloads/jenkins/scripts/test-rsyslog-slurm.sh
+++ b/workloads/jenkins/scripts/test-rsyslog-slurm.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+source workloads/jenkins/scripts/jenkins-common.sh
+
+# Assuming that we have rsyslog forwarding configured, we should be able to
+# generate a known syslog message on the GPU node and observe it in the logs
+# on the management node
+
+set -ex
+
+RSYSLOG_TAG="deepops_jenkins_slurm"
+RSYSLOG_MESSAGE="test message"
+
+# Generate syslog message on GPU node
+ssh \
+	-o "StrictHostKeyChecking no" \
+	-o "UserKnownHostsFile /dev/null" \
+	-l vagrant \
+	-i "${HOME}/.ssh/id_rsa" \
+	"10.0.0.6${GPU01}" \
+	"logger -t ${RSYSLOG_TAG} ${RSYSLOG_MESSAGE}"
+
+# Sleep for a couple seconds just in case forwarding is slow
+sleep 2
+
+# Check for syslog message on the login node
+ssh \
+	-o "StrictHostKeyChecking no" \
+	-o "UserKnownHostsFile /dev/null" \
+	-l vagrant \
+	-i "${HOME}/.ssh/id_rsa" \
+	"10.0.0.5${GPU01}" \
+	"sudo grep -R -E '.*virtual-gpu.*${RSYSLOG_TAG}' /var/log/hosts/ | grep -v mgmt"


### PR DESCRIPTION
## Summary

Implement basic rsyslog forwarding. 

Note that this is a minimal implementation of centralized logging. A future PR should add the option to forward these logs into ELK stack or other rich interface for querying logs.

- [x] Role for rsyslog server listener
- [x] Role rsyslog client forwarder
- [x] rsyslog server should store per-host logs in their own dynamically-named files
- [x] Slurm cluster: add import rules for slurmd.log and slurmctld.log
- [x] Slurm cluster: head node should be server by default, compute nodes should forward
- [x] k8s cluster: head node should be server by default
- [x] virtual k8s cluster: ensure correct forwarding in hybrid case
- [x] jenkins test for k8s cluster
- [x] jenkins test for slurm cluster

## Test plan

### Manual: Slurm cluster

Turned up a new virtual Slurm cluster with rsyslog logging enabled.

After cluster is turned up, I logged in and ran a simple job:

```
vagrant@virtual-login01:~$ srun -n1 hostname
virtual-gpu01
```

Then I checked the log directory on the cluster head node, and confirmed that a log file exists for the compute node and includes Slurm logs:

```
root@virtual-login01:~# cd /var/log/hosts/virtual-gpu01-eth1/2021-02-09/
root@virtual-login01:/var/log/hosts/virtual-gpu01-eth1/2021-02-09# grep slurm syslog.log | tail -n5
Feb  9 23:15:02 virtual-gpu01-eth1 sudo:     root : TTY=unknown ; PWD=/var/log/slurm ; USER=vagrant ; COMMAND=/bin/sh -c echo "/run/enroot/user-$(id -u)"
Feb  9 23:15:02 virtual-gpu01-eth1 sudo:     root : TTY=unknown ; PWD=/var/log/slurm ; USER=vagrant ; COMMAND=/bin/sh -c echo "/tmp/enroot-data/user-$(id -u)"
Feb  9 23:15:02 virtual-gpu01-eth1 slurm: Skipping /etc/slurm/epilog.d/60-exclusive-cpu because the job was not run in exclusive mode.
Feb  9 23:15:02 virtual-gpu01-eth1 slurm: Skipping /etc/slurm/epilog.d/80-exclusive-tmpfiles because the job was not run in exclusive mode.
Feb  9 23:15:02 virtual-gpu01-eth1 slurm-epilog: END user=vagrant job=3
root@virtual-login01:/var/log/hosts/virtual-gpu01-eth1/2021-02-09#
```

### Manual: k8s cluster

Turned up a new virtual k8s cluster with rsyslog logging enabled.

Logged into the k8s controller node and confirmed that logs exist for the nodes and kubelet logs are present:

```
root@virtual-mgmt01:/var/log/hosts/virtual-gpu01-eth0/2021-02-10# pwd
/var/log/hosts/virtual-gpu01-eth0/2021-02-10
root@virtual-mgmt01:/var/log/hosts/virtual-gpu01-eth0/2021-02-10# grep kubelet syslog.log | tail
Feb 10 03:48:17 virtual-gpu01-eth0 kubelet[29039]: E0210 03:48:17.691880   29039 dns.go:135] Nameserver limits were exceeded, some nameservers have been omitted, the applied nameserver line is: 4.2.2.1 4.2.2.2 208.67.220.220
Feb 10 03:48:19 virtual-gpu01-eth0 kubelet[29039]: I0210 03:48:19.494471   29039 setters.go:77] Using node IP: "10.0.0.6"
Feb 10 03:48:22 virtual-gpu01-eth0 kubelet[29039]: E0210 03:48:22.692071   29039 dns.go:135] Nameserver limits were exceeded, some nameservers have been omitted, the applied nameserver line is: 4.2.2.1 4.2.2.2 208.67.220.220
Feb 10 03:48:27 virtual-gpu01-eth0 kubelet[29039]: E0210 03:48:27.690977   29039 dns.go:135] Nameserver limits were exceeded, some nameservers have been omitted, the applied nameserver line is: 4.2.2.1 4.2.2.2 208.67.220.220
Feb 10 03:48:29 virtual-gpu01-eth0 kubelet[29039]: I0210 03:48:29.603353   29039 setters.go:77] Using node IP: "10.0.0.6"
Feb 10 03:48:33 virtual-gpu01-eth0 kubelet[29039]: I0210 03:48:33.653154   29039 kubelet_getters.go:173] status for pod nginx-proxy-virtual-gpu01 updated to {Running [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2021-02-10 03:06:34 +0000 UTC  } {Ready True 0001-01-01 00:00:00 +0000 UTC 2021-02-10 03:06:37 +0000 UTC  } {ContainersReady True 0001-01-01 00:00:00 +0000 UTC 2021-02-10 03:06:37 +0000 UTC  } {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2021-02-10 03:06:34 +0000 UTC  }]    10.0.0.6 10.0.0.6 [{10.0.0.6}] 2021-02-10 03:06:34 +0000 UTC [] [{nginx-proxy {nil &ContainerStateRunning{StartedAt:2021-02-10 03:06:37 +0000 UTC,} nil} {nil nil nil} true 0 nginx:1.19 docker-pullable://nginx@sha256:8e10956422503824ebb599f37c26a90fe70541942687f70bbdb744530fc9eba4 docker://b3d5bd85656b80d51cdb30153b7c64bfc054030480e413d9ac37c629d464b769 0xc0008ed490}] Burstable []}
Feb 10 03:48:33 virtual-gpu01-eth0 kubelet[29039]: W0210 03:48:33.858648   29039 container_manager_linux.go:912] CPUAccounting not enabled for pid: 29039
Feb 10 03:48:33 virtual-gpu01-eth0 kubelet[29039]: W0210 03:48:33.858677   29039 container_manager_linux.go:915] MemoryAccounting not enabled for pid: 29039
Feb 10 03:48:38 virtual-gpu01-eth0 kubelet[29039]: E0210 03:48:38.691050   29039 dns.go:135] Nameserver limits were exceeded, some nameservers have been omitted, the applied nameserver line is: 4.2.2.1 4.2.2.2 208.67.220.220
Feb 10 03:48:39 virtual-gpu01-eth0 kubelet[29039]: I0210 03:48:39.644524   29039 setters.go:77] Using node IP: "10.0.0.6"
```

### Jenkins

For each of the Slurm and Kubernetes cluster, added a Jenkins test that does the following:

* Generates a syslog message with a known tag on the compute node
* Greps for that tag in the recorded syslog on the management node