### PR TITLE
Add better/consistent vagrant cleanup to jenkins vagrant-startup script

### DIFF
--- a/workloads/jenkins/Jenkinsfile-matrix
+++ b/workloads/jenkins/Jenkinsfile-matrix
@@ -197,6 +197,24 @@ for(int i = 0; i < axes.size(); i++) {
               '''
             }
           }
+          stage("cleanup-${DEEPOPS_DEPLOYMENT_PLATFORM}-${DEEPOPS_VAGRANT_OS}-${DEEPOPS_FULL_INSTALL}") {
+              echo "Reset repo and unmunge files"
+              sh '''
+                git reset --hard
+                rm -rf config
+              '''
+
+              echo "Munge files for testing"
+              sh '''
+                bash -x ./workloads/jenkins/scripts/munge-files.sh
+              '''
+
+              echo "Tear down any Vagrant that was not cleaned up"
+              sh '''
+                pwd
+                cd virtual && ./vagrant_shutdown.sh || true
+              '''
+          }
         }
         // TODO: There seems to be a bug here if tasks fail, they do not get cleaned up properly
         // XXX: Not sure if the cleanup should live inside or outside of the lock. Also, this doesn't seem to work.

--- a/workloads/jenkins/Jenkinsfile-multi-nightly
+++ b/workloads/jenkins/Jenkinsfile-multi-nightly
@@ -83,9 +83,7 @@ pipeline {
 
           echo "Start new virtual environment pre-GPU Operator checks"
           sh '''
-            cd virtual
-            bash -x ./vagrant_shutdown.sh
-            bash -x ./vagrant_startup.sh
+            bash -x ./workloads/jenkins/scripts/vagrant-startup.sh
           '''
 
           echo "Cluster Up - Multiple GPU & MGMT Nodes"
@@ -108,9 +106,7 @@ pipeline {
 
           echo "Start new virtual environment pre-Slurm checks"
           sh '''
-            cd virtual
-            bash -x ./vagrant_shutdown.sh
-            bash -x ./vagrant_startup.sh
+            bash -x ./workloads/jenkins/scripts/vagrant-startup.sh
           '''
 
           echo "Set up Slurm"
@@ -226,9 +222,7 @@ pipeline {
 
           echo "Start new virtual environment pre-Slurm checks"
           sh '''
-            cd virtual
-            bash -x ./vagrant_shutdown.sh
-            bash -x ./vagrant_startup.sh
+            bash -x ./workloads/jenkins/scripts/vagrant-startup.sh
           '''
 
           echo "Set up Slurm"
@@ -356,9 +350,7 @@ pipeline {
 
           echo "Start new virtual environment pre-Slurm checks"
           sh '''
-            cd virtual
-            bash -x ./vagrant_shutdown.sh
-            bash -x ./vagrant_startup.sh
+            bash -x ./workloads/jenkins/scripts/vagrant-startup.sh
           '''
 
           echo "Set up Slurm"
@@ -475,9 +467,7 @@ pipeline {
 
           echo "Start new virtual environment pre-Slurm checks"
           sh '''
-            cd virtual
-            bash -x ./vagrant_shutdown.sh
-            bash -x ./vagrant_startup.sh
+            bash -x ./workloads/jenkins/scripts/vagrant-startup.sh
           '''
 
           echo "Set up Slurm"

--- a/workloads/jenkins/Jenkinsfile-nightly
+++ b/workloads/jenkins/Jenkinsfile-nightly
@@ -83,9 +83,7 @@ pipeline {
 
           echo "Start new virtual environment pre-GPU Operator checks"
           sh '''
-            cd virtual
-            bash -x ./vagrant_shutdown.sh
-            bash -x ./vagrant_startup.sh
+            bash -x ./workloads/jenkins/scripts/vagrant-startup.sh
           '''
 
           echo "Cluster Up - MGMT Nodes"
@@ -108,9 +106,7 @@ pipeline {
 
           echo "Start new virtual environment pre-Slurm checks"
           sh '''
-            cd virtual
-            bash -x ./vagrant_shutdown.sh
-            bash -x ./vagrant_startup.sh
+            bash -x ./workloads/jenkins/scripts/vagrant-startup.sh
           '''
 
           echo "Set up Slurm"
@@ -226,9 +222,7 @@ pipeline {
 
           echo "Start new virtual environment pre-Slurm checks"
           sh '''
-            cd virtual
-            bash -x ./vagrant_shutdown.sh
-            bash -x ./vagrant_startup.sh
+            bash -x ./workloads/jenkins/scripts/vagrant-startup.sh
           '''
 
           echo "Set up Slurm"
@@ -335,9 +329,7 @@ pipeline {
 
           echo "Start new virtual environment pre-GPU Operator checks"
           sh '''
-            cd virtual
-            bash -x ./vagrant_shutdown.sh
-            bash -x ./vagrant_startup.sh
+            bash -x ./workloads/jenkins/scripts/vagrant-startup.sh
           '''
 
           echo "Cluster Up - MGMT Nodes"
@@ -359,9 +351,7 @@ pipeline {
 
           echo "Start new virtual environment pre-Slurm checks"
           sh '''
-            cd virtual
-            bash -x ./vagrant_shutdown.sh
-            bash -x ./vagrant_startup.sh
+            bash -x ./workloads/jenkins/scripts/vagrant-startup.sh
           '''
 
           echo "Set up Slurm"
@@ -468,9 +458,7 @@ pipeline {
 
           echo "Start new virtual environment pre-Slurm checks"
           sh '''
-            cd virtual
-            bash -x ./vagrant_shutdown.sh
-            bash -x ./vagrant_startup.sh
+            bash -x ./workloads/jenkins/scripts/vagrant-startup.sh
           '''
 
           echo "Set up Slurm"

--- a/workloads/jenkins/scripts/vagrant-startup.sh
+++ b/workloads/jenkins/scripts/vagrant-startup.sh
@@ -3,6 +3,7 @@ set -ex
 source workloads/jenkins/scripts/jenkins-common.sh
 
 cd virtual || exit 1
+bash ./vagrant_shutdown.sh || true # Some previous VMs may not have been cleaned; this may fail if the environment is clean; so we proceed regardless
 bash ./vagrant_startup.sh # If this fails the entire test should halt
 cat virtual_inventory* # We can't look at config/inventory because that is created after this step
 cat Vagrantfile


### PR DESCRIPTION
This adds a call to vagrant_shutdown in the Jenkins vagrant-startup scrip.

There were a few edge-cases in the nightly testing where tests were not properly cleaning up after a failure and then causing the next tests to fail. This will address that last cleanup edge case.