### PR TITLE
Fix multinode testing

### DIFF
--- a/workloads/jenkins/Jenkinsfile-multi-nightly
+++ b/workloads/jenkins/Jenkinsfile-multi-nightly
@@ -410,7 +410,7 @@ pipeline {
         }
       }
     }
-    stage('Cluster Up - CentOS') {
+    stage('Cluster Up - CentOS 8') {
       environment {
         DEEPOPS_VAGRANT_OS = 'centos'
         DEEPOPS_OS_VERSION = '8'


### PR DESCRIPTION
I broke the testing a few weeks back with some of the new CentOS 8 tests. We fixed it in the single node tests, but the commit for the multinode case was accidentally pushed after the PR went through.