### PR TITLE
Install pyxis dependency for /usr/bin/column

### DIFF
--- a/roles/pyxis/defaults/main.yml
+++ b/roles/pyxis/defaults/main.yml
@@ -6,3 +6,9 @@ slurm_pyxis_tarball_url: "https://github.com/NVIDIA/pyxis/archive/v{{ slurm_pyxi
 
 is_controller: no
 is_compute: no
+
+pyxis_ubuntu_deps:
+- "bsdmainutils"
+
+pyxis_el_deps:
+- "util-linux"

--- a/roles/pyxis/tasks/main.yml
+++ b/roles/pyxis/tasks/main.yml
@@ -1,3 +1,18 @@
+---
+- name: install dependencies (Ubuntu)
+  apt:
+    name: "{{ item }}"
+    state: present
+  with_items: "{{ pyxis_ubuntu_deps }}"
+  when: ansible_distribution == "Ubuntu"
+
+- name: install dependencies (EL)
+  package:
+    name: "{{ item }}"
+    state: present
+  with_items: "{{ pyxis_el_deps }}"
+  when: ansible_os_family == "RedHat"
+
 - name: install slurm-pmi hook
   file:
     path: /etc/enroot/hooks.d/50-slurm-pmi.sh


### PR DESCRIPTION
When using the `--container-name` flag, pyxis depends on the `column`
command being present.

However, while this command is installed on most Linux systems, some
minimal deployment images don't include it by default! When it's not
present, you may see errors like this:

```
slurmstepd: error: pyxis: couldn't get list of existing container filesystems
slurmstepd: error: pyxis: printing contents of log file ...
slurmstepd: error: pyxis:     [ERROR] Command not found: column
slurmstepd: error: pyxis: couldn't get list of containers
```

This commit adds the packages that include `column` in Ubuntu (bsdmainutils)
and EL-based distros (util-linux).

## Test plan

Deployed a minimal image that reproduced this issue. Then installed the package in question and verified the error was fixed.