### PR TITLE
Update Trident deployment role to use Helm chart

### DIFF
--- a/config.example/group_vars/netapp-trident.yml
+++ b/config.example/group_vars/netapp-trident.yml
@@ -89,6 +89,30 @@ storageClasses_to_create:
       backendType: "ontap-nas-flexgroup"
   # Add additional StorageClasses as needed
 
+# Denotes whether or not to enable volume snapshots in your Kubernetes cluster
+# For more info, refer to: https://netapp-trident.readthedocs.io/en/stable-v21.01/kubernetes/operations/tasks/volumes/snapshots.html
+enable_volume_snapshots: true
+
+# List of volume snapshot CRDs to create
+volume_snapshot_CRD_manifest_URLs:
+  - https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/release-3.0/client/config/crd/snapshot.storage.k8s.io_volumesnapshotclasses.yaml
+  - https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/release-3.0/client/config/crd/snapshot.storage.k8s.io_volumesnapshotcontents.yaml
+  - https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/release-3.0/client/config/crd/snapshot.storage.k8s.io_volumesnapshots.yaml
+
+# List of snapshot controller manifest URLs
+snapshot_controller_manifest_URLs:
+  - https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/release-3.0/deploy/kubernetes/snapshot-controller/rbac-snapshot-controller.yaml
+  - https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/release-3.0/deploy/kubernetes/snapshot-controller/setup-snapshot-controller.yaml
+
+# List of volume snapshot classes to create
+volume_snapshot_classes_to_create:
+  - apiVersion: snapshot.storage.k8s.io/v1beta1
+    kind: VolumeSnapshotClass
+    metadata:
+      name: csi-snapclass
+    driver: csi.trident.netapp.io
+    deletionPolicy: Delete
+
 # Denotes whether or not to copy tridenctl binary to localhost
 copy_tridentctl_to_localhost: true
 # Directory that tridentctl will be copied to on localhost

--- a/config.example/group_vars/netapp-trident.yml
+++ b/config.example/group_vars/netapp-trident.yml
@@ -6,7 +6,7 @@ trident_version: "21.01.2"
 trident_installer_url: "https://github.com/NetApp/trident/releases/download/v{{ trident_version }}/trident-installer-{{ trident_version }}.tar.gz"
 
 # Namespace to install Trident in
-trident_namespace: trident
+trident_namespace: deepops-trident
 
 # Denotes whether or not to create new backends after deploying trident
 # For more info, refer to: https://netapp-trident.readthedocs.io/en/stable-v20.04/kubernetes/operator-install.html#creating-a-trident-backend

--- a/config.example/group_vars/netapp-trident.yml
+++ b/config.example/group_vars/netapp-trident.yml
@@ -2,14 +2,11 @@
 # vars file for netapp-trident playbook
 
 # URL of the Trident installer package that you wish to download and use
-trident_version: "20.07.0"
+trident_version: "21.01.2"
 trident_installer_url: "https://github.com/NetApp/trident/releases/download/v{{ trident_version }}/trident-installer-{{ trident_version }}.tar.gz"
 
-# Kubernetes version
-# Note: Do not include patch version, e.g. provide value of 1.16, not 1.16.7.
-# Note: Versions 1.14 and above are supported when deploying Trident with DeepOps.
-#   If you are using an earlier version, you must deploy Trident manually.
-k8s_version: 1.17
+# Namespace to install Trident in
+trident_namespace: trident
 
 # Denotes whether or not to create new backends after deploying trident
 # For more info, refer to: https://netapp-trident.readthedocs.io/en/stable-v20.04/kubernetes/operator-install.html#creating-a-trident-backend
@@ -95,4 +92,4 @@ storageClasses_to_create:
 # Denotes whether or not to copy tridenctl binary to localhost
 copy_tridentctl_to_localhost: true
 # Directory that tridentctl will be copied to on localhost
-tridentctl_copy_to_directory: ../ # will be copied to 'deepops/' directory
+tridentctl_copy_to_directory: ../../ # will be copied to 'deepops/' directory

--- a/docs/k8s-cluster/README.md
+++ b/docs/k8s-cluster/README.md
@@ -152,16 +152,16 @@ Deploy NetApp Trident for services that require persistent storage (such as Kube
 3. Verify that Trident is running.
 
    ```sh
-   ./tridentctl -n trident version
+   ./tridentctl -n deepops-trident version
    ```
 
-   Output of the above command should be:
+   Output of the above command should resemble the following:
 
    ```sh
    +----------------+----------------+
    | SERVER VERSION | CLIENT VERSION |
    +----------------+----------------+
-   | 20.04.0        | 20.04.0        |
+   | 21.01.2        | 21.01.2        |
    +----------------+----------------+
    ```
 

--- a/playbooks/k8s-cluster/netapp-trident.yml
+++ b/playbooks/k8s-cluster/netapp-trident.yml
@@ -20,6 +20,6 @@
   become: true
   become_method: sudo
   vars_files:
-    - ../config/group_vars/netapp-trident.yml
+    - ../../config/group_vars/netapp-trident.yml
   roles:
     - role: netapp-trident

--- a/roles/netapp-trident/README.md
+++ b/roles/netapp-trident/README.md
@@ -10,6 +10,7 @@ Requirements
 
 1. 'kubectl' must be installed on the target host.
 2. '~/.kube/config' must be configured, on the target host, for access to the cluster that you wish to deploy Trident to.
+3. 'helm' must be installed on the target host.
 
 Role Variables
 --------------
@@ -19,7 +20,7 @@ See defaults/main.yml, vars/main.yml
 Dependencies
 ------------
 
-Roles: openshift (https://github.com/mboglesby/deepops/tree/master/roles/openshift)
+Kubernetes must have already been deployed using DeepOps.
 
 Example Playbooks
 ----------------

--- a/roles/netapp-trident/defaults/main.yml
+++ b/roles/netapp-trident/defaults/main.yml
@@ -89,6 +89,30 @@ storageClasses_to_create:
       backendType: "ontap-nas-flexgroup"
   # Add additional StorageClasses as needed
 
+# Denotes whether or not to enable volume snapshots in your Kubernetes cluster
+# For more info, refer to: https://netapp-trident.readthedocs.io/en/stable-v21.01/kubernetes/operations/tasks/volumes/snapshots.html
+enable_volume_snapshots: true
+
+# List of volume snapshot CRDs to create
+volume_snapshot_CRD_manifest_URLs:
+  - https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/release-3.0/client/config/crd/snapshot.storage.k8s.io_volumesnapshotclasses.yaml
+  - https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/release-3.0/client/config/crd/snapshot.storage.k8s.io_volumesnapshotcontents.yaml
+  - https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/release-3.0/client/config/crd/snapshot.storage.k8s.io_volumesnapshots.yaml
+
+# List of snapshot controller manifest URLs
+snapshot_controller_manifest_URLs:
+  - https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/release-3.0/deploy/kubernetes/snapshot-controller/rbac-snapshot-controller.yaml
+  - https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/release-3.0/deploy/kubernetes/snapshot-controller/setup-snapshot-controller.yaml
+
+# List of volume snapshot classes to create
+volume_snapshot_classes_to_create:
+  - apiVersion: snapshot.storage.k8s.io/v1beta1
+    kind: VolumeSnapshotClass
+    metadata:
+      name: csi-snapclass
+    driver: csi.trident.netapp.io
+    deletionPolicy: Delete
+
 # Denotes whether or not to copy tridenctl binary to localhost
 copy_tridentctl_to_localhost: true
 # Directory that tridentctl will be copied to on localhost

--- a/roles/netapp-trident/defaults/main.yml
+++ b/roles/netapp-trident/defaults/main.yml
@@ -2,14 +2,11 @@
 # defaults file for netapp-trident role
 
 # URL of the Trident installer package that you wish to download and use
-trident_version: "20.07.0"
+trident_version: "21.01.2"
 trident_installer_url: "https://github.com/NetApp/trident/releases/download/v{{ trident_version }}/trident-installer-{{ trident_version }}.tar.gz"
 
-# Kubernetes version
-# Note: Do not include patch version, e.g. provide value of 1.16, not 1.16.7.
-# Note: Versions 1.14 and above are supported when deploying Trident with DeepOps.
-#   If you are using an earlier version, you must deploy Trident manually.
-k8s_version: 1.16
+# Namespace to install Trident in
+trident_namespace: trident
 
 # Denotes whether or not to create new backends after deploying trident
 # For more info, refer to: https://netapp-trident.readthedocs.io/en/stable-v20.04/kubernetes/operator-install.html#creating-a-trident-backend

--- a/roles/netapp-trident/meta/main.yml
+++ b/roles/netapp-trident/meta/main.yml
@@ -1,3 +1,0 @@
----
-dependencies:
-  - role: openshift

--- a/roles/netapp-trident/tasks/main.yml
+++ b/roles/netapp-trident/tasks/main.yml
@@ -4,13 +4,13 @@
 - name: Download and extract Trident installer
   unarchive:
     src: '{{ trident_installer_url }}'
-    dest: /root
+    dest: '{{ deepops_dir }}'
     remote_src: yes
 
 - name: Copy namespace config file to control node
   template:
     src: namespace.j2
-    dest: /root/trident-installer/namespace.yaml
+    dest: '{{ deepops_dir }}/trident-installer/namespace.yaml'
   run_once: true
 
 - name: Create Trident namespace
@@ -18,24 +18,24 @@
     state: present
     resource: Namespace
     name: trident
-    filename: /root/trident-installer/namespace.yaml
+    filename: '{{ deepops_dir }}/trident-installer/namespace.yaml'
   run_once: true
 
 - name: Install Trident using Helm
-  command: /usr/local/bin/helm -n trident install trident /root/trident-installer/helm/trident-operator-{{ trident_version }}.tgz
+  command: '/usr/local/bin/helm -n trident install trident {{ deepops_dir }}/trident-installer/helm/trident-operator-{{ trident_version }}.tgz'
   run_once: true
 
 - name: Copy backend config file(s) to control node
   template:
     src: backend.j2
-    dest: /root/trident-installer/backend-{{ item.backendName }}.json
-  with_items: "{{ backends_to_create }}"
+    dest: '{{ deepops_dir }}/trident-installer/backend-{{ item.backendName }}.json'
+  with_items: '{{ backends_to_create }}'
   when: create_backends == true
   run_once: true
 
 - name: Create Trident backend(s)
-  command: /root/trident-installer/tridentctl -n trident create backend -f /root/trident-installer/backend-{{ item.backendName }}.json
-  with_items: "{{ backends_to_create }}"
+  command: '{{ deepops_dir }}/trident-installer/tridentctl -n trident create backend -f {{ deepops_dir }}/trident-installer/backend-{{ item.backendName }}.json'
+  with_items: '{{ backends_to_create }}'
   retries: 10
   delay: 30
   register: result
@@ -45,8 +45,8 @@
 
 - name: Copy StorageClass config file(s) to control node
   copy:
-    content: "{{ item }}"
-    dest: /root/trident-installer/sc-{{ item.metadata.name }}.yaml
+    content: '{{ item }}'
+    dest: '{{ deepops_dir }}/trident-installer/sc-{{ item.metadata.name }}.yaml'
   with_items: "{{ storageClasses_to_create }}"
   when: create_StorageClasses == true
   run_once: true
@@ -56,15 +56,15 @@
     state: present
     resource: StorageClass
     name: "{{ item.metadata.name }}"
-    filename: /root/trident-installer/sc-{{ item.metadata.name }}.yaml
-  with_items: "{{ storageClasses_to_create }}"
+    filename: '{{ deepops_dir }}/trident-installer/sc-{{ item.metadata.name }}.yaml'
+  with_items: '{{ storageClasses_to_create }}'
   when: create_StorageClasses == true
   run_once: true
 
 - name: Fetch tridentctl from control node
   fetch:
-    src: /root/trident-installer/tridentctl
-    dest: "{{ tridentctl_copy_to_directory }}"
+    src: '{{ deepops_dir }}/trident-installer/tridentctl'
+    dest: '{{ tridentctl_copy_to_directory }}'
     flat: yes
   when: copy_tridentctl_to_localhost == true
   run_once: true

--- a/roles/netapp-trident/tasks/main.yml
+++ b/roles/netapp-trident/tasks/main.yml
@@ -7,153 +7,23 @@
     dest: /root
     remote_src: yes
 
-- name: Create Trident namespace (ubuntu)
-  k8s:
+- name: Copy namespace config file to control node
+  template:
+    src: namespace.j2
+    dest: /root/trident-installer/namespace.yaml
+  run_once: true
+
+- name: Create Trident namespace
+  kube:
     state: present
-    kind: Namespace
+    resource: Namespace
     name: trident
-    wait: yes
+    filename: /root/trident-installer/namespace.yaml
   run_once: true
-  environment:
-    PYTHONHOME: '{{ deepops_venv }}'
-  when: ansible_distribution == 'Ubuntu'
 
-- name: Create Trident namespace (Red Hat / CentOS)
-  k8s:
-    state: present
-    kind: Namespace
-    name: trident
-    wait: yes
+- name: Install Trident using Helm
+  command: /usr/local/bin/helm -n trident install trident /root/trident-installer/helm/trident-operator-{{ trident_version }}.tgz
   run_once: true
-  when: ansible_os_family == 'RedHat'
-
-- name: Create TridentProvisioner CRD (K8s version >= 1.16) (Ubuntu)
-  k8s:
-    state: present
-    src: /root/trident-installer/deploy/crds/trident.netapp.io_tridentprovisioners_crd_post1.16.yaml
-    wait: yes
-  run_once: true
-  environment:
-    PYTHONHOME: '{{ deepops_venv }}'
-  when: k8s_version >= 1.16 and ansible_distribution == 'Ubuntu'
-
-- name: Create TridentProvisioner CRD (K8s version >= 1.16) (Red Hat / CentOS)
-  k8s:
-    state: present
-    src: /root/trident-installer/deploy/crds/trident.netapp.io_tridentprovisioners_crd_post1.16.yaml
-    wait: yes
-  run_once: true
-  when: k8s_version >= 1.16 and ansible_os_family == 'RedHat'
-
-- name: Create TridentProvisioner CRD (K8s version < 1.16) (Ubuntu)
-  k8s:
-    state: present
-    src: /root/trident-installer/deploy/crds/trident.netapp.io_tridentprovisioners_crd_pre1.16.yaml
-    wait: yes
-  run_once: true
-  environment:
-    PYTHONHOME: '{{ deepops_venv }}'
-  when: k8s_version < 1.16 and ansible_distribution == 'Ubuntu'
-
-- name: Create TridentProvisioner CRD (K8s version < 1.16) (Red Hat / CentOS)
-  k8s:
-    state: present
-    src: /root/trident-installer/deploy/crds/trident.netapp.io_tridentprovisioners_crd_pre1.16.yaml
-    wait: yes
-  run_once: true
-  when: k8s_version < 1.16 and ansible_os_family == 'RedHat'
-
-- name: Deploy Trident operator resources (Ubuntu)
-  k8s:
-    state: present
-    src: /root/trident-installer/deploy/bundle.yaml
-    wait: yes
-  run_once: true
-  environment:
-    PYTHONHOME: '{{ deepops_venv }}'
-  when: ansible_distribution == 'Ubuntu'
-
-- name: Deploy Trident operator resources (Red Hat / CentOS)
-  k8s:
-    state: present
-    src: /root/trident-installer/deploy/bundle.yaml
-    wait: yes
-  run_once: true
-  when: ansible_os_family == 'RedHat'
-
-- name: Create TridentProvisioner CR (Ubuntu)
-  k8s:
-    state: present
-    src: /root/trident-installer/deploy/crds/tridentprovisioner_cr.yaml
-    wait: yes
-  run_once: true
-  environment:
-    PYTHONHOME: '{{ deepops_venv }}'
-  when: ansible_distribution == 'Ubuntu'
-
-- name: Create TridentProvisioner CR (Red Hat / CentOS)
-  k8s:
-    state: present
-    src: /root/trident-installer/deploy/crds/tridentprovisioner_cr.yaml
-    wait: yes
-  run_once: true
-  when: ansible_os_family == 'RedHat'
-
-- name: Wait until trident-csi Deployment exists (Ubuntu)
-  k8s_info:
-    kind: Deployment
-    namespace: trident
-    name: trident-csi
-  register: deployment_trident_csi
-  until: deployment_trident_csi.resources | length == 1
-  retries: 24
-  delay: 5
-  run_once: true
-  environment:
-    PYTHONHOME: '{{ deepops_venv }}'
-  when: ansible_distribution == 'Ubuntu'
-
-- name: Wait until trident-csi Deployment exists (Red Hat / CentOS)
-  k8s_info:
-    kind: Deployment
-    namespace: trident
-    name: trident-csi
-  register: deployment_trident_csi
-  until: deployment_trident_csi.resources | length == 1
-  retries: 24
-  delay: 5
-  run_once: true
-  when: ansible_os_family == 'RedHat'
-
-- name: Pause for 10 seconds
-  pause:
-    seconds: 10
-
-- name: Wait until trident-csi Deployment is ready (Ubuntu)
-  k8s_info:
-    kind: Deployment
-    namespace: trident
-    name: trident-csi
-  register: deployment_trident_csi
-  until: deployment_trident_csi.resources[0].status.availableReplicas == 1
-  retries: 24
-  delay: 5
-  run_once: true
-  environment:
-    PYTHONHOME: '{{ deepops_venv }}'
-  when: ansible_distribution == 'Ubuntu'
-
-- name: Wait until trident-csi Deployment is ready (Red Hat / CentOS)
-  k8s_info:
-    kind: Deployment
-    namespace: trident
-    name: trident-csi
-  register: deployment_trident_csi
-  until: deployment_trident_csi.resources[0].status.availableReplicas == 1
-  retries: 24
-  delay: 5
-  run_once: true
-  when: ansible_os_family == 'RedHat'
 
 - name: Copy backend config file(s) to control node
   template:
@@ -166,26 +36,30 @@
 - name: Create Trident backend(s)
   command: /root/trident-installer/tridentctl -n trident create backend -f /root/trident-installer/backend-{{ item.backendName }}.json
   with_items: "{{ backends_to_create }}"
+  retries: 10
+  delay: 30
+  register: result
+  until: result.rc == 0
   when: create_backends == true
   run_once: true
 
-- name: Create NetApp StorageClass(es) (Ubuntu)
-  k8s:
-    state: present
-    definition: "{{ item }}"
+- name: Copy StorageClass config file(s) to control node
+  copy:
+    content: "{{ item }}"
+    dest: /root/trident-installer/sc-{{ item.metadata.name }}.yaml
   with_items: "{{ storageClasses_to_create }}"
+  when: create_StorageClasses == true
   run_once: true
-  environment:
-    PYTHONHOME: '{{ deepops_venv }}'
-  when: create_StorageClasses == true and ansible_distribution == 'Ubuntu'
 
-- name: Create NetApp StorageClass(es) (Red Hat / CentOS)
-  k8s:
+- name: Create StorageClasses
+  kube:
     state: present
-    definition: "{{ item }}"
+    resource: StorageClass
+    name: "{{ item.metadata.name }}"
+    filename: /root/trident-installer/sc-{{ item.metadata.name }}.yaml
   with_items: "{{ storageClasses_to_create }}"
+  when: create_StorageClasses == true
   run_once: true
-  when: create_StorageClasses == true and ansible_os_family == 'RedHat'
 
 - name: Fetch tridentctl from control node
   fetch:

--- a/roles/netapp-trident/tasks/main.yml
+++ b/roles/netapp-trident/tasks/main.yml
@@ -22,7 +22,7 @@
   run_once: true
 
 - name: Install Trident using Helm
-  command: '/usr/local/bin/helm -n trident install trident {{ deepops_dir }}/trident-installer/helm/trident-operator-{{ trident_version }}.tgz'
+  command: '/usr/local/bin/helm -n {{ trident_namespace }} install trident {{ deepops_dir }}/trident-installer/helm/trident-operator-{{ trident_version }}.tgz'
   run_once: true
 
 - name: Copy backend config file(s) to control node
@@ -34,7 +34,7 @@
   run_once: true
 
 - name: Create Trident backend(s)
-  command: '{{ deepops_dir }}/trident-installer/tridentctl -n trident create backend -f {{ deepops_dir }}/trident-installer/backend-{{ item.backendName }}.json'
+  command: '{{ deepops_dir }}/trident-installer/tridentctl -n {{ trident_namespace }} create backend -f {{ deepops_dir }}/trident-installer/backend-{{ item.backendName }}.json'
   with_items: '{{ backends_to_create }}'
   retries: 10
   delay: 30
@@ -47,7 +47,7 @@
   copy:
     content: '{{ item }}'
     dest: '{{ deepops_dir }}/trident-installer/sc-{{ item.metadata.name }}.yaml'
-  with_items: "{{ storageClasses_to_create }}"
+  with_items: '{{ storageClasses_to_create }}'
   when: create_StorageClasses == true
   run_once: true
 
@@ -55,10 +55,44 @@
   kube:
     state: present
     resource: StorageClass
-    name: "{{ item.metadata.name }}"
+    name: '{{ item.metadata.name }}'
     filename: '{{ deepops_dir }}/trident-installer/sc-{{ item.metadata.name }}.yaml'
   with_items: '{{ storageClasses_to_create }}'
   when: create_StorageClasses == true
+  run_once: true
+
+- name: Create volume snapshot CRDs
+  kube:
+    state: present
+    filename: '{{ item }}'
+  with_items: '{{ volume_snapshot_CRD_manifest_URLs }}'
+  when: enable_volume_snapshots == true
+  run_once: true
+
+- name: Create snapshot controller
+  kube:
+    state: present
+    filename: '{{ item }}'
+  with_items: '{{ snapshot_controller_manifest_URLs }}'
+  when: enable_volume_snapshots == true
+  run_once: true
+
+- name: Copy volume snapshot class config file(s) to control node
+  copy:
+    content: '{{ item }}'
+    dest: '{{ deepops_dir }}/trident-installer/snapclass-{{ item.metadata.name }}.yaml'
+  with_items: '{{ volume_snapshot_classes_to_create }}'
+  when: enable_volume_snapshots == true
+  run_once: true
+
+- name: Create volume snapshot classes
+  kube:
+    state: present
+    resource: VolumeSnapshotClass
+    name: '{{ item.metadata.name }}'
+    filename: '{{ deepops_dir }}/trident-installer/snapclass-{{ item.metadata.name }}.yaml'
+  with_items: '{{ volume_snapshot_classes_to_create }}'
+  when: enable_volume_snapshots == true
   run_once: true
 
 - name: Fetch tridentctl from control node

--- a/roles/netapp-trident/templates/namespace.j2
+++ b/roles/netapp-trident/templates/namespace.j2
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ trident_namespace }}


### PR DESCRIPTION
Updating the 'netapp-trident' role to use the new Trident Helm chart to deploy Trident.