### PR TITLE
install python-docker with yum instead of pip

### DIFF
--- a/roles/standalone-container-registry/tasks/main.yml
+++ b/roles/standalone-container-registry/tasks/main.yml
@@ -27,16 +27,10 @@
       - "{{ epel_package }}"
     state: present
   when: ansible_os_family == 'RedHat'
-- name: Install package dependencies
-  package:
+- name: Install python2 Docker dependencies
+  yum:
     name:
-      - python3-pip
-    state: present
-  when: ansible_os_family == "RedHat"
-- name: Install python3 dependencies
-  pip:
-    name:
-      - docker
+      - python-docker
     state: present
   when: ansible_os_family == "RedHat"
 


### PR DESCRIPTION
This was failing for some customers and in the nightly tests.

It looks like the version of CentOS we are testing again is using Pyhon2, so the existing pip3 install was not necessary in this package, nor was it being used. Looking through the logs, the pip install was using pip2 and that seemed to cause some issues in deployment.

I swapped this over to use the built-in python docker packages for CentOS/RHEL and it seems to be working now on CentOS 7 and CentOS 8. I have yet to test on RHEL.