### PR TITLE
Update ingress verification test to check http/https/NodePort and work on multinode

### DIFF
--- a/workloads/jenkins/scripts/verify-ingress-config.sh
+++ b/workloads/jenkins/scripts/verify-ingress-config.sh
@@ -1,14 +1,22 @@
 #!/bin/bash
+
 source workloads/jenkins/scripts/jenkins-common.sh
 
 cd virtual || exit 1
 
 chmod 755 "$K8S_CONFIG_DIR/artifacts/kubectl"
 
-master_ip=$(kubectl get nodes -l node-role.kubernetes.io/master= --no-headers -o custom-columns=IP:.status.addresses.*.address | cut -f1 -d, | head -1)
+master_ip=$(kubectl get endpoints ingress-nginx-controller --no-headers -n deepops-ingress -o custom-columns=ENDPOINTS:.subsets[0].addresses[0].ip)
 
-# TODO: Come up with a better kubectl command here instead of a grep -v, currently two services have the same Selector
-ingress_port=$(kubectl get services --no-headers -l app.kubernetes.io/name=ingress-nginx,app.kubernetes.io/component=controller  -o custom-columns=PORT:.spec.ports.*.nodePort | grep -v none | awk -F, '{print $1}')
+# TODO: Come up with a better kubectl command here instead of a grep -v and head -n1, currently two services have the same Selector
+ingress_port=$(kubectl get services -A --no-headers -l app.kubernetes.io/name=ingress-nginx,app.kubernetes.io/component=controller  -o custom-columns=PORT:.spec.ports.*.nodePort | grep -v none | awk -F, '{print $1}')
+ingress_https_port=$(kubectl get services -A --no-headers -l app.kubernetes.io/name=ingress-nginx,app.kubernetes.io/component=controller  -o custom-columns=PORT:.spec.ports.*.nodePort | grep -v none | awk -F, '{print $2}')
 
-url="http://${master_ip}:${ingress_port}"
-curl ${url}
+# Test http
+curl "http://${master_ip}"
+curl "http://${master_ip}:${ingress_port}"
+
+# Test https
+curl -k "https://${master_ip}"
+curl -k "https://${master_ip}:${ingress_https_port}"
+


### PR DESCRIPTION
Small update to the tests for ingress verification.

This was failing occasionally in the multinode tests if the ingress Pod landed on the wrong mgmt node.

* Check for https and https
* Check proper nodeport
* Get the endpoint IP to use instead of just grabbing any management node.

No testing is needed for this beyond seeing the nightly regressions pass for the multinode and single node runs. See `deepops-matrix/119/`.