### PR TITLE
Grafana: add var for custom config template

### DIFF
--- a/roles/grafana/defaults/main.yml
+++ b/roles/grafana/defaults/main.yml
@@ -1,4 +1,5 @@
 grafana_config_dir: /etc/grafana
+grafana_config_template: templates/grafana.ini.j2
 grafana_data_dir: /var/lib/grafana
 grafana_user_id: 472
 grafana_container: "grafana/grafana"

--- a/roles/grafana/tasks/main.yml
+++ b/roles/grafana/tasks/main.yml
@@ -54,7 +54,7 @@
 
 - name: install config file
   template:
-    src: templates/grafana.ini.j2
+    src: "{{ grafana_config_template }}"
     dest: "{{ grafana_config_dir }}/grafana.ini"
     owner: root
     group: root


### PR DESCRIPTION
Summary
-------

Currently we use a hard-coded template for `grafana.ini`, but this file
is frequently customized by users to specify things like email servers.
This PR adds an Ansible var to allow the source of this template to be
specified by the user.

Addresses #977.

Test plan
---------

Passing CI tests.