### PR TITLE
Add libatomic to redhat slurm deps

### DIFF
--- a/roles/slurm/vars/redhat.yml
+++ b/roles/slurm/vars/redhat.yml
@@ -13,6 +13,7 @@ slurm_build_deps:
   - http-parser-devel
   - json-c-devel
   - perl-ExtUtils-MakeMaker
+  - libatomic
 
 slurm_pmix_deps:
   - "@Development Tools"


### PR DESCRIPTION
Include libatomic library in Slurm install as required by latests HPC-SDK (https://github.com/NVIDIA/hpc-container-maker/blob/master/docs/building_blocks.md#nvhpc)