### PR TITLE
Bump to latest Ansible 2.9.x and prevent newer versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,11 @@ For detailed help or guidance, read through our [Getting Started Guide](docs/) o
 
 ## Deployment Options
 
+### Supported Ansible versions
+
+DeepOps supports using Ansible 2.9.x.
+Ansible 2.10.x and newer are not currently supported.
+
 ### Supported distributions
 
 DeepOps currently supports the following Linux distributions:

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -8,8 +8,8 @@
 #                         or: curl -sL git.io/deepops | bash -s -- 19.07
 
 # Configuration
-ANSIBLE_VERSION="${ANSIBLE_VERSION:-2.9.5}"     # Ansible version to install
-ANSIBLE_OK="${ANSIBLE_OK:-2.7.8}"               # Oldest allowed Ansible version
+ANSIBLE_VERSION="${ANSIBLE_VERSION:-2.9.21}"     # Ansible version to install
+ANSIBLE_TOO_NEW="${ANSIBLE_TOO_NEW:-2.10.0}"    # Ansible version too new
 CONFIG_DIR="${CONFIG_DIR:-./config}"            # Default configuration directory location
 DEEPOPS_TAG="${1:-master}"                      # DeepOps branch to set up
 JINJA2_VERSION="${JINJA2_VERSION:-2.11.1}"      # Jinja2 required version
@@ -91,6 +91,21 @@ if command -v virtualenv &> /dev/null ; then
     virtualenv -q --python="${PYTHON_BIN}" "${VENV_DIR}"
     . "${VENV_DIR}/bin/activate"
     as_user "${PIP} install -q --upgrade pip"
+
+    # Check for any installed ansible pip package
+    if pip show ansible 2>&1 >/dev/null; then
+        current_version=$(pip show ansible | grep Version | awk '{print $2}')
+	echo "Current version of Ansible is ${current_version}"
+	if "${PYTHON_BIN}" -c "from distutils.version import LooseVersion; print(LooseVersion('$current_version') >= LooseVersion('$ANSIBLE_TOO_NEW'))" | grep True 2>&1 >/dev/null; then
+            echo "Ansible version ${current_version} too new for DeepOps"
+	    echo "Please uninstall any ansible, ansible-base, and ansible-core packages and re-run this script"
+	    exit 1
+	fi
+	if "${PYTHON_BIN}" -c "from distutils.version import LooseVersion; print(LooseVersion('$current_version') < LooseVersion('$ANSIBLE_VERSION'))" | grep True 2>&1 >/dev/null; then
+	    echo "Ansible will be upgraded from ${current_version} to ${ANSIBLE_VERSION}"
+	fi
+    fi
+
     as_user "${PIP} install -q --upgrade \
         ansible==${ANSIBLE_VERSION} \
         Jinja2==${JINJA2_VERSION} \
@@ -100,6 +115,7 @@ if command -v virtualenv &> /dev/null ; then
         selinux"
 else
     echo "ERROR: Unable to create Python virtual environment, 'virtualenv' command not found"
+    exit 1
 fi
 
 # Clone DeepOps git repo if running standalone


### PR DESCRIPTION
## Summary

Ansible has been in the habit of making breaking changes to both their modules and their packaging process for versions starting with Ansible 2.10.

This has led to some of our dependencies like Kubespray not yet being supported for newer versions, and implies that we will need to test more carefully before upgrading to newer versions.

Some DeepOps users who simply "pip install ansible" have also started to report issues. 😢 

Thankfully, Ansible 2.9.x is [still supported](https://docs.ansible.com/ansible/devel/reference_appendices/release_and_maintenance.html#ansible-core-release-cycle) for security fixes only at this time, so we can temporarily stick with this version and figure out our test strategy when our dependencies are ready.

This commit makes the following two changes in our `scripts/setup.sh` script which DeepOps users should run for new installs.

1. We bump to the latest version of 2.9.x (2.9.21) as our default install
2. We check for Ansible versions which are newer than we support, and report an error if these are present

## Test plan

Working CI tests