### PR TITLE
Fix spelling for setting Ubuntu version in vagrant

### DIFF
--- a/virtual/vagrant_startup.sh
+++ b/virtual/vagrant_startup.sh
@@ -123,7 +123,7 @@ esac
 # Set up Vagrantfile and start up the configuration in Vagrant
 if [ ${DEEPOPS_FULL_INSTALL} ]; then
   export CENTOS_DEEPOPS_VAGRANT_FILE="${DEEPOPS_VAGRANT_FILE:-${VIRT_DIR}/Vagrantfile-centos${DEEPOPS_OS_VERSION}-full}"
-  export UBUNTU_DEEPOPS_VAGRANT_FILE="${DEEPOPS_VAGRANT_FILE:-${VIRT_DIR}/Vagrantfile-ubuntu${DEPOPS_OS_VERSION}-full}"
+  export UBUNTU_DEEPOPS_VAGRANT_FILE="${DEEPOPS_VAGRANT_FILE:-${VIRT_DIR}/Vagrantfile-ubuntu${DEEPOPS_OS_VERSION}-full}"
 else
   export CENTOS_DEEPOPS_VAGRANT_FILE="${DEEPOPS_VAGRANT_FILE:-${VIRT_DIR}/Vagrantfile-centos}"
   export UBUNTU_DEEPOPS_VAGRANT_FILE="${DEEPOPS_VAGRANT_FILE:-${VIRT_DIR}/Vagrantfile-ubuntu}"


### PR DESCRIPTION
Currently we can't correctly set the version of Ubuntu to 20.04 using our virtual cluster setup, because the env var is mis-spelled in `vagrant_startup.sh`. This PR fixes the spelling mistake.