### PR TITLE
Add Ubuntu 20.04 and CentOS 8 to Jenkins test & improve manual testing capabilities

### DIFF
--- a/docs/deepops/dgx-pod.md
+++ b/docs/deepops/dgx-pod.md
@@ -379,7 +379,7 @@ The services can be reached from the following addresses:
 
 #### Logging
 
-Follow the [ELK Guide](elk.md) to setup logging in the cluster.
+Follow the [ELK Guide](../k8s-cluster/logging.md) to setup logging in the cluster.
 
 The service can be reached from the following address:
 * Kibana: http://\<kube-master\>:30700

--- a/docs/deepops/testing.md
+++ b/docs/deepops/testing.md
@@ -14,6 +14,8 @@ DeepOps CI contains two types of automated tests:
 
 * PR tests. These are faster and are executed against every open PR when commits are made to `master`. They are also when a commit is made to any DeepOps branch (`release-20.12`, `master`, etc.). Results are integrated into GitHub.
 
+In addition to the automated tests, we also provide developers the a method to manually kick off a test run against one or more deployment configurations in parallel from the below testing matrix through the [Jenkins-matrix](../../workloads/jenkins/Jenkinsfile-matrix) Jenkinsfile.
+
 ### Tests
 
 A short description of the nightly testing is outlined below. The full suit of tests can be reviewed in the [jenkins](../../workloads/jenkins) directory. Additional details can be found [here](../../workloads/jenkins/README.md).
@@ -24,8 +26,9 @@ A short description of the nightly testing is outlined below. The full suit of t
 | Test | [PR](../../workloads/jenkins/Jenkinsfile) | [Nightly](../../workloads/jenkins/Jenkinsfile-nightly) | [Nightly Multi-node](../../workloads/jenkins/Jenkinsfile-multi-nightly) | Comments |
 | --- | --- | --- | --- | --- |
 | Ubuntu 18.04 | x | x | x | |
-| Ubuntu 20.04 | | | | Support planned |
+| Ubuntu 20.04 | | | | x |
 | CentOS 7 | | x | x | |
+| CentOS | | | x | |
 | DGX OS | | | | No automated testing support |
 | RHEL | | | | No testing support |
 | 1 mgmt node | x | x | | |

--- a/virtual/Vagrantfile-centos8
+++ b/virtual/Vagrantfile-centos8
@@ -1,0 +1,41 @@
+VAGRANTFILE_API_VERSION = "2"
+BOX_IMAGE = "centos/8"
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+  config.ssh.insert_key = false
+  config.ssh.private_key_path = ["~/.ssh/id_rsa", "~/.vagrant.d/insecure_private_key"]
+  config.vm.provision "file", source: "~/.ssh/id_rsa.pub", destination: "~/.ssh/authorized_keys"
+
+  config.vm.define "virtual-mgmt01" do |mgmt|
+    mgmt.vm.provider "libvirt" do |v|
+      v.memory = 4096
+      v.cpus = 4
+    end
+    mgmt.vm.box = BOX_IMAGE
+    mgmt.vm.network :private_network, ip: "10.0.0.2"
+  end
+
+  config.vm.define "virtual-login01" do |login|
+    login.vm.provider "libvirt" do |v|
+      v.memory = 6144
+      v.cpus = 4
+    end
+    login.vm.box = BOX_IMAGE
+    login.vm.network :private_network, ip: "10.0.0.5"
+  end
+
+  config.vm.define "virtual-gpu01" do |gpu|
+    config.vm.provider "libvirt" do |v|
+      v.memory = 16384
+      v.cpus = 2
+      v.machine_type = "q35"
+      v.cpu_mode = "host-passthrough"
+      # comment in for pci passthrough (and change bus according
+      # to local hw setup - `lspci -nnk | grep NVIDIA`)
+      # BUS-GPU01 is a magic string used by automation, this should be removed
+      #BUS-GPU01 v.pci :bus => '0x08', :slot => '0x00', :function => '0x0'
+    end
+    gpu.vm.box = BOX_IMAGE
+    gpu.vm.network :private_network, ip: "10.0.0.6"
+  end
+end

--- a/virtual/Vagrantfile-centos8-full
+++ b/virtual/Vagrantfile-centos8-full
@@ -1,0 +1,75 @@
+VAGRANTFILE_API_VERSION = "2"
+BOX_IMAGE = "centos/8"
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+  config.ssh.insert_key = false
+  config.ssh.private_key_path = ["~/.ssh/id_rsa", "~/.vagrant.d/insecure_private_key"]
+  config.vm.provision "file", source: "~/.ssh/id_rsa.pub", destination: "~/.ssh/authorized_keys"
+
+  config.vm.define "virtual-mgmt01" do |mgmt|
+    mgmt.vm.provider "libvirt" do |v|
+      v.memory = 2048
+      v.cpus = 2
+    end 
+    mgmt.vm.box = BOX_IMAGE
+    mgmt.vm.network :private_network, ip: "10.0.0.2"
+  end
+
+  config.vm.define "virtual-mgmt02" do |mgmt|
+    mgmt.vm.provider "libvirt" do |v|
+      v.memory = 2048
+      v.cpus = 2 
+    end
+    mgmt.vm.box = BOX_IMAGE
+    mgmt.vm.network :private_network, ip: "10.0.0.3"
+  end
+
+  config.vm.define "virtual-mgmt03" do |mgmt|
+    mgmt.vm.provider "libvirt" do |v|
+      v.memory = 2048 
+      v.cpus = 2
+    end
+    mgmt.vm.box = BOX_IMAGE
+    mgmt.vm.network :private_network, ip: "10.0.0.4"
+  end 
+
+  config.vm.define "virtual-login01" do |login|
+    login.vm.provider "libvirt" do |v|
+      v.memory = 6144
+      v.cpus = 4
+    end
+    login.vm.box = BOX_IMAGE 
+    login.vm.network :private_network, ip: "10.0.0.5"
+  end
+
+  config.vm.define "virtual-gpu01" do |gpu|
+    config.vm.provider "libvirt" do |v|
+      v.memory = 16384
+      v.cpus = 2 
+      v.machine_type = "q35"
+      v.cpu_mode = "host-passthrough"
+      # comment in for pci passthrough (and change bus according
+      # to local hw setup - `lspci -nnk | grep NVIDIA`)
+      # BUS-GPU01 is a magic string used by automation, this should be removed
+      #BUS-GPU01 v.pci :bus => '0x08', :slot => '0x00', :function => '0x0'
+    end
+    gpu.vm.box = BOX_IMAGE
+    gpu.vm.network :private_network, ip: "10.0.0.6"
+  end 
+
+  config.vm.define "virtual-gpu02" do |gpu|
+    config.vm.provider "libvirt" do |v|
+      v.memory = 16384
+      v.cpus = 2
+      v.machine_type = "q35"
+      v.cpu_mode = "host-passthrough"
+      # comment in for pci passthrough (and change bus according
+      # to local hw setup - `lspci -nnk | grep NVIDIA`)
+      # BUS-GPU02 is a magic string used by automation, this should be removed
+      #BUS-GPU02 v.pci :bus => '0x08', :slot => '0x00', :function => '0x0'
+    end 
+    gpu.vm.box = BOX_IMAGE
+    gpu.vm.network :private_network, ip: "10.0.0.7"
+  end
+
+end

--- a/virtual/Vagrantfile-ubuntu20.04
+++ b/virtual/Vagrantfile-ubuntu20.04
@@ -1,0 +1,48 @@
+VAGRANTFILE_API_VERSION = "2"
+BOX_IMAGE = "generic/ubuntu2004"
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+  config.ssh.insert_key = false
+  config.ssh.private_key_path = ["~/.ssh/id_rsa", "~/.vagrant.d/insecure_private_key"]
+  config.vm.provision "file", source: "~/.ssh/id_rsa.pub", destination: "~/.ssh/authorized_keys"
+
+  config.vm.define "virtual-mgmt01" do |mgmt|
+    mgmt.vm.provider "libvirt" do |v|
+      v.memory = 4096
+      v.cpus = 4
+    end
+    mgmt.vm.box = BOX_IMAGE
+    mgmt.vm.network :private_network, ip: "10.0.0.2"
+  end
+
+  config.vm.define "virtual-login01" do |login|
+    login.vm.provider "libvirt" do |v|
+      v.memory = 6144
+      v.cpus = 4
+    end
+    login.vm.box = BOX_IMAGE
+    login.vm.network :private_network, ip: "10.0.0.5"
+  end
+
+  config.vm.define "virtual-gpu01" do |gpu|
+    config.vm.provider "libvirt" do |v|
+      v.memory = 16384
+      v.cpus = 2
+      v.machine_type = "q35"
+      v.cpu_mode = "host-passthrough"
+      # comment in for pci passthrough (and change bus according
+      # to local hw setup - `lspci -nnk | grep NVIDIA`)
+      # BUS-GPU01 is a magic string used by automation, this should be removed
+      #BUS-GPU01 v.pci :bus => '0x08', :slot => '0x00', :function => '0x0'
+    end
+    gpu.vm.box = BOX_IMAGE
+    gpu.vm.network :private_network, ip: "10.0.0.6"
+  end
+
+  config.vm.provision "shell", inline: <<-SHELL
+    sed -i -e 's/4\.2\.2\.1/8.8.8.8/g' -e 's/4\.2\.2\.2/8.8.4.4/g' /etc/netplan/01-netcfg.yaml
+    netplan apply
+
+    apt-get update
+  SHELL
+end

--- a/virtual/Vagrantfile-ubuntu20.04-full
+++ b/virtual/Vagrantfile-ubuntu20.04-full
@@ -1,0 +1,79 @@
+VAGRANTFILE_API_VERSION = "2"
+BOX_IMAGE = "generic/ubuntu2004"
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+  config.ssh.insert_key = false
+  config.ssh.private_key_path = ["~/.ssh/id_rsa", "~/.vagrant.d/insecure_private_key"]
+  config.vm.provision "file", source: "~/.ssh/id_rsa.pub", destination: "~/.ssh/authorized_keys"
+
+  config.vm.define "virtual-mgmt01" do |mgmt|
+    mgmt.vm.provider "libvirt" do |v|
+      v.memory = 2048
+      v.cpus = 2
+    end
+    mgmt.vm.box = BOX_IMAGE
+    mgmt.vm.network :private_network, ip: "10.0.0.2"
+  end
+
+  config.vm.define "virtual-mgmt02" do |mgmt|
+    mgmt.vm.provider "libvirt" do |v|
+      v.memory = 2048
+      v.cpus = 2
+    end
+    mgmt.vm.box = BOX_IMAGE
+    mgmt.vm.network :private_network, ip: "10.0.0.3"
+  end
+
+  config.vm.define "virtual-mgmt03" do |mgmt|
+    mgmt.vm.provider "libvirt" do |v|
+      v.memory = 2048
+      v.cpus = 2
+    end
+    mgmt.vm.box = BOX_IMAGE
+    mgmt.vm.network :private_network, ip: "10.0.0.4"
+  end
+
+  config.vm.define "virtual-login01" do |login|
+    login.vm.provider "libvirt" do |v|
+      v.memory = 6144
+      v.cpus = 4
+    end
+    login.vm.box = BOX_IMAGE
+    login.vm.network :private_network, ip: "10.0.0.5"
+  end
+
+  config.vm.define "virtual-gpu01" do |gpu|
+    config.vm.provider "libvirt" do |v|
+      v.memory = 16384
+      v.cpus = 2
+      v.machine_type = "q35"
+      v.cpu_mode = "host-passthrough"
+      # comment in for pci passthrough (and change bus according
+      # to local hw setup - `lspci -nnk | grep NVIDIA`)
+      # BUS-GPU01 is a magic string used by automation, this should be removed
+      #BUS-GPU01 v.pci :bus => '0x08', :slot => '0x00', :function => '0x0'
+    end 
+    gpu.vm.box = BOX_IMAGE
+    gpu.vm.network :private_network, ip: "10.0.0.6"
+  end
+
+  config.vm.define "virtual-gpu02" do |gpu|
+    config.vm.provider "libvirt" do |v|
+      v.memory = 16384
+      v.cpus = 2
+      v.machine_type = "q35"
+      v.cpu_mode = "host-passthrough"
+      # comment in for pci passthrough (and change bus according
+      # to local hw setup - `lspci -nnk | grep NVIDIA`)
+      # BUS-GPU02 is a magic string used by automation, this should be removed
+      #BUS-GPU02 v.pci :bus => '0x08', :slot => '0x00', :function => '0x0'
+    end
+    gpu.vm.box = BOX_IMAGE
+    gpu.vm.network :private_network, ip: "10.0.0.7"
+  end
+
+  config.vm.provision "shell", inline: <<-SHELL
+	sed -i -e 's/4\.2\.2\.1/8.8.8.8/g' -e 's/4\.2\.2\.2/8.8.4.4/g' /etc/netplan/01-netcfg.yaml
+	netplan apply
+  SHELL
+end

--- a/virtual/vagrant_startup.sh
+++ b/virtual/vagrant_startup.sh
@@ -122,8 +122,8 @@ esac
 #####################################
 # Set up Vagrantfile and start up the configuration in Vagrant
 if [ ${DEEPOPS_FULL_INSTALL} ]; then
-  export CENTOS_DEEPOPS_VAGRANT_FILE="${DEEPOPS_VAGRANT_FILE:-${VIRT_DIR}/Vagrantfile-centos-full}"
-  export UBUNTU_DEEPOPS_VAGRANT_FILE="${DEEPOPS_VAGRANT_FILE:-${VIRT_DIR}/Vagrantfile-ubuntu-full}"
+  export CENTOS_DEEPOPS_VAGRANT_FILE="${DEEPOPS_VAGRANT_FILE:-${VIRT_DIR}/Vagrantfile-centos${DEEPOPS_OS_VERSION}-full}"
+  export UBUNTU_DEEPOPS_VAGRANT_FILE="${DEEPOPS_VAGRANT_FILE:-${VIRT_DIR}/Vagrantfile-ubuntu${DEPOPS_OS_VERSION}-full}"
 else
   export CENTOS_DEEPOPS_VAGRANT_FILE="${DEEPOPS_VAGRANT_FILE:-${VIRT_DIR}/Vagrantfile-centos}"
   export UBUNTU_DEEPOPS_VAGRANT_FILE="${DEEPOPS_VAGRANT_FILE:-${VIRT_DIR}/Vagrantfile-ubuntu}"

--- a/workloads/jenkins/Jenkinsfile-matrix
+++ b/workloads/jenkins/Jenkinsfile-matrix
@@ -1,0 +1,217 @@
+// This Jenkins file is meant to allow a customized set of deployment tasks to be manually triggered
+// The primary use case for Jenkinsfile is quick smoke tests against a specific deployment configuration
+//
+// TODO: This should acts as a wrapper around the exising Jenkinsfile-nightly tests, but instead it runs a simplified test suite
+//
+// Use case 1: Allow a user to run the nightly tests on a single combination of deployment options
+// Use case 2: Allow a user to specify a group of deployment options and run them in parallel
+
+// Configuration options defaults
+// The assumption is that if Jenkins passess through 'all' each option must be tested
+//   Otherwise, the default in Jenkins should match the default here and that is used
+Map matrix_axes = [
+  DEEPOPS_VAGRANT_OS: ['centos', 'ubuntu'],
+  DEEPOPS_OS_VERSION: ['', '18.04', '20.04', '7', '8'],
+  DEEPOPS_FULL_INSTALL: ['', 'multinode'],
+  DEEPOPS_DEPLOYMENT_PLATFORM: ['slurm', 'k8s'],
+  DEEPOPS_BRANCH: ['master'],
+  DEEPOPS_REPO: ['https://github.com/NVIDIA/deepops.git'],
+  DEEPOPS_K8S_OPERATOR: ['', 'true']
+]
+
+// Override default values as specified by the manual builds with a special case for 'all'
+if("$DEEPOPS_VAGRANT_OS" != "all") {
+  matrix_axes['DEEPOPS_VAGRANT_OS'] = ["$DEEPOPS_VAGRANT_OS"]
+}
+if("$DEEPOPS_FULL_INSTALL" != "all") {
+  matrix_axes['DEEPOPS_FULL_INSTALL'] = ["$DEEPOPS_FULL_INSTALL"]
+}
+if("$DEEPOPS_DEPLOYMENT_PLATFORM" != "all") {
+  matrix_axes['DEEPOPS_DEPLOYMENT_PLATFORM'] = ["$DEEPOPS_DEPLOYMENT_PLATFORM"]
+}
+if("$DEEPOPS_K8S_OPERATOR" != "all") {
+  matrix_axes['DEEPOPS_K8S_OPERATOR'] = ["$DEEPOPS_K8S_OPERATOR"]
+}
+if("$DEEPOPS_OS_VERSION" != "all") {
+  matrix_axes['DEEPOPS_OS_VERSION'] = ["$DEEPOPS_OS_VERSION"]
+}
+
+// Special case for branch and repo, these cannot be blank
+if("$DEEPOPS_BRANCH" != "") {
+  matrix_axes['DEEPOPS_BRANCH'] = ["$DEEPOPS_BRANCH"]
+}
+if("$DEEPOPS_REPO" != "") {
+  matrix_axes['DEEPOPS_REPO'] = ["$DEEPOPS_REPO"]
+}
+
+// Default values
+String GPUCOUNT = 1 // Default to 1 GPU resource, use 2 if in 'multinode'
+
+Map tasks = [failFast: false] // Map that will hold all 'tasks' to run, failFast to continue in case of a single failure
+List axes = getMatrixAxes(matrix_axes).findAll { axis -> 1 == 1 } // List of combinations
+
+// Template code to convert matrix above into a usable list of configuration combinations
+@NonCPS
+List getMatrixAxes(Map matrix_axes) {
+  List axes = []
+  matrix_axes.each { axis, values ->
+    List axisList = []
+    values.each { value ->
+      axisList << [(axis): value]
+    }
+    axes << axisList
+  }
+  axes.combinations()*.sum()
+}
+
+// Generate a 'task' for each of the valid combinations
+for(int i = 0; i < axes.size(); i++) {
+  // convert the Axis into valid values for withEnv step
+  Map axis = axes[i]
+  List axisEnv = axis.collect { k, v ->
+    "${k}=${v}"
+  }
+  tasks[axisEnv.join(', ')] = { ->
+    node() {
+      withEnv(axisEnv) {
+        if("$DEEPOPS_FULL_INSTALL" == "multinode") {
+          GPUCOUNT=2
+        }
+
+        lock(resource: null, label: 'gpu', quantity: "${GPUCOUNT}", variable: 'GPUDATA') {
+
+          stage("Setup-${DEEPOPS_DEPLOYMENT_PLATFORM}-${DEEPOPS_VAGRANT_OS}-${DEEPOPS_FULL_INSTALL}") {
+            checkout([$class: 'GitSCM', branches: [[name: "*/$DEEPOPS_BRANCH"]],
+              userRemoteConfigs: [[url: "$DEEPOPS_REPO"]]]) // TODO: There is a timing bug here where this is pegged to a branch, not necessarily commit ID across tasks
+
+            echo "Reset repo and unmunge files"
+            sh '''
+              git reset --hard
+              rm -rf config
+            '''
+
+            echo "Munge files for testing"
+            sh '''
+              bash -x ./workloads/jenkins/scripts/munge-files.sh
+            '''
+
+            echo "Tear down any Vagrant that was not cleaned up"
+            sh '''
+              pwd
+              cd virtual && ./vagrant_shutdown.sh || true
+            '''
+
+            echo "Vagrant Up"
+            sh '''
+              bash -x ./workloads/jenkins/scripts/vagrant-startup.sh
+            '''
+          }
+
+          if("$DEEPOPS_DEPLOYMENT_PLATFORM" == "slurm") {
+            stage("Deployment-${DEEPOPS_DEPLOYMENT_PLATFORM}-${DEEPOPS_VAGRANT_OS}-${DEEPOPS_FULL_INSTALL}") {
+              echo "Set up Slurm"
+              sh '''
+                bash -x ./workloads/jenkins/scripts/test-setup-slurm.sh
+              '''
+
+              echo "Verify we can run a GPU job"
+              sh '''
+                timeout 60 bash -x ./workloads/jenkins/scripts/test-slurm-job.sh
+              '''
+            }
+          }
+
+          if("$DEEPOPS_DEPLOYMENT_PLATFORM" == "k8s") {
+            stage("Deployment-${DEEPOPS_DEPLOYMENT_PLATFORM}-${DEEPOPS_VAGRANT_OS}-${DEEPOPS_FULL_INSTALL}") {
+              echo "Set up K8S"
+              sh '''
+                bash -x ./workloads/jenkins/scripts/test-cluster-up.sh
+              '''
+            
+              echo "Get K8S Cluster Status"
+              sh '''
+                bash -x ./workloads/jenkins/scripts/get-k8s-debug.sh
+              '''
+
+              echo "Verify we can run a GPU job"
+              sh '''
+                timeout 500 bash -x ./workloads/jenkins/scripts/run-gpu-job.sh
+              '''
+            }
+          }
+
+          if("$DEEPOPS_DEPLOYMENT_PLATFORM" == "slurm") {
+            stage("Services-${DEEPOPS_DEPLOYMENT_PLATFORM}-${DEEPOPS_VAGRANT_OS}-${DEEPOPS_FULL_INSTALL}") {
+              echo "Test NFS"
+              sh '''
+                timeout 60 bash -x ./workloads/jenkins/scripts/test-slurm-nfs-mount.sh
+              '''
+
+              echo "Test MPI"
+              sh '''
+               timeout 60 bash -x ./workloads/jenkins/scripts/test-mpi-job.sh
+              '''
+            }  
+          }
+
+          if("$DEEPOPS_DEPLOYMENT_PLATFORM" == "k8s") {
+            stage("Services-${DEEPOPS_DEPLOYMENT_PLATFORM}-${DEEPOPS_VAGRANT_OS}-${DEEPOPS_FULL_INSTALL}") {
+              echo "Verify local docker registry"
+              sh '''
+                 bash -x ./workloads/jenkins/scripts/test-local-registry.sh
+              '''
+
+              echo "Verify ingress config"
+              sh '''
+                bash -x ./workloads/jenkins/scripts/verify-ingress-config.sh
+              '''
+
+              echo "Test Kubeflow installation"
+              sh '''
+                timeout 1500 bash -x ./workloads/jenkins/scripts/test-kubeflow.sh
+              '''
+
+              echo "Test Monitoring installation"
+              sh '''
+                timeout 800 bash -x ./workloads/jenkins/scripts/test-monitoring.sh
+              '''
+
+              echo "Test Dashboard installation"
+              sh '''
+                timeout 180 bash -x ./workloads/jenkins/scripts/test-dashboard.sh
+              '''
+
+              echo "Test Kubeflow pipeline"
+              sh '''
+                 timeout 1500 bash -x ./workloads/jenkins/scripts/test-kubeflow-pipeline.sh
+              '''
+            }
+          }
+        }
+        // TODO: There seems to be a bug here if tasks fail, they do not get cleaned up properly
+        // XXX: Not sure if the cleanup should live inside or outside of the lock. Also, this doesn't seem to work.
+        post {
+          always {
+            echo "Final cleanup"
+            sh '''
+              pwd
+              cd virtual && ./vagrant_shutdown.sh
+            '''
+          }
+        }
+      }
+    }
+  }
+}
+
+
+/*
+stage('Stop Any Old Builds') {
+  milestone label: '', ordinal:  Integer.parseInt(env.BUILD_ID) - 1
+  milestone label: '', ordinal:  Integer.parseInt(env.BUILD_ID)
+}
+*/
+
+stage("Matrix builds") {
+    parallel(tasks)
+}

--- a/workloads/jenkins/Jenkinsfile-multi-nightly
+++ b/workloads/jenkins/Jenkinsfile-multi-nightly
@@ -200,6 +200,215 @@ pipeline {
           sh '''
             timeout 60 bash -x ./workloads/jenkins/scripts/test-mpi-job.sh
           '''
+
+          echo "Reset repo and unmunge files"
+          sh '''
+            git reset --hard
+            rm -rf config
+          '''
+
+          echo "Tear down Vagrant before next cluster-up"
+          sh '''
+            pwd
+            cd virtual && ./vagrant_shutdown.sh
+          '''
+        }
+      }
+    }
+    stage('Cluster Up - Ubuntu 20.04') {
+      environment {
+        DEEPOPS_VAGRANT_OS = 'ubuntu'
+        DEEPOPS_OS_VERSION = '20.04'
+      }
+      steps {
+        // TODO: ideally lock should work with declared stages
+        lock(resource: null, label: 'gpu', quantity: 2, variable: 'GPUDATA') {
+          echo "Reset repo and unmunge files"
+          sh '''
+            git reset --hard
+            rm -rf config
+          '''
+
+          echo "Munge files for testing"
+          sh '''
+            bash -x ./workloads/jenkins/scripts/munge-files.sh
+          '''
+
+          echo "Vagrant Up"
+          sh '''
+            bash -x ./workloads/jenkins/scripts/vagrant-startup.sh
+          '''
+
+          echo "Cluster Up - Multiple GPU & MGMT Nodes"
+          sh '''
+            bash -x ./workloads/jenkins/scripts/test-cluster-up.sh
+          '''
+
+          echo "Get K8S Cluster Status"
+          sh '''
+            bash -x ./workloads/jenkins/scripts/get-k8s-debug.sh
+          '''
+
+          echo "Verify we can run a GPU job"
+          sh '''
+            timeout 500 bash -x ./workloads/jenkins/scripts/run-gpu-job.sh
+          '''
+
+          echo "Verify ingress config"
+          sh '''
+             bash -x ./workloads/jenkins/scripts/verify-ingress-config.sh
+          '''
+
+          echo "Verify local docker registry"
+          sh '''
+             bash -x ./workloads/jenkins/scripts/test-local-registry.sh
+          '''
+
+          echo "Test Kubeflow installation"
+          sh '''
+             timeout 4000 bash -x ./workloads/jenkins/scripts/test-kubeflow.sh
+          '''
+
+          echo "Test Monitoring installation"
+          sh '''
+             timeout 800 bash -x ./workloads/jenkins/scripts/test-monitoring.sh
+          '''
+
+          echo "Test Dashboard installation"
+          sh '''
+             timeout 180 bash -x ./workloads/jenkins/scripts/test-dashboard.sh
+          '''
+
+          echo "Test Kubeflow pipeline"
+          sh '''
+             timeout 1500 bash -x ./workloads/jenkins/scripts/test-kubeflow-pipeline.sh
+          '''
+
+          echo "Start new virtual environment pre-Slurm checks"
+          sh '''
+            cd virtual
+            bash -x ./vagrant_shutdown.sh
+            bash -x ./vagrant_startup.sh
+          '''
+
+          echo "Set up Slurm"
+          sh '''
+            bash -x ./workloads/jenkins/scripts/test-setup-slurm.sh
+          '''
+
+          echo "Test Slurm"
+          sh '''
+            timeout 60 bash -x ./workloads/jenkins/scripts/test-slurm-job.sh
+          '''
+
+          echo "Test NFS"
+          sh '''
+            timeout 60 bash -x ./workloads/jenkins/scripts/test-slurm-nfs-mount.sh
+          '''
+
+          echo "Test MPI"
+          sh '''
+            timeout 60 bash -x ./workloads/jenkins/scripts/test-mpi-job.sh
+          '''
+
+          echo "Reset repo and unmunge files"
+          sh '''
+            git reset --hard
+            rm -rf config
+          '''
+
+          echo "Tear down Vagrant before next cluster-up"
+          sh '''
+            pwd
+            cd virtual && ./vagrant_shutdown.sh
+          '''
+        }
+      }
+    }
+    stage('Cluster Up - CentOS') {
+      environment {
+        DEEPOPS_VAGRANT_OS = 'centos'
+        DEEPOPS_OS_VERSION = '8'
+      }
+      steps {
+        // TODO: ideally lock should work with declared stages
+        lock(resource: null, label: 'gpu', quantity: 2, variable: 'GPUDATA') {
+          echo "Munge files for testing"
+          sh '''
+            bash -x ./workloads/jenkins/scripts/munge-files.sh
+          '''
+
+          echo "Vagrant Up"
+          sh '''
+            bash -x ./workloads/jenkins/scripts/vagrant-startup.sh
+          '''
+
+          echo "Cluster Up - Multiple GPU & MGMT Nodes"
+          sh '''
+            bash -x ./workloads/jenkins/scripts/test-cluster-up.sh
+          '''
+
+          echo "Get K8S Cluster Status"
+          sh '''
+            bash -x ./workloads/jenkins/scripts/get-k8s-debug.sh
+          '''
+
+          echo "Verify we can run a GPU job"
+          sh '''
+            timeout 500 bash -x ./workloads/jenkins/scripts/run-gpu-job.sh
+          '''
+
+          echo "Verify ingress config"
+          sh '''
+             bash -x ./workloads/jenkins/scripts/verify-ingress-config.sh
+          '''
+
+          echo "Test Kubeflow installation"
+          sh '''
+             timeout 4000 bash -x ./workloads/jenkins/scripts/test-kubeflow.sh
+          '''
+
+          echo "Test Monitoring installation"
+          sh '''
+             timeout 800 bash -x ./workloads/jenkins/scripts/test-monitoring.sh
+          '''
+
+          echo "Test Dashboard installation"
+          sh '''
+             timeout 180 bash -x ./workloads/jenkins/scripts/test-dashboard.sh
+          '''
+
+          echo "Test Kubeflow pipeline"
+          sh '''
+             timeout 1500 bash -x ./workloads/jenkins/scripts/test-kubeflow-pipeline.sh
+          '''
+
+          echo "Start new virtual environment pre-Slurm checks"
+          sh '''
+            cd virtual
+            bash -x ./vagrant_shutdown.sh
+            bash -x ./vagrant_startup.sh
+          '''
+
+          echo "Set up Slurm"
+          sh '''
+            bash -x ./workloads/jenkins/scripts/test-setup-slurm.sh
+          '''
+
+          echo "Test Slurm"
+          sh '''
+            timeout 60 bash -x ./workloads/jenkins/scripts/test-slurm-job.sh
+          '''
+
+          echo "Test NFS"
+          sh '''
+            timeout 60 bash -x ./workloads/jenkins/scripts/test-slurm-nfs-mount.sh
+          '''
+
+          echo "Test MPI"
+          sh '''
+            timeout 60 bash -x ./workloads/jenkins/scripts/test-mpi-job.sh
+          '''
         }
       }
     }

--- a/workloads/jenkins/Jenkinsfile-nightly
+++ b/workloads/jenkins/Jenkinsfile-nightly
@@ -248,6 +248,228 @@ pipeline {
           sh '''
             timeout 60 bash -x ./workloads/jenkins/scripts/test-mpi-job.sh
           '''
+
+          echo "Reset repo and unmunge files"
+          sh '''
+            git reset --hard
+            rm -rf config
+          '''
+
+          echo "Tear down Vagrant before next cluster-up"
+          sh '''
+            pwd
+            cd virtual && ./vagrant_shutdown.sh
+          '''
+        }
+      }
+    }
+    stage('Cluster Up - Ubuntu 20.04') {
+      environment {
+        DEEPOPS_VAGRANT_OS = 'ubuntu'
+        DEEPOPS_OS_VERSION = '20.04'
+      }
+      steps {
+        // TODO: ideally lock should work with declared stages
+        lock(resource: null, label: 'gpu', quantity: 1, variable: 'GPUDATA') {
+          echo "Munge files for testing"
+          sh '''
+            bash -x ./workloads/jenkins/scripts/munge-files.sh
+          '''
+
+          echo "Vagrant Up"
+          sh '''
+            bash -x ./workloads/jenkins/scripts/vagrant-startup.sh
+          '''
+
+          echo "Cluster Up"
+          sh '''
+            bash -x ./workloads/jenkins/scripts/test-cluster-up.sh
+          '''
+
+          echo "Get K8S Cluster Status"
+          sh '''
+            bash -x ./workloads/jenkins/scripts/get-k8s-debug.sh
+          '''
+
+          echo "Verify we can run a GPU job"
+          sh '''
+            timeout 500 bash -x ./workloads/jenkins/scripts/run-gpu-job.sh
+          '''
+
+          echo "Verify ingress config"
+          sh '''
+             bash -x ./workloads/jenkins/scripts/verify-ingress-config.sh
+          '''
+
+          echo "Test Kubeflow installation"
+          sh '''
+             timeout 4000 bash -x ./workloads/jenkins/scripts/test-kubeflow.sh
+          '''
+
+          echo "Test Monitoring installation"
+          sh '''
+             timeout 800 bash -x ./workloads/jenkins/scripts/test-monitoring.sh
+          '''
+
+          echo "Test Dashboard installation"
+          sh '''
+             timeout 180 bash -x ./workloads/jenkins/scripts/test-dashboard.sh
+          '''
+
+          echo "Test Kubeflow pipeline"
+          sh '''
+             timeout 1500 bash -x ./workloads/jenkins/scripts/test-kubeflow-pipeline.sh
+          '''
+
+          echo "Start new virtual environment pre-GPU Operator checks"
+          sh '''
+            cd virtual
+            bash -x ./vagrant_shutdown.sh
+            bash -x ./vagrant_startup.sh
+          '''
+
+          echo "Cluster Up - MGMT Nodes"
+          sh '''
+            export DEEPOPS_K8S_OPERATOR=true
+            bash -x ./workloads/jenkins/scripts/test-cluster-up.sh
+          '''
+
+          echo "Get K8S Cluster Status"
+          sh '''
+            bash -x ./workloads/jenkins/scripts/get-k8s-debug.sh
+          '''
+
+          echo "Verify we can run a GPU job"
+          sh '''
+            export DEEPOPS_K8S_OPERATOR=true
+            timeout 500 bash -x ./workloads/jenkins/scripts/run-gpu-job.sh
+          '''
+
+          echo "Start new virtual environment pre-Slurm checks"
+          sh '''
+            cd virtual
+            bash -x ./vagrant_shutdown.sh
+            bash -x ./vagrant_startup.sh
+          '''
+
+          echo "Set up Slurm"
+          sh '''
+            bash -x ./workloads/jenkins/scripts/test-setup-slurm.sh
+          '''
+
+          echo "Test Slurm"
+          sh '''
+            timeout 60 bash -x ./workloads/jenkins/scripts/test-slurm-job.sh
+          '''
+
+          echo "Test NFS"
+          sh '''
+            timeout 60 bash -x ./workloads/jenkins/scripts/test-slurm-nfs-mount.sh
+          '''
+
+          echo "Test MPI"
+          sh '''
+            timeout 60 bash -x ./workloads/jenkins/scripts/test-mpi-job.sh
+          '''
+
+          echo "Reset repo and unmunge files"
+          sh '''
+            git reset --hard
+            rm -rf config
+          '''
+
+          echo "Tear down Vagrant before next cluster-up"
+          sh '''
+            pwd
+            cd virtual && ./vagrant_shutdown.sh
+          '''
+        }
+      }
+    }
+    stage('Cluster Up - CentOS 8') {
+      environment {
+        DEEPOPS_VAGRANT_OS = 'centos'
+        DEEPOPS_OS_VERSION = '8'
+      }
+      steps {
+        // TODO: ideally lock should work with declared stages
+        lock(resource: null, label: 'gpu', quantity: 1, variable: 'GPUDATA') {
+          echo "Munge files for testing"
+          sh '''
+            bash -x ./workloads/jenkins/scripts/munge-files.sh
+          '''
+
+          echo "Vagrant Up"
+          sh '''
+            bash -x ./workloads/jenkins/scripts/vagrant-startup.sh
+          '''
+
+          echo "Cluster Up"
+          sh '''
+            bash -x ./workloads/jenkins/scripts/test-cluster-up.sh
+          '''
+
+          echo "Get K8S Cluster Status"
+          sh '''
+            bash -x ./workloads/jenkins/scripts/get-k8s-debug.sh
+          '''
+
+          echo "Verify we can run a GPU job"
+          sh '''
+            timeout 500 bash -x ./workloads/jenkins/scripts/run-gpu-job.sh
+          '''
+
+          echo "Verify ingress config"
+          sh '''
+             bash -x ./workloads/jenkins/scripts/verify-ingress-config.sh
+          '''
+
+          echo "Test Kubeflow installation"
+          sh '''
+             timeout 4000 bash -x ./workloads/jenkins/scripts/test-kubeflow.sh
+          '''
+
+          echo "Test Monitoring installation"
+          sh '''
+             timeout 800 bash -x ./workloads/jenkins/scripts/test-monitoring.sh
+          '''
+
+          echo "Test Dashboard installation"
+          sh '''
+             timeout 180 bash -x ./workloads/jenkins/scripts/test-dashboard.sh
+          '''
+
+          echo "Test Kubeflow pipeline"
+          sh '''
+             timeout 1500 bash -x ./workloads/jenkins/scripts/test-kubeflow-pipeline.sh
+          '''
+
+          echo "Start new virtual environment pre-Slurm checks"
+          sh '''
+            cd virtual
+            bash -x ./vagrant_shutdown.sh
+            bash -x ./vagrant_startup.sh
+          '''
+
+          echo "Set up Slurm"
+          sh '''
+            bash -x ./workloads/jenkins/scripts/test-setup-slurm.sh
+          '''
+
+          echo "Test Slurm"
+          sh '''
+            timeout 60 bash -x ./workloads/jenkins/scripts/test-slurm-job.sh
+          '''
+
+          echo "Test NFS"
+          sh '''
+            timeout 60 bash -x ./workloads/jenkins/scripts/test-slurm-nfs-mount.sh
+          '''
+
+          echo "Test MPI"
+          sh '''
+            timeout 60 bash -x ./workloads/jenkins/scripts/test-mpi-job.sh
+          '''
         }
       }
     }


### PR DESCRIPTION
This will not have any impact on the existing PR tests. This only impacts the nightly and multi-node nightly tests. It also makes it easier to manually kick off tests and manually startup Ubuntu 20.04 or CentOS 8 through `virtual`.

**Updates**

* Add Ubuntu 20.04 Vagrantfile
* Add CentOS 8 Vagrantfile
* Update Jenkins nightly tests to include new OS support (we now run 18.04/20.04 & 7/8 nightly)
* Add Jenkinsfile-matrix to manually kick of one or more testing configurations in parallel (this previously existed in a forked repo)
* Update docs

**Testing**

Minimal manual testing is required for this PR.

There is no testing required for the updated Jenkinsfiles, these are automaticaly being executed in the nightlies (as of run 791).

The manual deployment can be tested through the deepops-matrix page of Jenkins (and has previously been running fine).