### PR TITLE
Simplify GPU Operator support and change vGPU deployment method

### DIFF
--- a/roles/nvidia-gpu-operator/defaults/main.yml
+++ b/roles/nvidia-gpu-operator/defaults/main.yml
@@ -12,8 +12,10 @@ gpu_operator_release_name: "nvidia-gpu-operator"
 gpu_operator_chart_version: "1.6.0"
 k8s_gpu_mig_strategy: "mixed"
 
+# Configuration customization
 # XXX: This currently appears to be hardcoded in the operator
 gpu_operator_namespace: "gpu-operator-resources"
+gpu_operator_grid_config_dir: "{{ deepops_dir }}/gpu_operator"
 
 # Defaults from https://github.com/NVIDIA/gpu-operator/blob/master/deployments/gpu-operator/values.yaml
 gpu_operator_default_runtime: "docker"
@@ -21,11 +23,9 @@ gpu_operator_driver_registry: "nvcr.io/nvidia"
 gpu_operator_driver_version: "460.32.03"
 gpu_operator_plugin_args: "--mig-strategy={{ k8s_gpu_mig_strategy }},--pass-device-specs=true,--fail-on-init-error=true,--device-list-strategy=envvar,--nvidia-driver-root=/run/nvidia/driver"
 
-# Variables used if driver containers are in a private registry (i.e. beta drivers & vGPU)
-## Flag that determines whether to add a k8s secret for private containers
-gpu_operator_create_secret: false
-## Name of k8s secret (typically "" or "registry-secret")
-gpu_operator_registry_secret: ""
+# Variables used for vGPU
+## This is the IP of the license server used for vGPU, must be set to use vGPU
+vgpu_grid_license_server: ""
 ## This should remain as $oauthtoken if using an NGC API key
 gpu_operator_registry_username: "$oauthtoken"
 ## This is most likely an NGC API key

--- a/roles/nvidia-gpu-operator/defaults/main.yml
+++ b/roles/nvidia-gpu-operator/defaults/main.yml
@@ -9,7 +9,7 @@
 gpu_operator_helm_repo: "https://nvidia.github.io/gpu-operator"
 gpu_operator_chart_name: "nvidia/gpu-operator"
 gpu_operator_release_name: "nvidia-gpu-operator"
-gpu_operator_chart_version: "1.6.0"
+gpu_operator_chart_version: "1.6.2"
 k8s_gpu_mig_strategy: "mixed"
 
 # Configuration customization

--- a/roles/nvidia-gpu-operator/tasks/main.yml
+++ b/roles/nvidia-gpu-operator/tasks/main.yml
@@ -1,33 +1,42 @@
 ---
+# vGPU support
+- block:
+  - name: Create namespace for GPU Operator resources
+    shell: kubectl create namespace {{ gpu_operator_namespace }} -o yaml --dry-run=client | kubectl apply -f -
+  - name: create local directory for gpu operator configuration
+    file:
+      path: "{{ gpu_operator_grid_config_dir }}"
+      state: directory
+      owner: "root"
+      group: "root"
+      mode: "0700"
+  - name: add gridd.conf config file from template
+    template:
+      src: "gridd.conf"
+      dest: "{{ gpu_operator_grid_config_dir }}/gridd.conf"
+      owner: "root"
+      group: "root"
+      mode: "0600"
+  - name: Create a docker gridd.conf license configmap
+    shell: kubectl create configmap licensing-config -n "{{ gpu_operator_namespace }}" --from-file="{{gpu_operator_grid_config_dir }}/gridd.conf" -o yaml --dry-run=client | kubectl apply -f -
+  - name: Create a docker secret for private GPU Operator containers
+    shell: kubectl create secret docker-registry registry-secret --docker-server='{{ gpu_operator_driver_registry }}' --docker-username='{{ gpu_operator_registry_username }}' --docker-password={{ gpu_operator_registry_password }} --docker-email={{ gpu_operator_registry_email }} -n {{ gpu_operator_namespace }} -o yaml --dry-run=client | kubectl apply -f -
+  - name: Set secret var for helm command line if specified
+    set_fact:
+      gpu_operator_registry_secret: --set driver.imagePullSecrets[0]="registry-secret"
+  when: vgpu_grid_license_server != ""
+
 # While we would prefer to use the Ansible helm module, it's broken! :-(
 # See https://github.com/ansible/ansible/pull/57897
 # Unfortunately this will not be fixed until Ansible 2.10 which is not yet released.
 # So for now we will run /usr/local/bin/helm commands directly...
-
 - name: install gpu-operator helm repo
   command: /usr/local/bin/helm repo add nvidia "{{ gpu_operator_helm_repo }}"
 
 - name: update helm repos
   command: /usr/local/bin/helm repo update
 
-# TODO: If this already exists we fail, so skip that for now with failed_when: false
-- name: Create namespace for GPU Operator resources
-  command: kubectl create namespace {{ gpu_operator_namespace }}
-  when: gpu_operator_create_secret
-  failed_when: false
-
-# TODO: If this already exists we fail, so skip that for now with failed_when: false
-- name: Create a docker secret for GPU Operator containers
-  command: kubectl create secret docker-registry {{ gpu_operator_registry_secret }} --docker-server="{{ gpu_operator_driver_registry }}" --docker-username={{ gpu_operator_registry_username }} --docker-password={{ gpu_operator_registry_password }} --docker-email={{ gpu_operator_registry_email }} -n {{ gpu_operator_namespace }}
-  when: gpu_operator_create_secret
-  failed_when: false
-
-- name: Set secret var for helm command line if specified
-  set_fact: 
-    gpu_operator_registry_secret: --set driver.imagePullSecrets[0]="{{ gpu_operator_registry_secret }}"
-  when: gpu_operator_registry_secret != ""
-
 # XXX: This currently installs into the default namespace, as per the GPU Operator docs
 # https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/getting-started.html
 - name: install nvidia gpu operator
-  command: /usr/local/bin/helm upgrade --install "{{ gpu_operator_release_name }}" "{{ gpu_operator_chart_name }}" --version "{{ gpu_operator_chart_version }}" --set migStrategy="{{ k8s_gpu_mig_strategy }}" --set operator.defaultRuntime="{{ gpu_operator_default_runtime }}" --set driver.repository="{{ gpu_operator_driver_registry }}" --set driver.version="{{ gpu_operator_driver_version }}" {{ gpu_operator_registry_secret }} --set gfd.migStrateg="{{ k8s_gpu_mig_strategy }}" --set devicePlugin.args={"{{ gpu_operator_plugin_args }}"} --wait
+  command: /usr/local/bin/helm upgrade --install "{{ gpu_operator_release_name }}" "{{ gpu_operator_chart_name }}" --version "{{ gpu_operator_chart_version }}" --set migStrategy="{{ k8s_gpu_mig_strategy }}" --set operator.defaultRuntime="{{ gpu_operator_default_runtime }}" --set driver.repository="{{ gpu_operator_driver_registry }}" --set driver.version="{{ gpu_operator_driver_version }}" {{ gpu_operator_registry_secret | default("") }} --set gfd.migStrateg="{{ k8s_gpu_mig_strategy }}" --set devicePlugin.args={"{{ gpu_operator_plugin_args }}"} --wait

--- a/roles/nvidia-gpu-operator/templates/gridd.conf
+++ b/roles/nvidia-gpu-operator/templates/gridd.conf
@@ -1,0 +1,5 @@
+# See the official documentaion for more details: https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/getting-started.html
+# Description: Set License Server Address
+# Data type: string
+# Format:  "<address>"
+ServerAddress="{{ vgpu_grid_license_server }}"


### PR DESCRIPTION
* Removed a few variables that added unnecessary flexibility for non-existant beta drivers
* Change vGPU support to rely on the new configmap method of installation using a vGPU license server IP
* Bump GPU Operator version to 1.6.2 to get containerd bugfix

Test plan:
* Covered by existing GPU Operator tests
* Install without GPU Operator
* Install with GPU Operator on vGPU (passing)