### PR TITLE
Add documentation-based support for NGC Ready configuration in offline environment

### DIFF
--- a/config.example/group_vars/all.yml
+++ b/config.example/group_vars/all.yml
@@ -292,7 +292,6 @@ standalone_container_registry_port: "5000"
 ################################################################################
 # Configuration for NGC-Ready playbok                                          #
 ################################################################################
-ngc_ready_epel_url: "https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm"
 ngc_ready_cuda_container: "nvcr.io/nvidia/cuda:10.1-base-ubuntu18.04"
 ngc_ready_pytorch: "nvcr.io/nvidia/pytorch:18.10-py3"
 ngc_ready_tensorflow: "nvcr.io/nvidia/tensorflow:18.10-py3"

--- a/config.example/group_vars/all.yml
+++ b/config.example/group_vars/all.yml
@@ -288,3 +288,12 @@ standalone_container_registry_port: "5000"
 # these if not specified.
 #docker_insecure_registries: ["<host>:<port>"]
 #docker_registry_mirrors: ["http://<host>:<port>"]
+
+################################################################################
+# Configuration for NGC-Ready playbok                                          #
+################################################################################
+ngc_ready_epel_url: "https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm"
+ngc_ready_cuda_container: "nvcr.io/nvidia/cuda:10.1-base-ubuntu18.04"
+ngc_ready_pytorch: "nvcr.io/nvidia/pytorch:18.10-py3"
+ngc_ready_tensorflow: "nvcr.io/nvidia/tensorflow:18.10-py3"
+

--- a/docs/airgap/mirror-apt-repos.md
+++ b/docs/airgap/mirror-apt-repos.md
@@ -1,0 +1,197 @@
+Setting up offline mirrors for APT repositories
+===============================================
+
+Summary
+-------
+
+Most of the software necessary to run GPU-enabled applications on Ubuntu servers is available via APT repositories.
+In order to deploy this software in an offline environment, the most straightforward path is to mirror the repositories in your offline network.
+
+
+Identifying package repositories to mirror
+------------------------------------------
+
+In order to mirror package repositories to use offline, you must first identify which repositories contain the software you need.
+For APT repositories, this means identifying the appropriate lines in the `/etc/apt/sources.list` or `/etc/apt/sources.list.d/` configuration.
+
+If you have a test system in an environment with Internet access, you can check which APT sources are in use with the following process:
+
+```
+$ cd /etc/apt
+$ grep http sources.list
+$ grep -R http sources.list.d/
+```
+
+The rest of this section lists the configuration for common repositories used by DeepOps.
+
+### Ubuntu repositories
+
+DeepOps assumes that a full mirror of your Ubuntu distribution repositories will be available for package installs.
+If you do not already have these distribution repositories available, the `sources.list` configuration should be:
+
+```
+deb http://security.ubuntu.com/ubuntu <release-name>-security main
+deb http://security.ubuntu.com/ubuntu <release-name>-security universe
+deb http://security.ubuntu.com/ubuntu <release-name>-security multiverse
+deb http://archive.ubuntu.com/ubuntu/ <release-name> main multiverse universe
+deb http://archive.ubuntu.com/ubuntu/ <release-name>-updates main multiverse universe
+```
+
+where `<release-name>` is the name of the Ubuntu release you want to mirror.
+This is `bionic` for Ubuntu 18.04, and `focal` for Ubuntu 20.04.
+
+
+### Docker repository
+
+APT configuration: 
+
+```
+deb https://download.docker.com/linux/ubuntu <release-name> stable
+```
+
+GPG key for validation:
+
+```
+https://download.docker.com/linux/ubuntu/gpg
+```
+
+where `<release-name>` is the name of the Ubuntu release you want to mirror.
+This is `bionic` for Ubuntu 18.04, and `focal` for Ubuntu 20.04.
+
+
+### NVIDIA CUDA repository
+
+APT configuration:
+
+```
+# For Ubuntu 18.04
+deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804 /
+# For Ubuntu 20.04
+deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004 /
+``` 
+
+GPG key for validation:
+
+```
+# For Ubuntu 18.04
+https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/7fa2af80.pub
+# For Ubuntu 20.04
+https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/7fa2af80.pub
+```
+
+### nvidia-docker
+
+APT configuration:
+
+```
+# For Ubuntu 18.04
+deb https://nvidia.github.io/libnvidia-container/stable/ubuntu18.04/$(ARCH) /
+deb https://nvidia.github.io/nvidia-container-runtime/stable/ubuntu18.04/$(ARCH) /
+deb https://nvidia.github.io/nvidia-docker/ubuntu18.04/$(ARCH) /
+# For Ubuntu 20.04
+deb https://nvidia.github.io/libnvidia-container/stable/ubuntu18.04/$(ARCH) /
+deb https://nvidia.github.io/nvidia-container-runtime/stable/ubuntu18.04/$(ARCH) /
+deb https://nvidia.github.io/nvidia-docker/ubuntu18.04/$(ARCH) /
+```
+
+GPG key for validation:
+
+```
+https://nvidia.github.io/nvidia-docker/gpgkey
+```
+
+### Additional DEB packages
+
+The following DEB files are not installed from an APT repository, but installed ad-hoc from direct URLs or file paths.
+
+- *NVIDIA DCGM*: Requires registration, download from [DCGM site](https://developer.nvidia.com/dcgm)
+- *NVIDIA Enroot*: Download from [Enroot releases](https://github.com/NVIDIA/enroot/releases/)
+- *TurboVNC*: Download from [TurboVNC](https://downloads.sourceforge.net/project/turbovnc/2.2.4/turbovnc_2.2.4_amd64.deb)
+
+
+Downloading package repositories on a machine with Internet access
+------------------------------------------------------------------
+
+On an Ubuntu machine with Internet access, install the `apt-mirror` package:
+
+```
+sudo apt update
+sudo apt install apt-mirror
+```
+
+After installing `apt-mirror`, edit the `/etc/apt/mirror.list` file make the following changes:
+
+* Set the `base_path` to the desired download path for your mirror (here, `/var/repos`)
+* Add a list of APT configuration lines for each repo you wish to mirror
+
+For example, if we just want to mirror the Docker and NVIDIA Docker repositories, this configuration would work:
+
+```
+############# config ##################
+#
+set base_path    /var/repos
+set nthreads     20
+set _tilde 0
+#
+############# end config ##############
+
+deb https://download.docker.com/linux/ubuntu bionic stable
+deb https://nvidia.github.io/nvidia-docker/ubuntu20.04/amd64 /
+```
+
+Then create the target directory and run `apt-mirror`:
+
+```
+$ sudo mkdir /var/repos
+$ sudo apt-mirror
+```
+
+
+Transferring repositories to offline network
+--------------------------------------------
+
+After downloading the repository contents, you will need to transfer the downloaded files to your offline network.
+
+There are many ways to do this, depending on your local setup!
+You should use the mechanism that gives you the best performance and ease-of-use in your environment.
+
+One common way to accomplish this transfer is to bundle the downloaded files into an ISO file, which can then be moved to the offline environment or "burned" to a DVD or external USB drive.
+
+```
+$ sudo yum install genisoimage
+$ sudo genisoimage -o /tmp/packages.iso /var/repos
+```
+
+
+Create mirrors on offline network
+---------------------------------
+
+One the repository contents have been transferred to the offline network, they need to be made available as repositories for package installs.
+Your offline enviroment may already have a package server, and there are many free and commercial solutions to do this!
+
+If you don't already have a package server, the following process shows a minimal approach using an Apache httpd server.
+
+First, in the offline network, pick a machine to use as your package server.
+We will assume the use of the Apache httpd server and that the web root is `/var/www/html`:
+
+```
+$ sudo apt update
+$ sudo apt install apache2
+$ sudo mkdir /var/www/html/repos
+```
+
+Then, from the extracted mirror directory,
+copy the directories for each repository into the web root.
+For example, assuming the extracted mirror directory is `/var/repos` and the repository is `nvidia-docker`:
+
+```
+$ sudo cp -r /var/repos/mirror/nvidia.github.com/nvidia-docker/ /var/www/html/repos/nvidia-docker/
+```
+
+At this point, the downloaded package repositories should be available on your offline network via the package server.
+You can then add these downloaded repos to the `/etc/apt/sources.list` configuration on the servers that need to install the packages, e.g.:
+
+```
+# Line added to /etc/apt/sources.list
+deb http://repo-server/repos/nvidia-docker/ubuntu20.04/amd64 /
+```

--- a/docs/airgap/mirror-docker-images.md
+++ b/docs/airgap/mirror-docker-images.md
@@ -1,0 +1,124 @@
+Setting up an offline mirror for Docker container images
+========================================================
+
+Identifying images to mirror
+----------------------------
+
+To identify which container images you need, we recommend configuring a server for your workload in an environment with Internet access.
+Then determine the list of images by:
+
+- If using Docker: run `docker images` on each host
+- If using Singularity: check your history of `singularity` commands to identify which containers you used
+- If using Pyxis/Enroot with Slurm: check your `slurmd` logs for a list of images downloaded by Pyxis
+
+
+Downloading images with NGC Container Replicator
+------------------------------------------------
+
+If you are only using containers from the [NGC Catalog](https://ngc.nvidia.com), we recommend using the [NGC Replicator](https://github.com/NVIDIA/ngc-container-replicator) to download the images you need.
+The NGC Replicator has helpful options that allow you to mirror a large number of images from NGC,
+filtering by image name(s) or version(s) where needed.
+
+For more information, see the [NGC Replicator documentation](https://github.com/NVIDIA/ngc-container-replicator/blob/master/README.md).
+
+
+Downloading container images with Docker 
+----------------------------------------
+
+If you need containers from registries other than NGC, or if you use containers from a mix of registries, you can download the images using Docker.
+
+On a machine with Internet access, install Docker manually or with DeepOps:
+
+```
+$ ansible-playbook playbooks/container/docker.yml
+```
+
+Then, for each image you want to download, you should pull the image from the remote registry and save it to a local file.
+In this example, we're saving all our Docker images to `/tmp/images`:
+
+```
+$ docker pull nvidia/cuda:11.1-devel-ubuntu20.04
+$ docker save nvidia/cuda:11.1-devel-ubuntu20.04 > /tmp/images/nvidia-cuda-11.1-devel-ubuntu20.04.tar
+```
+
+Additionally, you should download and save the [`registry` image](https://hub.docker.com/_/registry) so that you can deploy a local registry on the offline network.
+
+
+Transferring images to offline network
+--------------------------------------
+
+After downloading the container images, you will need to transfer the downloaded files to your offline network.
+
+There are many ways to do this, depending on your local setup!
+You should use the mechanism that gives you the best performance and ease-of-use in your environment.
+
+One common way to accomplish this transfer is to bundle the downloaded files into an ISO file, which can then be moved to the offline environment or "burned" to a DVD or external USB drive.
+
+```
+$ sudo apt install genisoimage
+$ sudo genisoimage -o /tmp/images.iso /tmp/images
+```
+
+
+Set up a container registry on the offline network
+--------------------------------------------------
+
+One the container images have been transferred to the offline network, they need to be pushed to a container registry for use on your offline cluster.
+Your offline environment may already have a container registry, and there are many free and commercial solutions for running a registry.
+
+If you don't already have a container registry, we recommend using the official [Docker Registry](https://hub.docker.com/_/registry) image to deploy a new registry.
+
+First, in the offline network, pick a host to use as your container registry.
+We will assume this host already has Docker installed and can run containers which expose ports to the offline network.
+Additionally, we assume that the `registry` image was included when you transferred container images from the Internet-connected machine.
+
+Load the registry image into the Docker image cache of your container registry host:
+
+```
+$ docker load < /tmp/images/registry-2.7.tar
+```
+
+Then create a Docker volume to store your container images:
+
+```
+$ docker volume create registry-images
+```
+
+And run the registry container:
+
+```
+$ docker run -d \
+    -p 5000:5000 \
+    --restart=always \
+    --name registry \
+    -v registry-images:/var/lib/registry \
+    registry:2.7
+```
+
+
+Configuring your hosts to use the offline container registry
+------------------------------------------------------------
+
+By default, Docker requires that connections to a container registry be secured with a TLS certificate.
+If you are able to set up a trusted TLS certificate in your offline environment, you can configure the registry to use the certificate by following the [registry documentation for certificates](https://docs.docker.com/registry/deploying/#get-a-certificate).
+
+If you do not have a TLS certificate (or you want to test first without one), you can configure Docker to treat your registry as an insecure registry.
+You can do this according to the [Docker insecure registry documentation](https://docs.docker.com/registry/insecure/);
+or, if you installed Docker with DeepOps, you can configure your list of insecure registries in the DeepOps configuration:
+
+```
+docker_insecure_registries:
+- "registry-host:5000"
+```
+
+
+Loading images into the container registry
+------------------------------------------
+
+Once your registry is running and you've configured your hosts to access it, you can load additional images and push them to the offline registry:
+
+```
+$ docker load < /tmp/images/nvidia-cuda-11.1-devel-ubuntu20.04.tar
+$ docker tag nvidia/cuda:11.1-devel-ubuntu20.04 registry-host:5000/nvidia/cuda:11.1-devel-ubuntu20.04
+$ docker push registry-host:5000/nvidia/cuda:11.1-devel-ubuntu20.04
+```

--- a/docs/airgap/mirror-http-files.md
+++ b/docs/airgap/mirror-http-files.md
@@ -1,0 +1,40 @@
+Setting up an offline mirror for HTTP downloads
+===============================================
+
+While most of the software installed by DeepOps makes use of package repositories, some software is downloaded directly over HTTP as raw files.
+
+To support these installations in offline environments, you may need to provide alternate download URLs for DeepOps to use.
+This requires that an HTTP (web) server be present and available to host files.
+
+
+Setting up the server
+---------------------
+
+Many offline environments already have a convenient HTTP server for hosting web pages or other downloads.
+If your environment already has a preferred server to use for downloads, you may be able to use that!
+
+If this doesn't exist already, the following process shows a minimal approach using an Apache httpd server.
+
+First, in the offline network, pick a machine to use as your HTTP server.
+We will assume the use of the Apache httpd server and that the web root is `/var/www/html`:
+
+```
+$ sudo apt update
+$ sudo apt install apache2
+$ sudo mkdir /var/www/html/downloads
+```
+
+Then, for any files you need to make available for download, simply copy these files to `/var/www/html/downlaods`.
+
+
+Configuring DeepOps
+-------------------
+
+To configure DeepOps to make use of this server, you will need to configure the specific variables for the download URL of each file.
+The best place to find these variables is the `defaults/main.yml` file of each role you plan to make use of.
+
+For example, in the [nvidia-docker role](https://github.com/NVIDIA/ansible-role-nvidia-docker), the wrapper script is downloaded from the [nvidia-docker Github repositories](https://raw.githubusercontent.com/NVIDIA/nvidia-docker/master/nvidia-docker).
+
+To mirror this file offline, you would download the script and place it on your offline repo server, then configure the `nvidia_docker_wrapper_url` variable with the alternate URL.
+
+Documentation on specific offline workflows (such as the [NGC ready offline doc](./ngc-ready.md)) may list specific files that need to be downloaded for those workflows.

--- a/docs/airgap/mirror-rpm-repos.md
+++ b/docs/airgap/mirror-rpm-repos.md
@@ -100,7 +100,7 @@ One common way to accomplish this transfer is to bundle the downloaded files int
 
 ```
 $ sudo yum install genisoimage
-$ sudo genisoimage -o /tmp/packes.iso /var/repos
+$ sudo genisoimage -o /tmp/packages.iso /var/repos
 ```
 
 

--- a/docs/airgap/mirror-rpm-repos.md
+++ b/docs/airgap/mirror-rpm-repos.md
@@ -1,0 +1,137 @@
+Setting up offline mirrors for RPM repositories
+===============================================
+
+
+Summary
+-------
+
+Most of the software necessary to run GPU-enabled applications on RHEL or CentOS servers is available via RPM repositories.
+In order to deploy this software in an offline environment, the most straightforward path is to mirror the repositories in your offline network.
+
+
+Identifying package repositories to mirror
+------------------------------------------
+
+In order to mirror package repositories to use offline, you must first identify which repositories contain the software you need.
+
+DeepOps assumes that a full mirror of your Linux distribution repositories will be available for package installs.
+If you do not already have mirrors of the distribution repositories available, please follow the
+[instructions provided by Red Hat for creating these mirrors](https://access.redhat.com/solutions/23016).
+
+The following additional RPM repositories are commonly used for GPU-enabled systems deployed by DeepOps:
+
+- [Fedora Extra Packages for Enterprise Linux (EPEL)](https://fedoraproject.org/wiki/EPEL)
+- NVIDIA CUDA repository: [repo file for EL7](https://developer.download.nvidia.com/compute/cuda/repos/rhel7/x86_64/cuda-rhel7.repo), [repo file for EL8](https://developer.download.nvidia.com/compute/cuda/repos/rhel7/x86_64/cuda-rhel8.repo)
+- NVIDIA container repositories: [repo file for EL7](https://raw.githubusercontent.com/NVIDIA/nvidia-docker/gh-pages/centos7/nvidia-docker.repo), [repo file for EL8](https://raw.githubusercontent.com/NVIDIA/nvidia-docker/gh-pages/centos8/nvidia-docker.repo)
+- Docker CE repository: [repo file](https://download.docker.com/linux/centos/docker-ce.repo)
+
+These repo files provide the following repository IDs, which will be needed by `reposync` below:
+
+- epel
+- cuda-rhel7-x86\_64 or cuda-rhel8-x86\_64
+- libnvidia-container
+- nvidia-container-runtime
+- nvidia-docker
+- docker-ce-stable
+
+To discover a complete list of repositories needed for your particular workload,
+we recommend configuring a server with Internet access with the necessary software and validating your list against the contents of `/etc/yum.repos.d`.
+
+
+Downloading package repositories on a machine with Internet access
+------------------------------------------------------------------
+
+On a RHEL or CentOS machine with Internet access, install the `yum-utils` and `createrepo` packages:
+
+```
+$ sudo yum install yum-utils createrepo
+```
+
+Then install the EPEL repository:
+
+```
+$ sudo yum install  https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+```
+
+Then, for each of the other repo files, install the file into the `/etc/yum.repos.d` directory.
+For example, if using the list of repositories from the previous section:
+
+```
+$ cd /etc/yum.repos.d
+$ sudo wget https://download.docker.com/linux/centos/docker-ce.repo
+$ sudo wget https://developer.download.nvidia.com/compute/cuda/repos/rhel7/x86_64/cuda-rhel7.repo
+$ sudo wget https://raw.githubusercontent.com/NVIDIA/nvidia-docker/gh-pages/centos7/nvidia-docker.repo
+```
+
+For each of the repositories you wish to mirror, run the `reposync` command to download the contents of the repository.
+This command will use the repository ID from the repo file to identify the repository to be downloaded.
+
+In this example, we're downloading our packages to the local path `/var/repos`, but you may substitute a different path where you want to download packages:
+
+```
+$ sudo reposync -l --repoid=docker-ce-stable --downloadcomps --download-metadata --download_path=/var/repos
+```
+
+Repeat this for each repository ID you wish to mirror.
+
+At this point, you should have one subdirectory for each of the repositories you chose to mirror, e.g.:
+
+```
+$ ls /var/repos/
+docker-ce-stable  nvidia-docker
+```
+
+For each of these directories, run the `createrepo` command to generate repository metadata:
+
+```
+$ sudo createrepo /var/repos/docker-ce-stable
+```
+
+
+Transferring repositories to offline network
+--------------------------------------------
+
+After downloading the repository contents, you will need to transfer the downloaded files to your offline network.
+
+There are many ways to do this, depending on your local setup!
+You should use the mechanism that gives you the best performance and ease-of-use in your environment.
+
+One common way to accomplish this transfer is to bundle the downloaded files into an ISO file, which can then be moved to the offline environment or "burned" to a DVD or external USB drive.
+
+```
+$ sudo yum install genisoimage
+$ sudo genisoimage -o /tmp/packes.iso /var/repos
+```
+
+
+Create mirrors on offline network
+---------------------------------
+
+One the repository contents have been transferred to the offline network, they need to be made available as repositories for package installs.
+Your offline enviroment may already have a package server, and there are many free and commercial solutions to do this!
+
+If you don't already have a package server, the following process shows a minimal approach using an Apache httpd server.
+
+First, in the offline network, pick a machine to use as your package server.
+We will assume the use of the Apache httpd server and that the web root is `/var/www/html`:
+
+```
+$ sudo yum install httpd
+$ sudo systemctl start httpd
+$ sudo mkdir /var/www/html/repos
+```
+
+Then extract and copy your downloaded package files to `/var/www/html/repos`.
+
+At this point, the downloaded package repositories should be available on your offline network via the package server.
+You can then create repo files on the offline network to allow other hosts to use the package repositories.
+For example, a new repo file for the docker-ce-stable repository might look like this:
+
+```
+[docker-ce-stable]
+name=Docker CE
+baseurl=http://<my-package-server>/repos/docker-ce-stable
+enabled=1
+```
+
+You can then add these repo files to `/etc/yum.repos.d` on any machine where you want to install these packages.

--- a/docs/airgap/ngc-ready.md
+++ b/docs/airgap/ngc-ready.md
@@ -76,7 +76,42 @@ To deploy the NGC-Ready playbook using alternative mirrors, you will need to con
 ### Configure servers to use your mirrors for the Linux distribution package repositories
 
 DeepOps does not configure the location of your Linux distribution's package repositories (e.g., Ubuntu or CentOS repositories).
-Instead..
+Instead, you will need to configure your servers to use your offline package mirrors directly.
+
+On Ubuntu servers, you should edit the `/etc/apt/sources.list` file to replace references to the Ubuntu distribution servers with your own mirror.
+For example,
+
+```
+# Replace this...
+deb http://us.archive.ubuntu.com/ubuntu bionic main restricted
+
+# With this...
+deb http://<your-mirror-server>/ubuntu bionic main restricted
+```
+
+On Enterprise Linux servers, you should edit the appropriate repo files in `/etc/yum.repos.d` and replace references to the upstream distribution servers with your own mirror.
+For repositories that reference a `mirrorlist`, you should replace these with `baseurl` parameters.
+
+For example,
+
+```
+# Replace this...
+[base]
+name=CentOS-$releasever - Base
+mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=os&infra=$infra
+#baseurl=http://mirror.centos.org/centos/$releasever/os/$basearch/
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
+
+# With this...
+[base]
+name=CentOS-$releasever - Base
+baseurl=http://<your-mirror-server>/centos/$releasever/os/$basearch/
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
+```
+
+In all cases, you should edit the URLs appropriately to ensure they can download from the paths exported from your mirrors.
 
 
 ### Configure DeepOps to use your mirrors for non-distribution package repositories

--- a/docs/airgap/ngc-ready.md
+++ b/docs/airgap/ngc-ready.md
@@ -65,12 +65,7 @@ For instructions on setting up a Docker registry mirror, see the [doc on Docker 
 
 ## Configuring DeepOps
 
-To deploy the NGC-Ready playbook using alternative mirrors, you will need to configure the following items.
-
-1. Configure the nodes to use your mirrors for the Linux distribution package repositories
-1. Set the following DeepOps variables to configure other package repositories
-1. Set the following DeepOps variables to configure container image pulls
-1. Set the following DeepOps variables to configure HTTP downloads
+To deploy the NGC-Ready playbook offline, you will need to configure your servers and DeepOps to make use of your mirrors.
 
 
 ### Configure servers to use your mirrors for the Linux distribution package repositories

--- a/docs/airgap/ngc-ready.md
+++ b/docs/airgap/ngc-ready.md
@@ -1,0 +1,42 @@
+Deploying the NGC-Ready playbook offline
+========================================
+
+## Necessary software mirrors
+
+Deploying the NGC-Ready playbook assumes that several package repositories and individual software packages are available to install.
+In order to deploy this configuration without Internet access, you will need to have the following software available in offline mirrors.
+
+
+### Ubuntu
+
+Apt repositories (how to mirror):
+
+
+Container images (how to mirror):
+
+
+HTTP downloads (how to mirror):
+
+
+
+### Enterprise Linux
+
+RPM repositories (how to mirror):
+
+
+Container images (how to mirror):
+
+
+HTTP downloads (how to mirror):
+
+
+
+## Configuring DeepOps
+
+To deploy the NGC-Ready playbook using alternative mirrors, you will need to configure the following items.
+
+1. Configure the nodes to use your mirrors for the Linux distribution package repositories
+1. Set the following DeepOps variables to configure other package repositories
+1. Set the following DeepOps variables to configure container image pulls
+1. Set the following DeepOps variables to configure HTTP downloads
+

--- a/docs/airgap/ngc-ready.md
+++ b/docs/airgap/ngc-ready.md
@@ -20,7 +20,7 @@ For instructions on mirroring these repositories, see the [doc on Apt mirrors](.
 
 The following files will need to be downloaded and made available in an HTTP mirror:
 
-* nvidia-docker wrapper (https://raw.githubusercontent.com/NVIDIA/nvidia-docker/master/nvidia-docker)
+* nvidia-docker wrapper (found [here](https://raw.githubusercontent.com/NVIDIA/nvidia-docker/master/nvidia-docker))
 * DCGM package (optional)
 
 For instructions on setting up an HTTP mirror, see the [doc on HTTP mirrors](./mirror-http-files.md).
@@ -48,8 +48,8 @@ For instructions on mirroring these repositories, see the [doc on RPM mirrors](.
 
 The following files will need to be downloaded and made available in an HTTP mirror:
 
-* EPEL package
-* nvidia-docker wrapper (https://raw.githubusercontent.com/NVIDIA/nvidia-docker/master/nvidia-docker)
+* EPEL package (found [here](https://fedoraproject.org/wiki/EPEL))
+* nvidia-docker wrapper (found [here](https://raw.githubusercontent.com/NVIDIA/nvidia-docker/master/nvidia-docker))
 * DCGM package (optional)
 
 For instructions on setting up an HTTP mirror, see the [doc on HTTP mirrors](./mirror-http-files.md).

--- a/docs/airgap/ngc-ready.md
+++ b/docs/airgap/ngc-ready.md
@@ -9,26 +9,58 @@ In order to deploy this configuration without Internet access, you will need to 
 
 ### Ubuntu
 
-Apt repositories (how to mirror):
+The following Apt repositories will need to be mirrored in the offline environment:
+
+* Ubuntu distribution repositories
+* Docker CE repository
+* nvidia-docker repositories
+
+For instructions on mirroring these repositories, see the [doc on Apt mirrors](./mirror-apt-repos.md).
 
 
-Container images (how to mirror):
+The following files will need to be downloaded and made available in an HTTP mirror:
+
+* nvidia-docker wrapper (https://raw.githubusercontent.com/NVIDIA/nvidia-docker/master/nvidia-docker)
+* DCGM package (optional)
+
+For instructions on setting up an HTTP mirror, see the [doc on HTTP mirrors](./mirror-http-files.md).
 
 
-HTTP downloads (how to mirror):
+Container images are only needed if you want to run the tests built into the playbook:
 
+* nvcr.io/nvidia/cuda:10.1-base-ubuntu18.04
+* nvcr.io/nvidia/pytorch:18.10-py3
+* nvcr.io/nvidia/tensorflow:18.10-py3
+
+For instructions on setting up a Docker registry mirror, see the [doc on Docker mirrors](./mirror-docker-images.md).
 
 
 ### Enterprise Linux
 
-RPM repositories (how to mirror):
+The following RPM repositories will need to be mirrored in the offline environment:
+
+* Enterprise Linux distribution repositories (RHEL or CentOS, depending on your distro)
+* Docker CE repository
+* nvidia-docker repositories
+
+For instructions on mirroring these repositories, see the [doc on RPM mirrors](./mirror-rpm-repos.md).
 
 
-Container images (how to mirror):
+The following files will need to be downloaded and made available in an HTTP mirror:
 
+* EPEL package
+* nvidia-docker wrapper (https://raw.githubusercontent.com/NVIDIA/nvidia-docker/master/nvidia-docker)
+* DCGM package (optional)
 
-HTTP downloads (how to mirror):
+For instructions on setting up an HTTP mirror, see the [doc on HTTP mirrors](./mirror-http-files.md).
 
+Container images (how to mirror) are only needed if you want to run the tests built into the playbook:
+
+* nvcr.io/nvidia/cuda:10.1-base-ubuntu18.04
+* nvcr.io/nvidia/pytorch:18.10-py3
+* nvcr.io/nvidia/tensorflow:18.10-py3
+
+For instructions on setting up a Docker registry mirror, see the [doc on Docker mirrors](./mirror-docker-images.md).
 
 
 ## Configuring DeepOps
@@ -40,3 +72,77 @@ To deploy the NGC-Ready playbook using alternative mirrors, you will need to con
 1. Set the following DeepOps variables to configure container image pulls
 1. Set the following DeepOps variables to configure HTTP downloads
 
+
+### Configure servers to use your mirrors for the Linux distribution package repositories
+
+DeepOps does not configure the location of your Linux distribution's package repositories (e.g., Ubuntu or CentOS repositories).
+Instead..
+
+
+### Configure DeepOps to use your mirrors for non-distribution package repositories
+
+The NGC-Ready playbook depends on the Docker CE and nvidia-docker package repositories.
+DeepOps sets up these repositories automatically during the installation.
+
+To configure alternate URLs for these repositories, set the following variables in your DeepOps configuration:
+
+```
+# Ubuntu
+docker_ubuntu_repo_base_url: "http://<your-package-mirror>/<your-path-to-docker-repo>"
+docker_ubuntu_repo_gpgkey: "http://<your-package-mirror>/<your-path-to-docker-gpgkey>"
+
+nvidia_docker_repo_base_url: "http://<your-package-mirror>/<your-path-to-nvidia-docker-base-dir>"
+nvidia_docker_repo_gpg_url: "http://<your-package-mirror>/<your-path-to-nvidia-docker-gpgkey>"
+
+# Enterprise Linux
+docker_rh_repo_base_url: "http://<your-package-mirror>/<your-path-to-docker-repo>"
+docker_rh_repo_gpgkey: "http://<your-package-mirror>/<your-path-to-docker-gpgkey>"
+
+nvidia_docker_repo_base_url: "http://<your-package-mirror>/<your-path-to-nvidia-docker-base-dir>"
+nvidia_docker_repo_gpg_url: "http://<your-package-mirror>/<your-path-to-nvidia-docker-gpgkey>"
+```
+
+
+### Configure DeepOps to use your mirrors for HTTP downloads
+
+In all cases, you will need to provide a URL to download the nvidia-docker wrapper:
+
+```
+nvidia_docker_wrapper_url: "http://<your-http-mirror>/<your-path>/nvidia-docker"
+```
+
+If installing on Enterprise Linux, you will need to provide a URL for the EPEL package.
+For example,
+
+```
+epel_package: "http://<your-http-mirror>/<your-path>/epel-release.rpm"
+```
+
+If installing NVIDIA DCGM, you will need to provide a local file path for your downloaded DCGM package.
+
+```
+# For Ubuntu
+dcgm_deb_package: "/path/to/datacenter-gpu-manager.deb"
+
+# For Enterprise Linux
+dcgm_rpm_package: "/path/to/datacenter-gpu-manager.rpm"
+```
+
+
+### Configure DeepOps to use your mirrors for container image pulls
+
+If running the container tests as part of the NGC-Ready playbook, set the following variables in your DeepOps configuration:
+
+```
+ngc_ready_cuda_container: "<your-container-registry>/nvidia/cuda:10.1-base-ubuntu18.04"
+ngc_ready_pytorch: "<your-container-registry>/nvidia/pytorch:18.10-py3"
+ngc_ready_tensorflow: "<your-container-registry>/nvidia/tensorflow:18.10-py3"
+``` 
+
+## Running the NGC-Ready playbook
+
+After setting these variables to point to your local mirrors, you should be able to run the NGC-Ready playbook:
+
+```
+ansible-playbook playbooks/ngc-ready-server.yml
+```

--- a/playbooks/ngc-ready-server.yml
+++ b/playbooks/ngc-ready-server.yml
@@ -13,8 +13,6 @@
 
 - hosts: all
   become: true
-  vars:
-    ngc_container_tag: 18.10-py3
   tasks:
     - name: install docker python3 module
       apt:
@@ -25,7 +23,7 @@
     - name: Enable EPEL repo
       package:
         name:
-          - epel-release
+          - "{{ ngc_ready_epel_url }}" 
         state: present
       when: ansible_os_family == 'RedHat'
     - name: Install package dependencies
@@ -43,7 +41,7 @@
     - name: pull CUDA container
       docker_container:
         name: gpu-test-pull
-        image: nvcr.io/nvidia/cuda:10.1-base-ubuntu18.04
+        image: "{{ ngc_ready_cuda_container }}" 
         auto_remove: yes
         pull: yes
       tags:
@@ -52,7 +50,7 @@
     - name: test CUDA container
       docker_container:
         name: gpu-test
-        image: nvcr.io/nvidia/cuda:10.1-base-ubuntu18.04
+        image: "{{ ngc_ready_cuda_container }}" 
         detach: no
         command: nvidia-smi -L
       register: cuda
@@ -75,7 +73,7 @@
     - name: pull pytorch container
       docker_container:
         name: pytorch-pull
-        image: "nvcr.io/nvidia/pytorch:{{ ngc_container_tag }}"
+        image: "{{ ngc_ready_pytorch }}"
         auto_remove: yes
         pull: yes
       tags:
@@ -84,7 +82,7 @@
     - name: test pytorch
       docker_container:
         name: pytorch
-        image: "nvcr.io/nvidia/pytorch:{{ ngc_container_tag }}"
+        image: "{{ ngc_ready_pytorch }}"
         working_dir: /opt/pytorch/examples/upstream/mnist
         detach: no
         network_mode: host
@@ -109,7 +107,7 @@
     - name: pull tensorflow container
       docker_container:
         name: tensorflow-pull
-        image: "nvcr.io/nvidia/tensorflow:{{ ngc_container_tag }}"
+        image: "{{ ngc_ready_tensorflow }}"
         auto_remove: yes
         pull: yes
       tags:
@@ -118,7 +116,7 @@
     - name: test tensorflow
       docker_container:
         name: tensorflow
-        image: "nvcr.io/nvidia/tensorflow:{{ ngc_container_tag }}"
+        image: "{{ ngc_ready_tensorflow }}"
         working_dir: /opt/tensorflow/tensorflow/examples/tutorials/mnist
         detach: no
         network_mode: host

--- a/playbooks/ngc-ready-server.yml
+++ b/playbooks/ngc-ready-server.yml
@@ -23,7 +23,7 @@
     - name: Enable EPEL repo
       package:
         name:
-          - "{{ ngc_ready_epel_url }}" 
+          - "{{ epel_package }}"
         state: present
       when: ansible_os_family == 'RedHat'
     - name: Install package dependencies


### PR DESCRIPTION
## Summary

Provide documentation on how to deploy NGC-Ready configuration without Internet access.

- [x] Document RPM package repository mirrors
- [x] Document APT package repository mirrors
- [x] Document Docker registry mirror
- [x] Document software requirements for NGC-Ready configuration
- [x] Modify [NGC-Ready playbook](https://github.com/NVIDIA/deepops/blob/master/playbooks/ngc-ready-server.yml) to allow specifying Docker images in Ansible vars

## Test plan

- [x] Successfully deploy playbook on Ubuntu 20.04 with all mirrors configured
- [ ] Successfully deploy playbook on RHEL 8 with all mirrors configured