### PR TITLE
Fixes for DGX firmware update role

### DIFF
--- a/roles/nvidia-dgx-firmware/defaults/main.yml
+++ b/roles/nvidia-dgx-firmware/defaults/main.yml
@@ -10,7 +10,7 @@ update_firmware: false
 load_firmware: true
 
 # Remove all log files and any loaded Docker images on all nodes
-clean_firmware: true
+clean_fw: true
 
 # These two actions can take a very long time, and dcgm_stress especially can stress hardware
 dcgm_stress: false
@@ -39,8 +39,9 @@ fw_dir: "/opt/deepops/nvfw"
 # nv_mgmt_interface: enp2s0f1 # DGX-Station
 nv_mgmt_interface: enp225s0f0 # DGX A100
 
-# Target_fw can be set to 'all' or something specific (sbios, bmc, etc. - check container release notes on
+# Target_fw can be set to 'all' or something specific (SBIOS, BMC, etc. - check container release notes on
 # NVIDIA Enterprise support portal for details on valid options)
+# Current valid options: CEC SBIOS BMC VBIOS FPGA SSD SWITCH CPLD
 # target_fw: all
 target_fw: all
 
@@ -49,3 +50,18 @@ force_update: false
 
 # Reboot timeout (in seconds)
 reboot_timeout: 600
+
+nv_services:
+  - nvsm
+  - nvidia-persistenced
+  - nvidia-fabricmanager
+  - nv_peer_mem
+  - dcgm
+  - docker
+nv_modules:
+  - nv_peer_mem
+  - nvidia_uvm
+  - nvidia_drm
+  - nvidia_modeset
+  - nvidia
+

--- a/roles/nvidia-dgx-firmware/tasks/check-firmware.yml
+++ b/roles/nvidia-dgx-firmware/tasks/check-firmware.yml
@@ -14,7 +14,7 @@
 
 # This is an optimization, checking the firmware versions can take a long time, so unless we are forcing an update only do this once
 - name: Check firmware version
-  shell: "docker run --rm --privileged  -v /:/hostfs {{ firmware_update_repo }}:{{ firmware_update_tag }} show_version | tee {{ fw_dir }}/fw-versions{{ run_diagnostics_type }}.log"
+  shell: "docker run -ti --rm --privileged  -v /:/hostfs {{ firmware_update_repo }}:{{ firmware_update_tag }} show_version | tee {{ fw_dir }}/fw-versions{{ run_diagnostics_type }}.log"
   register: firmware_versions_response
 
 - name: Print show_fw_manifest output

--- a/roles/nvidia-dgx-firmware/tasks/main.yml
+++ b/roles/nvidia-dgx-firmware/tasks/main.yml
@@ -30,6 +30,22 @@
   - include: load-image.yml
     when: load_firmware
 
+  # Shut down services and unload drivers
+  - name: stop system services
+    systemd:
+      state: stopped
+      enabled: no
+      name: "{{ item }}"
+    with_items: "{{ nv_services }}"
+    when: update_firmware
+
+  - name: unload drivers
+    modprobe:
+      state: absent
+      name: "{{ item }}"
+    with_items: "{{ nv_modules }}"
+    when: update_firmware
+
   # Update the FW and reboot if necessary
   - include: update-firmware.yml
     when: update_firmware


### PR DESCRIPTION
## Summary

- Correct variable for firmware cleanup
- Correctly stop services and unload modules before updating
- Fix docker run command

## Test plan

Used to update DGX A100 firmware successfully!