### PR TITLE
Fix Jenkins test for k8s container registry

### DIFF
--- a/workloads/jenkins/scripts/test-local-registry.sh
+++ b/workloads/jenkins/scripts/test-local-registry.sh
@@ -14,7 +14,7 @@ ansible-playbook \
         "${ROOT_DIR}/playbooks/k8s-cluster/container-registry.yml"
 
 # Wait for Docker registry to be online
-kubectl wait --for=condition=ready --timeout=600s pod -l app=docker-registry
+kubectl wait --for=condition=ready --timeout=600s pod -n deepops-docker -l app=docker-registry
 
 # Upload script for pushing image to registry
 scp  \


### PR DESCRIPTION
## Summary

PR #840 changed the namespace for the registry, so we need to set the namespace correctly in the Jenkins test kubectl command.

CI tests are currently failing with messages like:

```
+ kubectl wait --for=condition=ready --timeout=600s pod -l app=docker-registry

error: no matching resources found

script returned exit code 1
```

## Test plan

If the CI tests for this PR pass, then we should be good!