### PR TITLE
Rclone role for deepops

### DIFF
--- a/config.example/group_vars/all.yml
+++ b/config.example/group_vars/all.yml
@@ -279,3 +279,14 @@ standalone_container_registry_port: "5000"
 # these if not specified.
 #docker_insecure_registries: ["<host>:<port>"]
 #docker_registry_mirrors: ["http://<host>:<port>"]
+
+
+################################################################################
+# rclone configuration
+################################################################################
+#rclone_cluster_name: deepops_cluster
+#rclone_type: s3
+#rclone_provider: AWS
+#rclone_region: us-west-2
+#rclone_key_id: INSERT_KEY_ID
+#rclone_access_key: INSERT_ACCESS_KEY

--- a/roles/rclone/README.md
+++ b/roles/rclone/README.md
@@ -1,0 +1,3 @@
+Rclone is a command line program to manage files on cloud storage. It supports over 40 cloud storage products including S3.
+
+For more information or rclone see: https://rclone.org

--- a/roles/rclone/defaults/main.yml
+++ b/roles/rclone/defaults/main.yml
@@ -1,0 +1,27 @@
+---
+# For more information or rclone see https://rclone.org
+
+rclone_config_location: '/opt/rclone'
+rclone_cluster_name: sr-cluster 
+rclone_key_id: INSERT_ACCESS_KEY
+rclone_access_key: INSERT_ACCESS_KEYID
+rclone_type: s3
+rclone_provider: AWS
+rclone_region: us-west-2
+
+rclone_configs:
+    - name: "{{ rclone_cluster_name }}"
+      properties:
+          type: "{{ rclone_type }}"
+          provider: "{{ rclone_provider }}"
+          env_auth: false
+          access_key_id: "{{ rclone_key_id }}"
+          secret_access_key: "{{ rclone_access_key }}"
+          region: "{{ rclone_region }}"
+          location_constraint: "{{ rclone_region }}"
+          acl: private
+          #storage_class: DEEP_ARCHIVE
+          #endpoint:""
+          #location_constraint:
+          #server_side_encryption =
+          #storage_class =

--- a/roles/rclone/tasks/main.yml
+++ b/roles/rclone/tasks/main.yml
@@ -1,0 +1,30 @@
+---
+- name: Uninstall current version of rclone
+  become: yes
+  shell: rm /usr/bin/rclone /usr/local/share/man/man1/rclone.1 '{{ rclone_config_location }}/rclone.conf'
+  ignore_errors: yes
+
+- name: Install rclone
+  shell: curl https://rclone.org/install.sh | sudo bash
+
+- name: Create rclone config directory
+  file:
+    path: '{{ rclone_config_location }}'
+    state: directory
+    mode: 0777
+  become: yes
+
+- name: Set up rclone config
+  template:
+    src: rclone.conf.j2
+    dest: '{{ rclone_config_location }}/rclone.conf'
+  become: yes
+
+- name: Add RCLONE_CONFIG to /etc/environment
+  become: yes
+  lineinfile:
+    dest: "/etc/environment"
+    state: present
+    regexp: "^RCLONE_CONFIG="
+    line: "RCLONE_CONFIG={{ rclone_config_location }}/rclone.conf"
+

--- a/roles/rclone/templates/rclone.conf.j2
+++ b/roles/rclone/templates/rclone.conf.j2
@@ -1,0 +1,7 @@
+{% for config in rclone_configs %}
+[{{ config.name }}]
+{% for key, value in config.properties.items() %}
+{{ key }} = {{ value }}
+{% endfor %}
+
+{% endfor %}


### PR DESCRIPTION
This is one of multiple PRs upcoming for NVIDIA effort to add support for Scenario Runner to DeepOps.

We have built a POC to validate this internally. I have tested this role individually.

The full list of planned PRs:

    docker-ce role - https://github.com/NVIDIA/deepops/pull/860 
    rclone role - this one
    scenario-runner role and playbooks - coming soon

Signed-off-by: Martin Antolini mantolini@nvidia.com