### PR TITLE
Add a GPU job test for Slurm

### DIFF
--- a/workloads/jenkins/Jenkinsfile
+++ b/workloads/jenkins/Jenkinsfile
@@ -100,6 +100,11 @@ pipeline {
           sh '''
              bash -x ./workloads/jenkins/scripts/test-rsyslog-slurm.sh
           '''
+
+          echo "Test GPU job"
+          sh '''
+            timeout 60 bash -x ./workloads/jenkins/scripts/test-slurm-gpu.sh
+          '''
         }
       }
     }

--- a/workloads/jenkins/Jenkinsfile-matrix
+++ b/workloads/jenkins/Jenkinsfile-matrix
@@ -114,9 +114,14 @@ for(int i = 0; i < axes.size(); i++) {
                 bash -x ./workloads/jenkins/scripts/test-setup-slurm.sh
               '''
 
-              echo "Verify we can run a GPU job"
+              echo "Verify we can run a basic Slurm job"
               sh '''
                 timeout 60 bash -x ./workloads/jenkins/scripts/test-slurm-job.sh
+              '''
+
+              echo "Test GPU job"
+              sh '''
+                timeout 60 bash -x ./workloads/jenkins/scripts/test-slurm-gpu.sh
               '''
             }
           }

--- a/workloads/jenkins/Jenkinsfile-multi-nightly
+++ b/workloads/jenkins/Jenkinsfile-multi-nightly
@@ -138,6 +138,11 @@ pipeline {
              bash -x ./workloads/jenkins/scripts/test-rsyslog-slurm.sh
           '''
 
+          echo "Test GPU job"
+          sh '''
+            timeout 60 bash -x ./workloads/jenkins/scripts/test-slurm-gpu.sh
+          '''
+
           echo "Reset repo and unmunge files"
           sh '''
             git reset --hard
@@ -244,6 +249,11 @@ pipeline {
           echo "Verify rsyslog forwarding is working for the slurm cluster"
           sh '''
              bash -x ./workloads/jenkins/scripts/test-rsyslog-slurm.sh
+          '''
+
+          echo "Test GPU job"
+          sh '''
+            timeout 60 bash -x ./workloads/jenkins/scripts/test-slurm-gpu.sh
           '''
 
           echo "Reset repo and unmunge files"
@@ -366,6 +376,11 @@ pipeline {
              bash -x ./workloads/jenkins/scripts/test-rsyslog-slurm.sh
           '''
 
+          echo "Test GPU job"
+          sh '''
+            timeout 60 bash -x ./workloads/jenkins/scripts/test-slurm-gpu.sh
+          '''
+
           echo "Reset repo and unmunge files"
           sh '''
             git reset --hard
@@ -473,6 +488,11 @@ pipeline {
           echo "Verify rsyslog forwarding is working for the slurm cluster"
           sh '''
              bash -x ./workloads/jenkins/scripts/test-rsyslog-slurm.sh
+          '''
+
+          echo "Test GPU job"
+          sh '''
+            timeout 60 bash -x ./workloads/jenkins/scripts/test-slurm-gpu.sh
           '''
         }
       }

--- a/workloads/jenkins/Jenkinsfile-nightly
+++ b/workloads/jenkins/Jenkinsfile-nightly
@@ -138,6 +138,11 @@ pipeline {
              bash -x ./workloads/jenkins/scripts/test-rsyslog-slurm.sh
           '''
 
+          echo "Test GPU job"
+          sh '''
+            timeout 60 bash -x ./workloads/jenkins/scripts/test-slurm-gpu.sh
+          '''
+
           echo "Reset repo and unmunge files"
           sh '''
             git reset --hard
@@ -239,6 +244,11 @@ pipeline {
           echo "Test MPI"
           sh '''
             timeout 60 bash -x ./workloads/jenkins/scripts/test-mpi-job.sh
+          '''
+
+          echo "Test GPU job"
+          sh '''
+            timeout 60 bash -x ./workloads/jenkins/scripts/test-slurm-gpu.sh
           '''
 
           echo "Reset repo and unmunge files"
@@ -364,6 +374,11 @@ pipeline {
             timeout 60 bash -x ./workloads/jenkins/scripts/test-mpi-job.sh
           '''
 
+          echo "Test GPU job"
+          sh '''
+            timeout 60 bash -x ./workloads/jenkins/scripts/test-slurm-gpu.sh
+          '''
+
           echo "Reset repo and unmunge files"
           sh '''
             git reset --hard
@@ -466,6 +481,11 @@ pipeline {
           echo "Verify rsyslog forwarding is working for the slurm cluster"
           sh '''
              bash -x ./workloads/jenkins/scripts/test-rsyslog-slurm.sh
+          '''
+
+          echo "Test GPU job"
+          sh '''
+            timeout 60 bash -x ./workloads/jenkins/scripts/test-slurm-gpu.sh
           '''
         }
       }

--- a/workloads/jenkins/scripts/remote-script-for-slurm-gpu.sh
+++ b/workloads/jenkins/scripts/remote-script-for-slurm-gpu.sh
@@ -1,0 +1,10 @@
+#!/bin/bash -l
+#
+# Test compiling and running a GPU program using NVIDIA HPC SDK
+
+set -x
+set -euo pipefail
+
+module load nvhpc
+nvcc -o "${HOME}/deviceQuery" -I /usr/local/cuda/samples/common/inc /usr/local/cuda/samples/1_Utilities/deviceQuery/deviceQuery.cpp
+srun -n1 -G1 "${HOME}/deviceQuery"

--- a/workloads/jenkins/scripts/test-slurm-gpu.sh
+++ b/workloads/jenkins/scripts/test-slurm-gpu.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+source workloads/jenkins/scripts/jenkins-common.sh
+
+# Upload test script
+scp  \
+	-o "StrictHostKeyChecking no" \
+	-o "UserKnownHostsFile /dev/null" \
+	-i "${HOME}/.ssh/id_rsa" \
+	workloads/jenkins/scripts/remote-script-for-slurm-gpu.sh \
+	"vagrant@10.0.0.5${GPU01}:remote-script-for-slurm-gpu.sh"
+
+# Compile and run CUDA sample 
+ssh \
+	-o "StrictHostKeyChecking no" \
+	-o "UserKnownHostsFile /dev/null" \
+	-l vagrant \
+	-i "${HOME}/.ssh/id_rsa" \
+	"10.0.0.5${GPU01}" \
+	"bash -l /home/vagrant/remote-script-for-slurm-gpu.sh"


### PR DESCRIPTION
Right now we don't have a Jenkins test that executes a GPU job under the
Slurm scheduler. I think we validate GPU functionality pretty well under
Kubernetes, but it would be good to check it under Slurm as well.

This test uses the CUDA toolkit in nvhpc to build the `deviceQuery`
sample and run it on the GPU node.