### PR TITLE
Install Docker SDK correctly in standalone-container-registry

### DIFF
--- a/roles/standalone-container-registry/tasks/main.yml
+++ b/roles/standalone-container-registry/tasks/main.yml
@@ -15,24 +15,29 @@
     group: "root"
     mode: "0600"
 
-- name: install docker python3 module
-  apt:
-    name: python3-docker
-    state: present
-    update_cache: yes
-  when: ansible_distribution == "Ubuntu"
 - name: Enable EPEL repo
   package:
     name:
       - "{{ epel_package }}"
     state: present
   when: ansible_os_family == 'RedHat'
-- name: Install python2 Docker dependencies
-  yum:
-    name:
-      - python-docker
-    state: present
-  when: ansible_os_family == "RedHat"
+
+- name: Ensure Python 2 dependencies are installed via OS packages
+  when: (ansible_python.version.major==2) and (ansible_python.version.minor==7)
+  block:
+  - name: install python-docker
+    package:
+      name: python-docker
+
+- name: Ensure Python 3 dependencies are installed via pip
+  when: ansible_python.version.major==3
+  block:
+  - name: install pip
+    package:
+      name: python3-pip
+  - name: install docker
+    pip:
+      name: docker
 
 - name: run registry docker container
   docker_container:


### PR DESCRIPTION
In PR #967 I missed one instance of installing the Docker SDK, resulting
in failures on CentOS 8 for the standalone container registry playbook.
This PR should fix the last gap.

This should cover all cases for the python-docker install now.

```
$ grep -l -R python-docker roles/
roles/prometheus/tasks/main.yml
roles/nginx-docker-registry-cache/tasks/server.yml
roles/standalone-container-registry/tasks/main.yml
```