### PR TITLE
Remove trailing whitespace in inventory file

### DIFF
--- a/config.example/inventory
+++ b/config.example/inventory
@@ -36,8 +36,8 @@
 #gpu02
 
 [k8s-cluster:children]
-kube-master 	 
-kube-node 	 
+kube-master
+kube-node
 
 ######
 # SLURM


### PR DESCRIPTION
no functional change, just cleanup for better diffing with local
branches, etc.