### PR TITLE
[WIP] Bump GPU Device Plugin to v0.8.0 and GFD to 0.4.0

### DIFF
--- a/roles/nvidia-k8s-gpu-device-plugin/defaults/main.yml
+++ b/roles/nvidia-k8s-gpu-device-plugin/defaults/main.yml
@@ -2,6 +2,6 @@
 k8s_gpu_plugin_helm_repo: "https://nvidia.github.io/k8s-device-plugin"
 k8s_gpu_plugin_chart_name: "nvdp/nvidia-device-plugin"
 k8s_gpu_plugin_release_name: "nvidia-device-plugin"
-k8s_gpu_plugin_chart_version: "0.7.0"
+k8s_gpu_plugin_chart_version: "0.8.0"
 k8s_gpu_plugin_init_error: "false"
 k8s_gpu_mig_strategy: "mixed"

--- a/roles/nvidia-k8s-gpu-feature-discovery/defaults/main.yml
+++ b/roles/nvidia-k8s-gpu-feature-discovery/defaults/main.yml
@@ -2,5 +2,5 @@
 k8s_gpu_feature_discovery_helm_repo: "https://nvidia.github.io/gpu-feature-discovery"
 k8s_gpu_feature_discovery_chart_name: "nvgfd/gpu-feature-discovery"
 k8s_gpu_feature_discovery_release_name: "gpu-feature-discovery"
-k8s_gpu_feature_discovery_chart_version: "0.3.0"
+k8s_gpu_feature_discovery_chart_version: "0.4.0"
 k8s_gpu_mig_strategy: "mixed"


### PR DESCRIPTION
This version bump primarily improves MIG support in migStrategy=single.

https://github.com/NVIDIA/k8s-device-plugin/releases/tag/v0.8.0

https://github.com/NVIDIA/gpu-feature-discovery/releases/tag/v0.4.0