### PR TITLE
Clarify air-gap support level in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ GPU infrastructure and automation tools
 
 The DeepOps project encapsulates best practices in the deployment of GPU server clusters and sharing single powerful nodes (such as [NVIDIA DGX Systems](https://www.nvidia.com/en-us/data-center/dgx-systems/)). DeepOps can also be adapted or used in a modular fashion to match site-specific cluster needs. For example:
 
-* An on-prem, air-gapped data center of NVIDIA DGX servers where DeepOps provides end-to-end capabilities to set up the entire cluster management stack
+* An on-prem data center of NVIDIA DGX servers where DeepOps provides end-to-end capabilities to set up the entire cluster management stack
 * An existing cluster running Kubernetes where DeepOps scripts are used to deploy Kubeflow and connect NFS storage
 * An existing cluster that needs a resource manager / batch scheduler, where DeepOps is used to install Slurm, Kubernetes, or a hybrid of both
 * A single machine where no scheduler is desired, only NVIDIA drivers, Docker, and the NVIDIA Container Runtime

--- a/docs/airgap/offline.md
+++ b/docs/airgap/offline.md
@@ -1,9 +1,12 @@
 Building DeepOps Offline
 ========================
 
-## UNDER CONSTRUCTION
+## EXPERIMENTAL
 
-This feature is currently incomplete and in development.
+Deploying DeepOps without Internet access is currently an experimental feature and is still in development.
+This is not guaranteed to work for any given release, and may break without notice.
+
+In our current iteration,
 
 - Currently only CentOS is targeted for offline support.
 - DGXie and PXE containers are not yet supported.


### PR DESCRIPTION
Right now our support for deploying without Internet access is broken. 😢  This needs to be fixed, but also this support has always been considered experimental within the development team and isn't guaranteed to stay up to date.

This PR edits the docs to clarify the (lack of) support for offline deployment.

We're making future plans within the development team to improve this support and make it more maintainable. If we can get to a stage where it's possible to keep this up to date and working consistently, we mark it as such in the dos.