### PR TITLE
Fix wrong path of DeepOps custom configurations on kubeflow install

### DIFF
--- a/scripts/k8s/deploy_kubeflow.sh
+++ b/scripts/k8s/deploy_kubeflow.sh
@@ -190,7 +190,7 @@ function stand_up() {
   fi
 
   # Copy over DeepOps custom configurations & bugfixes
-  cp -r workloads/services/k8s/kubeflow-install/ config/
+  cp -r ${ROOT_DIR}/workloads/services/k8s/kubeflow-install/ ${CONFIG_DIR}
   sed -i '/metadata:.*/a\  ClusterName: cluster.local' ${CONFIG_FILE} # BUGFIX: Need to add the ClusterName for proper deletion:https://github.com/kubeflow/kubeflow/issues/4815
 
   # Update Kubeflow with the NGC containers and NVIDIA configurations


### PR DESCRIPTION
Below error occurs when installing kubeflow using `deploy_kubeflow.sh`

```
cp: cannot stat 'workloads/services/k8s/kubeflow-install/': No such file or directory
```

Since the script assumes that the command runs in root path, it is not able to find the given directory.
This PR fixed this issue so that the given custom configuration is correctly applied on kubeflow.