### PR TITLE
ood-wrapper: Don't install python3-passlib on CentOS 7

### DIFF
--- a/roles/ood-wrapper/tasks/server.yml
+++ b/roles/ood-wrapper/tasks/server.yml
@@ -60,6 +60,17 @@
     - python3-passlib
   tags:
     - configure
+  when: (ansible_distribution == "Ubuntu") or ((ansible_os_family == "RedHat") and (ansible_distribution_major_version == "8"))
+
+- name: install package dependency for htpasswd module
+  package:
+    name: "{{ item }}"
+    state: present
+  with_items:
+    - python-passlib
+  tags:
+    - configure
+  when: (ansible_os_family == "RedHat") and (ansible_distribution_major_version == "7")
 
 - name: create .htpasswd entries
   htpasswd:


### PR DESCRIPTION
## Summary

The `python3-passlib` package is not available on CentOS 7, and python2 will typically be used on that distro anyway. Addresses #985 .

`python3-passlib` is available on CentOS 8 so we will still install it there.

## Test plan

Virtual Slurm cluster standup with CentOS 7. Verified that install succeeded after making this change.