### PR TITLE
EasyBuild: Enable both shells on all distros

### DIFF
--- a/roles/easy-build/tasks/main.yml
+++ b/roles/easy-build/tasks/main.yml
@@ -106,7 +106,7 @@
     owner: root
     group: root
     mode: 0777
-  when: ansible_os_family == "Debian" and not ebsw_exe.matched
+  when: not ebsw_exe.matched
   tags:
     - configuration
 
@@ -118,6 +118,6 @@
     owner: root
     group: root
     mode: 0777
-  when: ansible_os_family == "RedHat" and not ebsw_exe.matched
+  when: not ebsw_exe.matched
   tags:
     - configuration


### PR DESCRIPTION
Our current EasyBuild role enables the bash profile on Debian-based systems, and the csh profile on RedHat-based systems, but not vice-versa. There's no clear reason for this limitation, so let's remove it.

Addresses #987 .