### PR TITLE
removed {{ }} from when clause

### DIFF
--- a/playbooks/generic/hosts.yml
+++ b/playbooks/generic/hosts.yml
@@ -5,7 +5,7 @@
     - name: set /etc/hostname
       hostname:
         name: "{{ inventory_hostname }}"
-      when: "{{ deepops_set_hostname | default(true) }}"
+      when: deepops_set_hostname | default(true)
 
     - name: set /etc/hosts
       include_role:


### PR DESCRIPTION
Warning from install

```
TASK [set /etc/hostname] ******************************************************************************************************************************************************
[WARNING]: conditional statements should not include jinja2 templating delimiters such as {{ }} or {% %}. Found: {{ deepops_set_hostname | default(true) }}
[WARNING]: conditional statements should not include jinja2 templating delimiters such as {{ }} or {% %}. Found: {{ deepops_set_hostname | default(true) }}
[WARNING]: conditional statements should not include jinja2 templating delimiters such as {{ }} or {% %}. Found: {{ deepops_set_hostname | default(true) }}
```