### PR TITLE
Install Docker SDK correctly for all Pythons

### DIFF
--- a/roles/nginx-docker-registry-cache/tasks/server.yml
+++ b/roles/nginx-docker-registry-cache/tasks/server.yml
@@ -1,15 +1,20 @@
 ---
-- name: Install package dependencies
-  package:
-    name:
-    - "python3-pip"
-    - "python3-setuptools"
-    state: present
+- name: Ensure Python 2 dependencies are installed via OS packages
+  when: (ansible_python.version.major==2) and (ansible_python.version.minor==7)
+  block:
+  - name: install python-docker
+    package:
+      name: python-docker
 
-- name: Install Python Docker dependencies
-  pip:
-    name: "docker"
-    state: present
+- name: Ensure Python 3 dependencies are installed via pip
+  when: ansible_python.version.major==3
+  block:
+  - name: install pip
+    package:
+      name: python3-pip
+  - name: install docker
+    pip:
+      name: docker
 
 - name: Ensure data directories exist
   file:

--- a/roles/prometheus/tasks/main.yml
+++ b/roles/prometheus/tasks/main.yml
@@ -18,20 +18,22 @@
     mode: 0644
   notify: restart prometheus
 
-- name: install pip
-  package:
-    name: python3-pip
+- name: Ensure Python 2 dependencies are installed via OS packages
+  when: (ansible_python.version.major==2) and (ansible_python.version.minor==7)
+  block:
+  - name: install python-docker
+    package:
+      name: python-docker
 
-- name: install docker libraries
-  pip:
-    name: docker
-
-- name: Install python2 Docker dependencies
-  yum:
-    name:
-      - python-docker
-    state: present
-  when: ansible_os_family == "RedHat"
+- name: Ensure Python 3 dependencies are installed via pip
+  when: ansible_python.version.major==3
+  block:
+  - name: install pip
+    package:
+      name: python3-pip
+  - name: install docker
+    pip:
+      name: docker
 
 - name: create a persistent docker volume for metrics
   docker_volume:


### PR DESCRIPTION
## Summary

On distros where we are running under Python 2, we should use the OS package for python-docker in order to ensure compatibility with the distro python.

On distros where we are running under Python 3, we will install via pip to get the correct and most up-to-date package.

## Test plan

Ran Prometheus playbook on each of CentOS 7 and 8, and Ubuntu 18.04 and 20.04. Python 2 was used in CentOS 7, all other distros used Python 3.