### PR TITLE
Modify firewall rules only when firewalld is installed

### DIFF
--- a/roles/nfs/tasks/firewall.yml
+++ b/roles/nfs/tasks/firewall.yml
@@ -1,4 +1,8 @@
 ---
+- name: gather package facts
+  package_facts:
+    manager: rpm
+
 - name: configure firewall to allow NFS server
   ansible.posix.firewalld:
     service: "{{ item }}"
@@ -14,4 +18,6 @@
   notify:
   - restart rpcbind
   - restart nfs
-  when: ansible_os_family == "RedHat"
+  when:
+    - ansible_os_family == "RedHat"
+    - "'firewalld' in ansible_facts.packages"

--- a/roles/nfs/tasks/firewall.yml
+++ b/roles/nfs/tasks/firewall.yml
@@ -43,4 +43,4 @@
     - ansible_os_family == "RedHat"
     - "'firewalld' in ansible_facts.packages"
     - "'firewalld.service' in ansible_facts.services"
-    - ansible_facts.services['firewalld.service']['state'] is 'started'
+    - ansible_facts.services['firewalld.service']['state'] == "started"

--- a/roles/nfs/tasks/firewall.yml
+++ b/roles/nfs/tasks/firewall.yml
@@ -42,4 +42,5 @@
   when:
     - ansible_os_family == "RedHat"
     - "'firewalld' in ansible_facts.packages"
-    - "'firewalld.service' in ansible_facts.services" and ansible_facts.services['firewalld.service']['state'] is 'started'
+    - "'firewalld.service' in ansible_facts.services"
+    - ansible_facts.services['firewalld.service']['state'] is 'started'

--- a/roles/nfs/tasks/firewall.yml
+++ b/roles/nfs/tasks/firewall.yml
@@ -2,17 +2,38 @@
 - name: gather package facts
   package_facts:
     manager: rpm
+  tags:
+    - nfs
+  when:
+    - ansible_os_family == "RedHat"
+
+- name: gather service facts
+  ansible.builtin.service_facts:
+  tags:
+    - nfs
+  when:
+    - ansible_os_family == "RedHat"
 
 - name: configure firewall to allow NFS server
   ansible.posix.firewalld:
     service: "{{ item }}"
     permanent: yes
     state: enabled
-    immediate: yes
+    immediate: no
   with_items:
     - mountd
     - rpc-bind
     - nfs
+  tags:
+    - nfs
+  when:
+    - ansible_os_family == "RedHat"
+    - "'firewalld' in ansible_facts.packages"
+
+- name: restart firewalld if it was running
+  ansible.builtin.systemd:
+    state: restarted
+    name: firewalld
   tags:
     - nfs
   notify:
@@ -21,3 +42,4 @@
   when:
     - ansible_os_family == "RedHat"
     - "'firewalld' in ansible_facts.packages"
+    - "'firewalld.service' in ansible_facts.services" and ansible_facts.services['firewalld.service']['state'] is 'started'


### PR DESCRIPTION
Fix for #833

**Test Plan:**
On CentOS/RHEL systems without the `firewalld` package, the task to configure firewall rules should be skipped.