### PR TITLE
Fix CUDA toolkit versions for DGX

### DIFF
--- a/config.example/group_vars/all.yml
+++ b/config.example/group_vars/all.yml
@@ -109,6 +109,13 @@ users:
 # NVIDIA GPU configuration
 # Playbook: nvidia-cuda
 cuda_version: cuda-toolkit-11-0
+
+# DGX-specific vars may be used to target specific models,
+# because available versions for DGX may differ from the generic repo
+#cuda_dgx_1_version: "{{ cuda_version }}"
+#cuda_dgx_2_version: "{{ cuda_version }}"
+#cuda_dgx_a100_version: "{{ cuda_version }}"
+
 # Playbook: nvidia-set-gpu-clocks
 # Resets the Gpu clocks to the default values. (see the `--reset-gpu-clocks` flag in nvidia-smi for more)
 gpu_clock_reset: no

--- a/roles/nvidia-cuda/defaults/main.yml
+++ b/roles/nvidia-cuda/defaults/main.yml
@@ -2,10 +2,11 @@
 # 'cuda' is the generic package and will pull the latest version
 cuda_version: "cuda-toolkit-11-0"
 
-# DGX-specific versions
-cuda_dgx_1_version: "cuda-toolkit-10-1"
-cuda_dgx_2_version: "cuda-toolkit-10-1"
-cuda_dgx_a100_version: "cuda-toolkit-11-0"
+# DGX-specific vars may be used to target specific models,
+# because available versions for DGX may differ from the generic repo
+cuda_dgx_1_version: "{{ cuda_version }}"
+cuda_dgx_2_version: "{{ cuda_version }}"
+cuda_dgx_a100_version: "{{ cuda_version }}"
 
 # To install a specific CUDA package on DGX, define cuda_dgx_override.
 # We override DGX version separately because DGX OS may release at a different


### PR DESCRIPTION
## Summary

Addresses #854 .

* Fixes the default DGX package versions to `cuda-toolkit-11-0` as the older package is no longer available
* Adds (commented) versions of these variables to the example config to make it clearer that this can be overridden

## Test plan

Verified the packages were available on a DGX of each type.