### PR TITLE
Update to nvidia.enroot v0.4.0 role

### DIFF
--- a/playbooks/container/pyxis.yml
+++ b/playbooks/container/pyxis.yml
@@ -21,8 +21,12 @@
         enroot_environ_config_files: "{{ enroot_environ_config_files_dgx }}"
       when: ansible_product_name is search("DGX")
 
+- hosts: slurm-node
+  become: yes
+  roles:
+    - name: nvidia.enroot
+
 - hosts: slurm-cluster
   become: yes
   roles:
-    - name: ansible-role-enroot
     - name: pyxis

--- a/roles/pyxis/tasks/main.yml
+++ b/roles/pyxis/tasks/main.yml
@@ -18,12 +18,14 @@
     path: /etc/enroot/hooks.d/50-slurm-pmi.sh
     state: link
     src: /usr/share/enroot/hooks.d/50-slurm-pmi.sh
+  when: is_compute
 
 - name: install slurm-pytorch hook
   file:
     path: /etc/enroot/hooks.d/50-slurm-pytorch.sh
     state: link
     src: /usr/share/enroot/hooks.d/50-slurm-pytorch.sh
+  when: is_compute
 
 - name: pyxis tasks
   include_tasks: pyxis.yml

--- a/roles/requirements.yml
+++ b/roles/requirements.yml
@@ -29,8 +29,8 @@ roles:
 - src: nvidia.nvidia_docker
   version: "v1.2.1"
 
-- src: https://github.com/NVIDIA/ansible-role-enroot.git
-  version: "v0.3.2"
+- src: nvidia.enroot
+  version: "v0.4.0"
 
 - src: geerlingguy.filebeat
   version: "2.0.1"

--- a/workloads/jenkins/Jenkinsfile-multi-nightly
+++ b/workloads/jenkins/Jenkinsfile-multi-nightly
@@ -253,7 +253,7 @@ pipeline {
 
           echo "Test Enroot"
           sh '''
-             # TODO: ISSUE-784 timeout 120 bash -x ./workloads/jenkins/scripts/test-slurm-enroot-job.sh
+            timeout 120 bash -x ./workloads/jenkins/scripts/test-slurm-enroot-job.sh
           '''
 
           echo "Verify rsyslog forwarding is working for the slurm cluster"
@@ -502,7 +502,7 @@ pipeline {
 
           echo "Test Enroot"
           sh '''
-             # TODO: ISSUE-784 timeout 120 bash -x ./workloads/jenkins/scripts/test-slurm-enroot-job.sh
+            timeout 120 bash -x ./workloads/jenkins/scripts/test-slurm-enroot-job.sh
           '''
 
           echo "Verify rsyslog forwarding is working for the slurm cluster"

--- a/workloads/jenkins/Jenkinsfile-nightly
+++ b/workloads/jenkins/Jenkinsfile-nightly
@@ -258,7 +258,7 @@ pipeline {
           
           echo "Test Enroot"
           sh '''
-            # TODO: ISSUE-784 timeout 120 bash -x ./workloads/jenkins/scripts/test-slurm-enroot-job.sh
+            timeout 120 bash -x ./workloads/jenkins/scripts/test-slurm-enroot-job.sh
           '''
 
           echo "Reset repo and unmunge files"
@@ -495,7 +495,7 @@ pipeline {
 
           echo "Test Enroot"
           sh '''
-             # TODO: ISSUE-784 timeout 120 bash -x ./workloads/jenkins/scripts/test-slurm-enroot-job.sh
+            timeout 120 bash -x ./workloads/jenkins/scripts/test-slurm-enroot-job.sh
           '''
 
           echo "Verify rsyslog forwarding is working for the slurm cluster"


### PR DESCRIPTION
## Summary

This adds support for configuring the kernel command line options for Enroot on EL distros.

Also makes the following DeepOps changes:
- By default, only run nvidia.enroot role in group `slurm-node`, instead of on `slurm-cluster`. We make this change because `enroot` is only needed on the compute nodes, and following this change, adding the kernel flags can result in nodes rebooting.
- Pyxis role should only set up enroot hooks on `slurm-node`, for the same reason.
- Re-enables Jenkins CI tests for Enroot on CentOS.

Addresses #784 .

## Test plan

Tested manually to confirm that Enroot now works on CentOS.

Need to validate Jenkins CI tests pass for all stacks.