### PR TITLE
Install DCGM using the CUDA repositories

### DIFF
--- a/config.example/group_vars/all.yml
+++ b/config.example/group_vars/all.yml
@@ -243,17 +243,7 @@ maas_kvm: false
 ################################################################################
 # NVIDIA Datacenter GPU Manager                                                #
 ################################################################################
-# DCGM is available through package repositories for DGX, but for other host
-# types you must download from the NVIDIA Developer portal at
-# https://developer.nvidia.com/dcgm
-# To install DCGM, please download the correct package type(s) and set the
-# following variables to a path where the file exists on the Ansible control
-# machine.
-#
-# dcgm_rpm_package: "/tmp/datacenter-gpu-manager.rpm"
-# dcgm_deb_package: "/tmp/datacenter-gpu-manager.deb"
-
-install_dcgm: false
+install_dcgm: true 
 
 ################################################################################
 # Misc.                                                                        #

--- a/config.example/group_vars/all.yml
+++ b/config.example/group_vars/all.yml
@@ -130,7 +130,7 @@ gpu_clock_lock: "1507,1507"
 ################################################################################
 # Docker configuration
 # Playbook: docker, nvidia-docker, k8s-cluster
-# 
+#
 # For supported Docker versions, see: kubespray/roles/container-engine/docker/vars/*
 docker_install: yes
 docker_version: '19.03'
@@ -243,7 +243,7 @@ maas_kvm: false
 ################################################################################
 # NVIDIA Datacenter GPU Manager                                                #
 ################################################################################
-install_dcgm: true 
+install_dcgm: true
 
 ################################################################################
 # Misc.                                                                        #

--- a/docs/deepops/architecture.md
+++ b/docs/deepops/architecture.md
@@ -1,0 +1,28 @@
+DeepOps project architecture
+============================
+
+
+Ansible
+-------
+
+### Playbooks
+
+
+### Roles
+
+
+### Configuration
+
+
+Scripts
+-------
+
+
+Workloads
+---------
+
+
+Virtual
+-------
+
+

--- a/roles/nvidia-dcgm/defaults/main.yml
+++ b/roles/nvidia-dcgm/defaults/main.yml
@@ -1,14 +1,12 @@
 ---
-# DCGM is available through package repositories for DGX, but for other host
-# types you must download from the NVIDIA Developer portal at
-# https://developer.nvidia.com/dcgm
-# To install DCGM, please download the correct package type(s) and set the
-# following variables to a path where the file exists on the Ansible control
-# machine.
-#
-# dcgm_rpm_package: "/tmp/datacenter-gpu-manager.rpm"
-# dcgm_deb_package: "/tmp/datacenter-gpu-manager.deb"
+dcgm_pkg_name: "datacenter-gpu-manager"
 
-# Location where the packages will be copied on the nodes
-dcgm_rpm_dest_path: "/tmp/datacenter-gpu-manager.rpm"
-dcgm_deb_dest_path: "/tmp/datacenter-gpu-manager.deb"
+# RedHat family
+epel_package: "https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm"
+nvidia_driver_rhel_cuda_repo_baseurl: "https://developer.download.nvidia.com/compute/cuda/repos/{{ _rhel_repo_dir }}/"
+nvidia_driver_rhel_cuda_repo_gpgkey: "https://developer.download.nvidia.com/compute/cuda/repos/{{ _rhel_repo_dir }}/7fa2af80.pub"
+
+# Ubuntu
+nvidia_driver_ubuntu_cuda_repo_gpgkey_url: "https://developer.download.nvidia.com/compute/cuda/repos/{{ _ubuntu_repo_dir }}/7fa2af80.pub"
+nvidia_driver_ubuntu_cuda_repo_gpgkey_id: "7fa2af80"
+nvidia_driver_ubuntu_cuda_repo_baseurl: "https://developer.download.nvidia.com/compute/cuda/repos/{{ _ubuntu_repo_dir }}"

--- a/roles/nvidia-dcgm/files/cuda-ubuntu.pin
+++ b/roles/nvidia-dcgm/files/cuda-ubuntu.pin
@@ -1,0 +1,3 @@
+Package: *
+Pin: release l=NVIDIA CUDA
+Pin-Priority: 600

--- a/roles/nvidia-dcgm/tasks/install-redhat.yml
+++ b/roles/nvidia-dcgm/tasks/install-redhat.yml
@@ -2,7 +2,7 @@
 - name: RedHat | add epel repo
   become: yes
   yum:
-    name: 
+    name:
       - "{{ epel_package }}"
     state: latest
   environment: "{{proxy_env if proxy_env is defined else {}}}"

--- a/roles/nvidia-dcgm/tasks/install-redhat.yml
+++ b/roles/nvidia-dcgm/tasks/install-redhat.yml
@@ -1,18 +1,21 @@
 ---
-- name: ensure package var is defined
-  fail:
-    msg: "dcgm_rpm_package must be defined with file path to package"
-  when: dcgm_rpm_package is not defined
-
-- name: copy rpm to nodes
-  copy:
-    src: "{{ dcgm_rpm_package }}"
-    dest: "{{ dcgm_rpm_dest_path }}"
-    owner: "root"
-    group: "root"
-    mode: "0644"
-
-- name: install package
+- name: RedHat | add epel repo
+  become: yes
   yum:
-    name: "{{ dcgm_rpm_dest_path }}"
+    name: 
+      - "{{ epel_package }}"
+    state: latest
+  environment: "{{proxy_env if proxy_env is defined else {}}}"
+
+- name: RedHat | add CUDA repo
+  yum_repository:
+    name: cuda
+    description: NVIDIA CUDA YUM Repo
+    baseurl: "{{ nvidia_driver_rhel_cuda_repo_baseurl }}"
+    gpgkey: "{{ nvidia_driver_rhel_cuda_repo_gpgkey }}"
+  environment: "{{proxy_env if proxy_env is defined else {}}}"
+
+- name: RedHat | install package
+  package:
+    name: "{{ dcgm_pkg_name }}"
     state: "present"

--- a/roles/nvidia-dcgm/tasks/install-ubuntu.yml
+++ b/roles/nvidia-dcgm/tasks/install-ubuntu.yml
@@ -1,18 +1,25 @@
 ---
-- name: ensure package var is defined
-  fail:
-    msg: "dcgm_deb_package must be defined with file path to package"
-  when: dcgm_deb_package is not defined
-
-- name: copy deb to nodes
+- name: Ubuntu | add pin file
   copy:
-    src: "{{ dcgm_deb_package }}"
-    dest: "{{ dcgm_deb_dest_path }}"
+    src: "cuda-ubuntu.pin"
+    dest: "/etc/apt/preferences.d/cuda-repository-pin-600"
     owner: "root"
     group: "root"
     mode: "0644"
 
-- name: install package
+- name: Ubuntu | add key
+  apt_key:
+    url: "{{ nvidia_driver_ubuntu_cuda_repo_gpgkey_url }}"
+    id: "{{ nvidia_driver_ubuntu_cuda_repo_gpgkey_id }}"
+  environment: "{{proxy_env if proxy_env is defined else {}}}"
+
+- name: Ubuntu | add CUDA repo
+  apt_repository:
+    repo: "deb {{ nvidia_driver_ubuntu_cuda_repo_baseurl }} /"
+    update_cache: yes
+  environment: "{{proxy_env if proxy_env is defined else {}}}"
+
+- name: Ubuntu | install package
   apt:
-    deb: "{{ dcgm_deb_dest_path }}"
+    deb: "{{ dcgm_pkg_name }}"
     state: "present"

--- a/roles/nvidia-dcgm/tasks/install-ubuntu.yml
+++ b/roles/nvidia-dcgm/tasks/install-ubuntu.yml
@@ -21,5 +21,5 @@
 
 - name: Ubuntu | install package
   apt:
-    deb: "{{ dcgm_pkg_name }}"
+    name: "{{ dcgm_pkg_name }}"
     state: "present"

--- a/roles/nvidia-dcgm/tasks/main.yml
+++ b/roles/nvidia-dcgm/tasks/main.yml
@@ -19,6 +19,6 @@
 - name: Start the DCGM service
   systemd:
     daemon_reload: yes
-    name: "dcgm"
+    name: "nvidia-dcgm"
     state: "started"
     enabled: true

--- a/roles/nvidia-dcgm/vars/main.yml
+++ b/roles/nvidia-dcgm/vars/main.yml
@@ -1,2 +1,4 @@
 ---
 dcgm_is_dgx: false
+_ubuntu_repo_dir: "{{ ansible_distribution | lower }}{{ ansible_distribution_version | replace('.', '') }}/{{ ansible_architecture }}"
+_rhel_repo_dir: "rhel{{ ansible_distribution_major_version }}/{{ ansible_architecture }}"


### PR DESCRIPTION
## Summary

Since DCGM is now open source, the user does not need to manually download the package using their NVIDIA Developer account. Instead, DCGM can be installed directly from the CUDA repositories.

This PR replaces the "manual download and install" flow with the recommended installation flow from the [DCGM download page](https://developer.nvidia.com/dcgm#Downloads).

We also enable DCGM by default in the Slurm and NGC Ready top-level playbooks.

## Test plan

Run the DCGM playbook without doing anything special for package downloads:

```
$ ansible-playbook --flush-cache -i virtual/config/inventory -l virtual-gpu01 playbooks/nvidia-software/nvidia-dcgm.yml
```

Confirm the playbook executes successfully, and that dcgm is now installed:

```
vagrant@ubuntu1804:~$ dpkg -l | grep datacenter
ii  datacenter-gpu-manager                1:2.1.7                           amd64        NVIDIA® Datacenter GPU Management Tools
```

We should also expect to see this playbook succeed in CI tests now that it's enabled by default in configuration.