### PR TITLE
Update Jenkinsfiles to cleanup previously botched Vagrant resources at startup

### DIFF
--- a/workloads/jenkins/Jenkinsfile
+++ b/workloads/jenkins/Jenkinsfile
@@ -26,6 +26,12 @@ pipeline {
             bash -x ./workloads/jenkins/scripts/munge-files.sh
           '''
 
+          echo "Tear down any Vagrant that was not cleaned up"
+	    sh '''
+	    pwd
+	    cd virtual && ./vagrant_shutdown.sh || true
+          '''
+
           echo "Vagrant Up"
           sh '''
             bash -x ./workloads/jenkins/scripts/vagrant-startup.sh

--- a/workloads/jenkins/Jenkinsfile-multi-nightly
+++ b/workloads/jenkins/Jenkinsfile-multi-nightly
@@ -26,6 +26,12 @@ pipeline {
             bash -x ./workloads/jenkins/scripts/munge-files.sh
           '''
 
+          echo "Tear down any Vagrant that was not cleaned up"
+          sh '''
+	    pwd
+	    cd virtual && ./vagrant_shutdown.sh || true
+          '''
+
           echo "Vagrant Up"
           sh '''
             bash -x ./workloads/jenkins/scripts/vagrant-startup.sh

--- a/workloads/jenkins/Jenkinsfile-nightly
+++ b/workloads/jenkins/Jenkinsfile-nightly
@@ -26,6 +26,12 @@ pipeline {
             bash -x ./workloads/jenkins/scripts/munge-files.sh
           '''
 
+	  echo "Tear down any Vagrant that was not cleaned up"
+          sh '''
+	    pwd
+	    cd virtual && ./vagrant_shutdown.sh || true
+          '''
+
           echo "Vagrant Up"
           sh '''
             bash -x ./workloads/jenkins/scripts/vagrant-startup.sh


### PR DESCRIPTION
Last night I pushed some changes that brought up a corner-case in our testing. These changes simply attempt a cleanup to any previously botched runs (that did not properly cleanup).

This might add ~30 seconds to each PR test.