### PR TITLE
Move nvidia-peer-memory logic into a role

### DIFF
--- a/playbooks/nvidia-software/nvidia-peer-memory.yml
+++ b/playbooks/nvidia-software/nvidia-peer-memory.yml
@@ -1,31 +1,5 @@
 ---
-- hosts: all
+- hosts: "{{ hostlist | default('all') }}"
   become: true
-  tasks:
-
-    - name: Check for DGX packages
-      stat:
-        path: /etc/dgx-release
-      register: is_dgx
-
-    - name: Autoinstall DKMS modules
-      command: dkms autoinstall
-      when:
-        - ansible_local['gpus']['count']
-        - is_dgx.stat.exists == True
-
-    - name: Modprobe nv_peer_mem
-      modprobe:
-        name: nv_peer_mem
-        state: present
-      when:
-        - ansible_local['gpus']['count']
-        - is_dgx.stat.exists == True
-
-    - name: Start nv_peer_mem service
-      service:
-        name: nv_peer_mem
-        state: started
-      when:
-        - ansible_local['gpus']['count']
-        - is_dgx.stat.exists == True
+  roles:
+  - nvidia-peer-memory

--- a/roles/nvidia-peer-memory/tasks/main.yml
+++ b/roles/nvidia-peer-memory/tasks/main.yml
@@ -1,0 +1,27 @@
+---
+- name: Check for DGX packages
+  stat:
+    path: /etc/dgx-release
+  register: is_dgx
+
+- name: Autoinstall DKMS modules
+  command: dkms autoinstall
+  when:
+    - ansible_local['gpus']['count']
+    - is_dgx.stat.exists == True
+
+- name: Modprobe nv_peer_mem
+  modprobe:
+    name: nv_peer_mem
+    state: present
+  when:
+    - ansible_local['gpus']['count']
+    - is_dgx.stat.exists == True
+
+- name: Start nv_peer_mem service
+  service:
+    name: nv_peer_mem
+    state: started
+  when:
+    - ansible_local['gpus']['count']
+    - is_dgx.stat.exists == True


### PR DESCRIPTION
This is mostly to support future refactoring and make the layout consistent with what we do in other playbooks/roles.

Test plan is passing CI tests.