### PR TITLE
Enroot: adjust cache directory to be per-user

### DIFF
--- a/config.example/group_vars/all.yml
+++ b/config.example/group_vars/all.yml
@@ -173,7 +173,7 @@ docker_iptables_enabled: true
 #
 # See: https://github.com/NVIDIA/pyxis/wiki/Setup#enroot-configuration-example
 enroot_runtime_path: '/run/enroot/user-$(id -u)'
-enroot_cache_path: '/var/lib/enroot-cache/group-$(id -g)'
+enroot_cache_path: '/var/lib/enroot-cache/user-$(id -u)'
 enroot_data_path: '/tmp/enroot-data/user-$(id -u)'
 enroot_config: |
   ENROOT_CONFIG_PATH ${HOME}/.config/enroot

--- a/roles/slurm/templates/etc/slurm/prolog.d/50-all-enroot-dirs
+++ b/roles/slurm/templates/etc/slurm/prolog.d/50-all-enroot-dirs
@@ -15,7 +15,7 @@ chmod 0700 "$runtime_path"
 cache_path="$(sudo -u "$SLURM_JOB_USER" sh -c 'echo "{{ enroot_cache_path }}"')"
 mkdir -p "$cache_path"
 chown "$SLURM_JOB_UID:$(id -g "$SLURM_JOB_UID")" "$cache_path"
-chmod 0770 "$cache_path"
+chmod 0700 "$cache_path"
 {% endif %}
 
 {% if enroot_data_path | default(none) %}


### PR DESCRIPTION
## Summary

Previously, the enroot configuration directory on a node was allocated on a per-group basis according to the user's primary group. However, the permissions are not set to be group readable as per #969.

From a permissions standpoint, we probably don't want the enroot cache directory to be group-readable by default. Users may have access to different sets of private container images, so we should default to making these permissions restrictive.

This PR therefore switches Enroot to use a per-user cache directory by default.

## Test plan

Set up a test Slurm cluster with this configuration, and created two test users (`user1` and `user2`) with the same primary group.

Started an enroot job as `user1`:

```
user1@virtual-login01:~$ id
uid=20001(user1) gid=100(users) groups=100(users),27(sudo)
user1@virtual-login01:~$ srun -n1 --container-image="centos" --pty bash
pyxis: importing docker image ...
root@virtual-gpu01:/#
```

Then started a simultaneous job on the same host as `user2` and confirmed this works (addressing the error condition in #969):

```
user2@virtual-login01:~$ id
uid=20002(user2) gid=100(users) groups=100(users),27(sudo)
user2@virtual-login01:~$ srun -n1 -w virtual-gpu01 --container-image="centos" --pty bash
pyxis: importing docker image ...
root@virtual-gpu01:/#
```

Checked the cache directories on `virtual-gpu01` and verified two cache directories exist:

```
vagrant@virtual-gpu01:~$ ls /var/lib/enroot-cache/
user-20001  user-20002
```