### PR TITLE
Bump Slurm version to 20.11.7

### DIFF
--- a/config.example/group_vars/slurm-cluster.yml
+++ b/config.example/group_vars/slurm-cluster.yml
@@ -3,7 +3,7 @@
 ################################################################################
 # Slurm job scheduler configuration
 # Playbook: slurm, slurm-cluster, slurm-perf, slurm-perf-cluster, slurm-validation
-slurm_version: 20.11.3
+slurm_version: 20.11.7
 slurm_install_prefix: /usr/local
 pmix_install_prefix: /opt/deepops/pmix
 hwloc_install_prefix: /opt/deepops/hwloc

--- a/roles/slurm/defaults/main.yml
+++ b/roles/slurm/defaults/main.yml
@@ -5,7 +5,7 @@ hwloc_build_dir: /opt/deepops/build/hwloc
 pmix_build_dir: /opt/deepops/build/pmix
 
 slurm_workflow_build: yes
-slurm_version: 20.11.3
+slurm_version: 20.11.7
 slurm_src_url: "https://download.schedmd.com/slurm/slurm-{{ slurm_version }}.tar.bz2"
 slurm_build_make_clean: no
 slurm_build_dir_cleanup: no


### PR DESCRIPTION
## Summary

SchedMD has published Slurm 20.11.7 which addresses [CVE-2021-31215](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-31215). They've also un-published all the previous vulnerable versions from their website.

This commit bumps the default version of Slurm in DeepOps to 20.11.7.

## Test plan

Passing CI tests