### PR TITLE
yum install docker-py for centos-slurm

### DIFF
--- a/roles/prometheus/tasks/main.yml
+++ b/roles/prometheus/tasks/main.yml
@@ -26,6 +26,13 @@
   pip:
     name: docker
 
+- name: Install python2 Docker dependencies
+  yum:
+    name:
+      - python-docker
+    state: present
+  when: ansible_os_family == "RedHat"
+
 - name: create a persistent docker volume for metrics
   docker_volume:
     name: "{{ prometheus_docker_volume_name }}"


### PR DESCRIPTION
This is the same issue we were seeing in the standalone registry. The Ansible modules are relying on Python 2 in CentOS/RedHat and this requires us to install the python-docker pages with yum and not pip.

