### PR TITLE
Update our default Slurm version to 20.11.3

### DIFF
--- a/config.example/group_vars/slurm-cluster.yml
+++ b/config.example/group_vars/slurm-cluster.yml
@@ -3,7 +3,7 @@
 ################################################################################
 # Slurm job scheduler configuration
 # Playbook: slurm, slurm-cluster, slurm-perf, slurm-perf-cluster, slurm-validation
-slurm_version: 20.02.4
+slurm_version: 20.11.3
 slurm_install_prefix: /usr/local
 pmix_install_prefix: /opt/deepops/pmix
 hwloc_install_prefix: /opt/deepops/hwloc

--- a/roles/slurm/defaults/main.yml
+++ b/roles/slurm/defaults/main.yml
@@ -3,7 +3,7 @@ hwloc_build_dir: /opt/deepops/build/hwloc
 pmix_build_dir: /opt/deepops/build/pmix
 
 slurm_workflow_build: yes
-slurm_version: 20.02.4
+slurm_version: 20.11.3
 slurm_src_url: "https://download.schedmd.com/slurm/slurm-{{ slurm_version }}.tar.bz2"
 slurm_build_make_clean: no
 slurm_build_dir_cleanup: no

--- a/roles/slurm/tasks/controller.yml
+++ b/roles/slurm/tasks/controller.yml
@@ -93,6 +93,7 @@
   template:
     src: "{{ slurm_dbd_conf_template }}"
     dest: "{{ slurm_config_dir }}/slurmdbd.conf"
+    owner: "{{ slurm_username }}"
     mode: 0600
   notify:
   - restart slurmdbd


### PR DESCRIPTION
The 20.11 branch of Slurm seems to be stable enough at this point to get broad adoption, so let's bump our default version to the latest 20.11.3.

## Test plan

- [x] Virtual cluster turnup with new Slurm version works
- [x] Basic job submission tests
- [x] Verify Jenkins tests all pass