### PR TITLE
Globally run helm repo add stable to avoid WARNINGs

### DIFF
--- a/playbooks/k8s-cluster.yml
+++ b/playbooks/k8s-cluster.yml
@@ -232,6 +232,9 @@
     - name: Install Helm on admin node
       command: "sh {{ playbook_dir }}/../scripts/k8s/install_helm.sh"
       delegate_to: localhost
+    - name: Globally update the deprecated "stable" helm repo
+      command: "/usr/local/bin/helm repo add 'stable' 'https://charts.helm.sh/stable' --force-update"
+      delegate_to: localhost
     - name: kubeadm | Remove taint for master with node role
       command: "{{ artifacts_dir }}/kubectl --kubeconfig {{ artifacts_dir }}/admin.conf taint node {{ inventory_hostname }} node-role.kubernetes.io/master:NoSchedule-"
       delegate_to: localhost


### PR DESCRIPTION
I'm a little sick of seeing this warning in all the tests and scripts.

It looks like this might be added/referenced in the current Kubespray version.

```
WARNING: "kubernetes-charts.storage.googleapis.com" is deprecated for "stable" and will be deleted Nov. 13, 2020.
WARNING: You should switch to "https://charts.helm.sh/stable" via:
WARNING: helm repo add "stable" "https://charts.helm.sh/stable" --force-update
```