### PR TITLE
[yaml] Fix double 'when' on nvidia-hpc-sdk//main.yml

### DIFF
--- a/roles/nvidia-hpc-sdk/tasks/main.yml
+++ b/roles/nvidia-hpc-sdk/tasks/main.yml
@@ -59,11 +59,12 @@
     NVHPC_DEFAULT_CUDA: "{{ hpcsdk_default_cuda }}"
 
 - name: clean up the temp directory
-  when: not nvhpc_localrc.stat.exists
   file:
     path: "{{ hpcsdk_temp_dir }}"
     state: absent
-  when: hpcsdk_clean_up_temp_dir
+  when:
+    - not nvhpc_localrc.stat.exists
+    - hpcsdk_clean_up_temp_dir
 
 - name: run the makelocalrc script
   when: not nvhpc_localrc.stat.exists


### PR DESCRIPTION
> roles/nvidia-hpc-sdk/tasks/main.yml, line 54, column 3, found a duplicate dict key (when). Using last defined value only.

Signed-off-by: Leo Gallucci <elgalu3@gmail.com>