### PR TITLE
Skips nvidia hpc sdk installation if localrc is already present

### DIFF
--- a/roles/nvidia-hpc-sdk/tasks/main.yml
+++ b/roles/nvidia-hpc-sdk/tasks/main.yml
@@ -1,20 +1,26 @@
 ---
+- name: check for existing nvhpc installation
+  stat:
+    path: "{{ hpcsdk_install_dir }}/Linux_{{ hpcsdk_arch }}/{{ hpcsdk_version_dir }}/compilers/bin/localrc"
+  register: nvhpc_localrc
+
 - name: install dependencies (ubuntu)
   apt:
     name:
     - "gcc"
     - "g++"
     state: present
-  when: ansible_distribution == "Ubuntu"
+  when: ansible_distribution == "Ubuntu" and not nvhpc_localrc.stat.exists
 
 - name: install dependencies (rhel)
   yum:
     name:
     - "gcc"
     - "gcc-c++"
-  when: ansible_os_family == "RedHat"
+  when: ansible_os_family == "RedHat" and not nvhpc_localrc.stat.exists
 
 - name: ensure download and install directories exist
+  when: not nvhpc_localrc.stat.exists
   file:
     path: "{{ item }}"
     state: "directory"
@@ -26,12 +32,14 @@
   - "{{ hpcsdk_install_dir }}"
 
 - name: download nvidia hpc sdk
+  when: not nvhpc_localrc.stat.exists
   get_url:
     url: "{{ hpcsdk_download_url }}"
     dest: "{{ hpcsdk_dest_download_path }}"
     mode: "0444"
 
 - name: extract archive
+  when: not nvhpc_localrc.stat.exists
   unarchive:
     src: "{{ hpcsdk_dest_download_path }}"
     dest: "{{ hpcsdk_temp_dir }}"
@@ -39,6 +47,7 @@
     creates: "{{ hpcsdk_temp_dir }}/{{ hpcsdk_download_name }}/install"
 
 - name: run the installer
+  when: not nvhpc_localrc.stat.exists
   command: "./install"
   args:
     chdir: "{{ hpcsdk_temp_dir }}/{{ hpcsdk_download_name }}"
@@ -50,12 +59,14 @@
     NVHPC_DEFAULT_CUDA: "{{ hpcsdk_default_cuda }}"
 
 - name: clean up the temp directory
+  when: not nvhpc_localrc.stat.exists
   file:
     path: "{{ hpcsdk_temp_dir }}"
     state: absent
   when: hpcsdk_clean_up_temp_dir
 
 - name: run the makelocalrc script
+  when: not nvhpc_localrc.stat.exists
   command: "{{ hpcsdk_install_dir }}/Linux_{{ hpcsdk_arch }}/{{ hpcsdk_version_dir }}/compilers/bin/makelocalrc -x {{ hpcsdk_install_dir }}/Linux_{{ hpcsdk_arch }}/{{ hpcsdk_version_dir }}/compilers"
   args:
     creates: "{{ hpcsdk_install_dir }}/Linux_{{ hpcsdk_arch }}/{{ hpcsdk_version_dir }}/compilers/bin/localrc"


### PR DESCRIPTION
Fixes #933 and greatly speeds up iteration when prototyping changes on a SLURM deployment.