### PR TITLE
Use correct ns when checking helm status of metallb

### DIFF
--- a/scripts/k8s/deploy_ingress.sh
+++ b/scripts/k8s/deploy_ingress.sh
@@ -29,7 +29,7 @@ if ! kubectl version ; then
 fi
 
 # If MetalLB is installed, use LoadBalancer, otherwise use NodePort (unless the user specifies a config)
-if ! helm status metallb >/dev/null 2>&1; then
+if ! helm status metallb -n deepops-loadbalancer >/dev/null 2>&1; then
 	HELM_INGRESS_CONFIG="${HELM_INGRESS_CONFIG:-${ROOT_DIR}/workloads/examples/k8s/ingress-nodeport.yml}"
 else
 	HELM_INGRESS_CONFIG="${HELM_INGRESS_CONFIG:-${ROOT_DIR}/workloads/examples/k8s/ingress-loadbalancer.yml}"

--- a/scripts/k8s/deploy_loadbalancer.sh
+++ b/scripts/k8s/deploy_loadbalancer.sh
@@ -36,7 +36,7 @@ if [ "${METALLB_CONTROLLER_REPO}" ]; then
 fi
 
 # Set up the MetalLB load balancer
-if ! helm status metallb >/dev/null 2>&1; then
+if ! helm status metallb -n deepops-loadbalancer >/dev/null 2>&1; then
 	kubectl create namespace deepops-loadbalancer
 	helm install --wait metallb bitnami/metallb "${helm_install_args[@]}" --version ${HELM_METALLB_CHART_VERSION} --namespace deepops-loadbalancer
 fi


### PR DESCRIPTION
After the metallb deployment got moved to the "deepops-loadbalancer" namespace, the places where the helm status of this deployment is checked fails. Presumably the helm status assumes default namespace if none is specified.  Notably this broke the ingress deployment, making it always deploy  using nodeport.