### PR TITLE
Add a var to force nvidia driver install

### DIFF
--- a/config.example/group_vars/all.yml
+++ b/config.example/group_vars/all.yml
@@ -124,6 +124,9 @@ gpu_clock_reset: no
 # Specifies <minGpuClock,maxGpuClock> clocks as a pair (e.g. 1500,1500) that defines the range of desired locked GPU clock speed in MHz. Setting this will supercede application clocks and take effect regardless if an app is running. Input can also be a singular desired clock value. (see the `--lock-gpu-clocks` flag in nvidia-smi for more)
 gpu_clock_lock: "1507,1507"
 
+# Debugging var: force install NVIDIA driver even if GPU not detected
+nvidia_driver_force_install: false
+
 
 ################################################################################
 # CONTAINER RUNTIME                                                            #

--- a/playbooks/nvidia-software/nvidia-driver.yml
+++ b/playbooks/nvidia-software/nvidia-driver.yml
@@ -17,9 +17,7 @@
     - name: install nvidia driver
       include_role:
         name: nvidia.nvidia_driver
-      when:
-        - ansible_local['gpus']['count']
-        - is_dgx.stat.exists == False
+      when: (ansible_local['gpus']['count'] and is_dgx.stat.exists == False) or (nvidia_driver_force_install|default(false))
 
     - name: test nvidia-smi
       command: nvidia-smi


### PR DESCRIPTION
## Summary

For some debugging workflows, I find it helpful to install the driver packages even if our facts role doesn't detect GPUs on the node.

This commit adds a variable to force execution of the install task regardless of the detected GPUs.


## Test plan

On a VM without a GPU, run with `nvidia_driver_force_install: true`:

```
ansible-playbook -i virtual/config/inventory -l virtual-login01 -e '{"nvidia_driver_force_install": true}' playbooks/nvidia-software/nvidia-driver.yml
```

After running the playbook, log in and verify that the driver packages are installed:

```
vagrant@ubuntu1804:~$ dpkg -l | grep nvidia
ii  libnvidia-cfg1-450-server:amd64       450.102.04-0ubuntu0.18.04.1       amd64        NVIDIA binary OpenGL/GLX configuration library
ii  libnvidia-compute-450-server:amd64    450.102.04-0ubuntu0.18.04.1       amd64        NVIDIA libcompute package
ii  nvidia-compute-utils-450-server       450.102.04-0ubuntu0.18.04.1       amd64        NVIDIA compute utilities
ii  nvidia-dkms-450-server                450.102.04-0ubuntu0.18.04.1       amd64        NVIDIA DKMS package
ii  nvidia-headless-450-server            450.102.04-0ubuntu0.18.04.1       amd64        NVIDIA headless metapackage
ii  nvidia-headless-no-dkms-450-server    450.102.04-0ubuntu0.18.04.1       amd64        NVIDIA headless metapackage - no DKMS
ii  nvidia-kernel-common-450-server       450.102.04-0ubuntu0.18.04.1       amd64        Shared files used with the kernel module
ii  nvidia-kernel-source-450-server       450.102.04-0ubuntu0.18.04.1       amd64        NVIDIA kernel source package
ii  nvidia-utils-450-server               450.102.04-0ubuntu0.18.04.1       amd64        NVIDIA Server Driver support binaries
```