### PR TITLE
Use full paths for files in setup.sh

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -23,6 +23,7 @@ VENV_DIR="${VENV_DIR:-/opt/deepops/env}"        # Path to python virtual environ
 . /etc/os-release
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+ROOT_DIR="${SCRIPT_DIR}/.."
 
 DEPS_DEB=(git virtualenv python3-virtualenv sshpass wget)
 DEPS_EL7=(git libselinux-python3 python-virtualenv python3-virtualenv sshpass wget)
@@ -134,7 +135,7 @@ fi
 # Copy default configuration
 if grep -i deepops README.md >/dev/null 2>&1 ; then
     if [ ! -d "${CONFIG_DIR}" ] ; then
-        cp -rfp ./config.example "${CONFIG_DIR}"
+        cp -rfp "${ROOT_DIR}/config.example" "${CONFIG_DIR}"
         echo "Copied default configuration to ${CONFIG_DIR}"
     else
         echo "Configuration directory '${CONFIG_DIR}' exists, not overwriting"
@@ -144,10 +145,10 @@ fi
 # Install Ansible Galaxy roles
 if command -v ansible-galaxy &> /dev/null ; then
     echo "Updating Ansible Galaxy roles..."
-    as_user ansible-galaxy collection install --force -r roles/requirements.yml >/dev/null
-    as_user ansible-galaxy role install --force -r roles/requirements.yml >/dev/null
-    as_user ansible-galaxy collection install --force -i -r config/requirements.yml >/dev/null
-    as_user ansible-galaxy role install --force -i -r config/requirements.yml >/dev/null
+    as_user ansible-galaxy collection install --force -r "${ROOT_DIR}/roles/requirements.yml" >/dev/null
+    as_user ansible-galaxy role install --force -r "${ROOT_DIR}/roles/requirements.yml" >/dev/null
+    as_user ansible-galaxy collection install --force -i -r "${ROOT_DIR}/config/requirements.yml" >/dev/null
+    as_user ansible-galaxy role install --force -i -r "${ROOT_DIR}/config/requirements.yml" >/dev/null
 else
     echo "ERROR: Unable to install Ansible Galaxy roles, 'ansible-galaxy' command not found"
 fi


### PR DESCRIPTION
In the last release we introduced a minor issue with the refactoring of the setup script.

When `setup.sh` was executed from somewhere other than the deepops directory it expected config.example and roles to be in the local directory. This resulted in failed deployments.

This fixes the issue by using full paths.