### PR TITLE
remove breaking post directive from jenkinsfile

### DIFF
--- a/workloads/jenkins/Jenkinsfile-matrix
+++ b/workloads/jenkins/Jenkinsfile-matrix
@@ -198,17 +198,6 @@ for(int i = 0; i < axes.size(); i++) {
             }
           }
         }
-        // TODO: There seems to be a bug here if tasks fail, they do not get cleaned up properly
-        // XXX: Not sure if the cleanup should live inside or outside of the lock. Also, this doesn't seem to work.
-        post {
-          always {
-            echo "Final cleanup"
-            sh '''
-              pwd
-              cd virtual && ./vagrant_shutdown.sh
-            '''
-          }
-        }
       }
     }
   }


### PR DESCRIPTION
This is a minor change that lets the Jenkins Matrix job finish.

Without this, the cleanup will fail at the end.