### PR TITLE
Update NVIDIA HPC SDK to default of 21.2

### DIFF
--- a/config.example/group_vars/slurm-cluster.yml
+++ b/config.example/group_vars/slurm-cluster.yml
@@ -109,7 +109,12 @@ sm_install_host: "slurm-master[0]"
 # NVIDIA HPC SDK                                                               #
 ################################################################################
 slurm_install_hpcsdk: true
-hpcsdk_version: "2020_207"
+
+# Select the version of HPC SDK to download
+hpcsdk_major_version: "21"
+hpcsdk_minor_version: "2"
+hpcsdk_file_cuda: "11.2"
+hpcsdk_arch: "x86_64"
 
 # In a Slurm cluster, default to setting up HPC SDK as modules rather than in
 # the default user environment

--- a/roles/nvidia-hpc-sdk/defaults/main.yml
+++ b/roles/nvidia-hpc-sdk/defaults/main.yml
@@ -16,7 +16,7 @@
 
 # Version strings used to construct download URL
 hpcsdk_major_version: "21"
-hpcsdk_minor_version: "1"
+hpcsdk_minor_version: "2"
 hpcsdk_file_cuda: "11.2"
 hpcsdk_arch: "x86_64"
 

--- a/roles/nvidia-hpc-sdk/defaults/main.yml
+++ b/roles/nvidia-hpc-sdk/defaults/main.yml
@@ -15,15 +15,15 @@
 # See https://developer.nvidia.com/nvidia-hpc-sdk-downloads for more detail on available downloads.
 
 # Version strings used to construct download URL
-hpcsdk_major_version: "20"
-hpcsdk_minor_version: "9"
-hpcsdk_file_cuda: "11.0"
+hpcsdk_major_version: "21"
+hpcsdk_minor_version: "1"
+hpcsdk_file_cuda: "11.2"
 hpcsdk_arch: "x86_64"
 
 # We need to specify the default CUDA toolkit to use during installation.
 # This should usually be the latest CUDA included in the HPC SDK you are
 # installing.
-hpcsdk_default_cuda: "11.0"
+hpcsdk_default_cuda: "11.2"
 
 # Add HPC SDK modules to the MODULEPATH?
 hpcsdk_install_as_modules: false


### PR DESCRIPTION
Update NVIDIA HPC SDK to default version of 21.2, and set this correctly in both role defaults and example configuration.

## Test plan

- [x] Manual Slurm cluster setup and verify installation
- [x] Verify Jenkins completes successfully, including MPI test which uses HPC SDK