### PR TITLE
Bump virtual vagrant version to 2.2.14

### DIFF
--- a/virtual/vagrant_startup.sh
+++ b/virtual/vagrant_startup.sh
@@ -48,7 +48,7 @@ case "$ID" in
     if ! which vagrant >/dev/null 2>&1; then
       # install vagrant (frozen at 2.2.3 to avoid various issues)
       pushd "$(mktemp -d)"
-      wget https://releases.hashicorp.com/vagrant/2.2.3/vagrant_2.2.3_x86_64.rpm -O vagrant.rpm
+      wget https://releases.hashicorp.com/vagrant/2.2.14/vagrant_2.2.14_x86_64.rpm -O vagrant.rpm
       #sudo rpm -i vagrant.rpm
       sudo yum -y localinstall vagrant.rpm
       popd
@@ -100,7 +100,7 @@ case "$ID" in
     if ! which vagrant >/dev/null 2>&1; then
       # install vagrant (frozen at 2.2.3 to avoid various issues)
       pushd "$(mktemp -d)"
-      wget https://releases.hashicorp.com/vagrant/2.2.3/vagrant_2.2.3_x86_64.deb -O vagrant.deb
+      wget https://releases.hashicorp.com/vagrant/2.2.14/vagrant_2.2.14_x86_64.deb -O vagrant.deb
       sudo dpkg -i vagrant.deb
       popd
   


### PR DESCRIPTION
The existing vagrant_startup.sh was having issues installing libvirt with the below error. The install was able to resolve the version conflicts/mismatch after updating the version from 2.2.3 to 2.2.14 (and possibly some manual steps that I did not properly document).

```
$ vagrant plugin install vagrant-libvirt
Installing the 'vagrant-libvirt' plugin. This can take a few minutes...
Bundler, the underlying system Vagrant uses to install plugins,
reported an error. The error is shown below. These errors are usually
caused by misconfigured plugin installations or transient network
issues. The error from Bundler is:
nokogiri requires Ruby version < 3.1.dev, >= 2.5.
```

**Testing**:

This PR can be simply tested by deploying an OS on a new node and running the below set of commands. The result of which should be the libvirt plugin being listed as installed. This should be repeated for CentOS and Ubuntu.

```
cd deepops
./scripts/setsup.sh
cd virtual
./vagrant_startup
vagrant plugin list
```