### PR TITLE
Fix EPEL install on RHEL systems

### DIFF
--- a/config.example/group_vars/all.yml
+++ b/config.example/group_vars/all.yml
@@ -87,6 +87,8 @@ deepops_set_hostname: true
 #    path: /export/shared
 #    options: async,vers=3
 
+# Extra Packages for Enterprise Linux (RHEL/CentOS)
+epel_package: "https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm"
 
 ################################################################################
 # USERS                                                                        #

--- a/roles/lmod/defaults/main.yml
+++ b/roles/lmod/defaults/main.yml
@@ -4,3 +4,5 @@ sm_prefix: "/sw"
 sm_module_root: "{{ sm_prefix }}/modules"
 sm_module_path: "{{ sm_module_root }}/all"
 sm_software_path: "{{ sm_prefix }}/software"
+
+epel_package: "https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm"

--- a/roles/lmod/tasks/main.yml
+++ b/roles/lmod/tasks/main.yml
@@ -6,7 +6,7 @@
   become: yes
   yum:
     name: 
-      - "epel-release"
+      - "{{ epel_package }}"
     state: latest
   environment: "{{proxy_env if proxy_env is defined else {}}}"
   when: ansible_os_family == "RedHat"

--- a/roles/nvidia-cuda/defaults/main.yml
+++ b/roles/nvidia-cuda/defaults/main.yml
@@ -17,6 +17,7 @@ cuda_dgx_a100_version: "cuda-toolkit-11-0"
 cuda_toolkit_add_profile_script: yes
 
 # RedHat family
+epel_package: "https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm"
 nvidia_driver_rhel_cuda_repo_baseurl: "https://developer.download.nvidia.com/compute/cuda/repos/{{ _rhel_repo_dir }}/"
 nvidia_driver_rhel_cuda_repo_gpgkey: "https://developer.download.nvidia.com/compute/cuda/repos/{{ _rhel_repo_dir }}/7fa2af80.pub"
 

--- a/roles/nvidia-cuda/tasks/install-redhat.yml
+++ b/roles/nvidia-cuda/tasks/install-redhat.yml
@@ -3,7 +3,7 @@
   become: yes
   yum:
     name: 
-      - "epel-release"
+      - "{{ epel_package }}"
     state: latest
   environment: "{{proxy_env if proxy_env is defined else {}}}"
 

--- a/roles/nvidia-dgx/defaults/main.yml
+++ b/roles/nvidia-dgx/defaults/main.yml
@@ -1,5 +1,6 @@
 nvidia_dgx_rhel_baseurl: "https://international.download.nvidia.com/dgx/repos/{{ dgx_repo_dir }}/"
 nvidia_dgx_rhel_gpgkey: "https://international.download.nvidia.com/dgx/repos/RPM-GPG-KEY-dgx-cosmos-support"
+epel_package: "https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm"
 
 nvidia_dgx_ubuntu_baseurl: "http://international.download.nvidia.com/dgx/repos"
 nvidia_dgx_ubuntu_gpgkey: "https://international.download.nvidia.com/dgx/repos/bionic/pool/multiverse/d/dgx-repo-keys/dgx-repo-keys_2.0_amd64.deb"

--- a/roles/nvidia-dgx/tasks/redhat.yml
+++ b/roles/nvidia-dgx/tasks/redhat.yml
@@ -5,7 +5,7 @@
 - name: Add epel repo
   yum:
     name: 
-      - "epel-release"
+      - "{{ epel_package }}"
     state: latest
 
 - name: Add DGX repo

--- a/roles/nvidia-ml/defaults/main.yml
+++ b/roles/nvidia-ml/defaults/main.yml
@@ -3,6 +3,7 @@ nvidia_cudnn_package_version: ''
 nvidia_nccl_package_version: ''
 rhel_nvidiaml_gpgkey: "https://developer.download.nvidia.com/compute/machine-learning/repos/{{ rhel_repo_dir }}/7fa2af80.pub"
 rhel_nvidiaml_baseurl: "https://developer.download.nvidia.com/compute/machine-learning/repos/{{ rhel_repo_dir }}/"
+epel_package: "https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm"
 ubuntu_nvidiaml_gpgkey: "https://developer.download.nvidia.com/compute/machine-learning/repos/{{ ubuntu_repo_dir }}/7fa2af80.pub"
 ubuntu_nvidiaml_baseurl: "http://developer.download.nvidia.com/compute/machine-learning/repos/{{ ubuntu_repo_dir }}"
 ubuntu_nvidiaml_keyid: "7fa2af80"

--- a/roles/nvidia-ml/tasks/redhat-pre-install.yml
+++ b/roles/nvidia-ml/tasks/redhat-pre-install.yml
@@ -2,7 +2,7 @@
 - name: add epel repo
   yum:
     name: 
-      - "epel-release"
+      - "{{ epel_package }}"
     state: latest
 
 - name: add repo

--- a/roles/openshift/defaults/main.yml
+++ b/roles/openshift/defaults/main.yml
@@ -1,2 +1,3 @@
 deepops_dir: /opt/deepops
 deepops_venv: '{{ deepops_dir }}/venv'
+epel_package: "https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm"

--- a/roles/openshift/tasks/main.yml
+++ b/roles/openshift/tasks/main.yml
@@ -21,9 +21,9 @@
   when: ansible_distribution == 'Ubuntu'
   environment: "{{proxy_env if proxy_env is defined else {}}}"
 
-- name: install {{ epel_package }} for CentOS
+- name: install EPEL for CentOS
   yum:
-    name: {{ epel_package }}
+    name: "{{ epel_package }}"
   when: ansible_distribution == "CentOS"
 
   # TODO: Verify that RHEL  does not require venv

--- a/roles/openshift/tasks/main.yml
+++ b/roles/openshift/tasks/main.yml
@@ -21,9 +21,9 @@
   when: ansible_distribution == 'Ubuntu'
   environment: "{{proxy_env if proxy_env is defined else {}}}"
 
-- name: install epel-release for CentOS
+- name: install {{ epel_package }} for CentOS
   yum:
-    name: epel-release
+    name: {{ epel_package }}
   when: ansible_distribution == "CentOS"
 
   # TODO: Verify that RHEL  does not require venv

--- a/roles/slurm/defaults/main.yml
+++ b/roles/slurm/defaults/main.yml
@@ -1,3 +1,5 @@
+epel_package: "https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm"
+
 slurm_build_dir: /opt/deepops/build/slurm
 hwloc_build_dir: /opt/deepops/build/hwloc
 pmix_build_dir: /opt/deepops/build/pmix

--- a/roles/slurm/tasks/setup-role.yml
+++ b/roles/slurm/tasks/setup-role.yml
@@ -14,6 +14,6 @@
 - name: add epel repo
   yum:
     name: 
-      - "epel-release"
+      - "{{ epel_package }}"
     state: latest
   when: ansible_os_family == "RedHat"

--- a/roles/standalone-container-registry/defaults/main.yml
+++ b/roles/standalone-container-registry/defaults/main.yml
@@ -1,4 +1,6 @@
 ---
+epel_package: "https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm"
+
 standalone_container_registry_image: "registry:2.7"
 standalone_container_registry_port: "5000"
 standalone_container_registry_name: "deepops-registry"

--- a/roles/standalone-container-registry/tasks/main.yml
+++ b/roles/standalone-container-registry/tasks/main.yml
@@ -24,7 +24,7 @@
 - name: Enable EPEL repo
   package:
     name:
-      - epel-release
+      - {{ epel_package }}
     state: present
   when: ansible_os_family == 'RedHat'
 - name: Install package dependencies

--- a/roles/standalone-container-registry/tasks/main.yml
+++ b/roles/standalone-container-registry/tasks/main.yml
@@ -24,7 +24,7 @@
 - name: Enable EPEL repo
   package:
     name:
-      - {{ epel_package }}
+      - "{{ epel_package }}"
     state: present
   when: ansible_os_family == 'RedHat'
 - name: Install package dependencies

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -42,7 +42,8 @@ as_user(){
 case "$ID" in
     rhel*|centos*)
         # Enable EPEL (required for Pip)
-        EPEL_URL="https://dl.fedoraproject.org/pub/epel/epel-release-latest-${VERSION_ID}.noarch.rpm"
+        EPEL_VERSION="$(echo ${VERSION_ID} | sed  's/^[^0-9]*//;s/[^0-9].*$//')"
+        EPEL_URL="https://dl.fedoraproject.org/pub/epel/epel-release-latest-${EPEL_VERSION}.noarch.rpm"
         as_sudo "yum -y install ${EPEL_URL}"
 
         # Install pip

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -42,7 +42,8 @@ as_user(){
 case "$ID" in
     rhel*|centos*)
         # Enable EPEL (required for Pip)
-        as_sudo 'yum -y install epel-release'
+        EPEL_URL="https://dl.fedoraproject.org/pub/epel/epel-release-latest-${VERSION_ID}.noarch.rpm"
+        as_sudo "yum -y install ${EPEL_URL}"
 
         # Install pip
         if ! which ${PIP} >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary

RHEL systems may not include `epel-release` in the default repos, so installing this as a bare package name may fail.

The instructions on the [EPEL site](https://fedoraproject.org/wiki/EPEL) suggest installing direct from their site, so we do that here. We also pull the install location into a variable so we can override it when needed.

## Test plan

Turned up Kubernetes cluster on CentOS using these changes, validated that EPEL was installed correctly. This validates that the install mechanism from the EPEL URL works.

Still need to test directly on RHEL, waiting on a test host.