### PR TITLE
Fix disabling NVIDIA driver install on Slurm cluster install

### DIFF
--- a/playbooks/nvidia-software/nvidia-cuda.yml
+++ b/playbooks/nvidia-software/nvidia-cuda.yml
@@ -19,6 +19,7 @@
       when:
         - ansible_local['gpus']['count']
         - is_dgx.stat.exists == False
+        - cuda_playbook_install_driver|default(true)
       tags:
       - nvidia_driver
 
@@ -31,6 +32,7 @@
       changed_when: false
       when:
         - ansible_local['gpus']['count']
+        - cuda_playbook_install_driver|default(true)
       tags:
       - nvidia_driver
   environment: "{{ proxy_env if proxy_env is defined else{} }}"

--- a/playbooks/slurm-cluster.yml
+++ b/playbooks/slurm-cluster.yml
@@ -31,7 +31,11 @@
   when: slurm_cluster_install_nvidia_driver|default(true)
 
 # Install NVIDIA CUDA Toolkit
+#   Note: the CUDA playbook also installs the driver, so we pass the
+#   appropriate flag to this playbook as well.
 - include: nvidia-software/nvidia-cuda.yml
+  vars:
+     cuda_playbook_install_driver: "{{ slurm_cluster_install_nvidia_driver }}"
   when: slurm_cluster_install_cuda|default(true)
 
 # Install software


### PR DESCRIPTION
The Slurm cluster playbook provides the var `slurm_cluster_install_nvidia_driver` to disable installs of the NVIDIA driver. However, the Slurm cluster playbook also sources the CUDA playbook, which installs the driver itself. And the CUDA playbook does not respect the flag in the Slurm cluster playbook.

Aren't dependencies fun?

This commit adds a flag to the CUDA playbook to allow disabling the driver install, and plumbs it through so the user can set the flag in the Slurm cluster playbook.

To test, set `slurm_cluster_install_nvidia_driver` to false and set up a Slurm cluster, and the driver should not be installed.