### PR TITLE
Add explicit download URL for HPC SDK 21.2

### DIFF
--- a/config.example/group_vars/slurm-cluster.yml
+++ b/config.example/group_vars/slurm-cluster.yml
@@ -116,6 +116,10 @@ hpcsdk_minor_version: "2"
 hpcsdk_file_cuda: "11.2"
 hpcsdk_arch: "x86_64"
 
+# WAR for download URL on 21.2
+# See: https://github.com/NVIDIA/deepops/issues/896
+hpcsdk_download_url: "https://developer.download.nvidia.com/hpc-sdk/21.2t/nvhpc_2021_212_Linux_x86_64_cuda_11.2.tar.gz"
+
 # In a Slurm cluster, default to setting up HPC SDK as modules rather than in
 # the default user environment
 hpcsdk_install_as_modules: true


### PR DESCRIPTION
Work-around for #896 

## Test plan

HPC SDK should install and CI tests should pass with this work-around in place