### PR TITLE
Fix GPU Operator node prep for CentOS

### DIFF
--- a/roles/nvidia-gpu-operator-node-prep/handlers/main.yml
+++ b/roles/nvidia-gpu-operator-node-prep/handlers/main.yml
@@ -1,3 +1,15 @@
 ---
-- name: update-initramfs
+- name: update-initramfs (Debian)
   command: update-initramfs -u
+  when: ansible_os_family == "Debian"
+  listen: update-initramfs
+
+- name: Backup initramfs (RedHat)
+  shell: mv /boot/initramfs-$(uname -r).img /boot/initramfs-$(uname -r).img.bak
+  when: ansible_os_family == "RedHat"
+  listen: update-initramfs
+
+- name: update-initramfs (RedHat)
+  shell: dracut /boot/initramfs-$(uname -r).img $(uname -r)
+  when: ansible_os_family == "RedHat"
+  listen: update-initramfs

--- a/workloads/jenkins/Jenkinsfile-nightly
+++ b/workloads/jenkins/Jenkinsfile-nightly
@@ -91,6 +91,7 @@ pipeline {
 
           echo "Get K8S Cluster Status"
           sh '''
+            export DEEPOPS_K8S_OPERATOR=true
             bash -x ./workloads/jenkins/scripts/get-k8s-debug.sh
           '''
 
@@ -213,6 +214,7 @@ pipeline {
 
           echo "Get K8S Cluster Status"
           sh '''
+            export DEEPOPS_K8S_OPERATOR=true
             bash -x ./workloads/jenkins/scripts/get-k8s-debug.sh
           '''
 

--- a/workloads/jenkins/scripts/get-k8s-debug.sh
+++ b/workloads/jenkins/scripts/get-k8s-debug.sh
@@ -13,8 +13,16 @@ kubectl describe nodes
 kubectl get nodes
 
 # Get some basic info about all running pods
-kubectl get pods -A
+kubectl get pods -A -o wide
 kubectl get daemonsets -A
 
+# Get some logs from the GPU operator Pods
+if [ ${DEEPOPS_K8S_OPERATOR} ]; then
+  kubectl -n gpu-operator-resources logs -l app=gpu-feature-discovery
+  kubectl -n gpu-operator-resources logs -l app=nvidia-driver-daemonset
+  kubectl -n gpu-operator-resources logs -l app=dcgm-exporter-daemonset
+  kubectl -n gpu-operator-resources logs -l app=nvidia-container-toolkit-daemonset
+fi
+
 # Get helm status (requires helm install)
-helm list
+helm list -aA


### PR DESCRIPTION
Fix for https://github.com/NVIDIA/deepops/issues/868.

Now that we have additional testing for the GPU Operator, CentOS has begun failing. This PR changes the nvidia-gpu-operator-node-prep role to account for differences in Ubuntu (update-initramfs)/CentOS (dracut with manual backup).

**Testing:**
There is no additional test plan required for this other than the regression test already in the nightly Jenkinsfile.