### PR TITLE
Permit SFTP in default SSHD config

### DIFF
--- a/config.example/group_vars/all.yml
+++ b/config.example/group_vars/all.yml
@@ -106,6 +106,18 @@ users:
 
 
 ################################################################################
+# SSH HARDENING                                                                #
+#   dev-sec.ssh-hardening role called from users playbook                      #
+################################################################################
+
+ssh_client_hardening: false
+ssh_server_password_login: true
+ssh_use_pam: 10
+ssh_max_auth_retries: 10
+sftp_enabled: true
+sftp_chroot: false
+
+################################################################################
 # NVIDIA                                                                       #
 ################################################################################
 # NVIDIA GPU configuration

--- a/playbooks/generic/users.yml
+++ b/playbooks/generic/users.yml
@@ -3,14 +3,26 @@
 - hosts: all
   become: true
   tasks:
+
+    - name: Set backward compatible values for ssh-hardening if not defined
+      block:
+      - set_fact:
+          ssh_client_hardening: false
+        when: ssh_client_hardening is undefined
+      - set_fact:
+          ssh_server_password_login: true
+        when: ssh_server_password_login is undefined
+      - set_fact:
+          ssh_use_pam: true
+        when: ssh_use_pam is undefined
+      - set_fact:
+          ssh_max_auth_retries: 10
+        when: ssh_use_pam is undefined
+
     - name: Configure SSH to allow login with password
       include_role:
         name: dev-sec.ssh-hardening
-      vars:
-        ssh_client_hardening: false
-        ssh_server_password_login: true
-        ssh_use_pam: true
-        ssh_max_auth_retries: 10
+
     - name: Set user password
       include_role:
         name: DeepOps.users


### PR DESCRIPTION
Our SSH hardening role disables the use of SFTP by default. This causes problems with Ansible, which expects to be able to use SFTP to transfer large files. In particular, this has caused problems for the DGX firmware upgrade role, which will fail to work correctly if the SSH hardening role has run.

This commit also makes it easier to override the SSH configuration by moving hard-coded parameters from the user playbook to the DeepOps configuration.

## Test plan

Run `playbooks/generic/users.yml` and examine `/etc/ssh/sshd_config` on the target system. SFTP should now be enabled by default.