### PR TITLE
[lint] fix [208] missing 'mode'

### DIFF
--- a/playbooks/bootstrap/bootstrap-ssh.yml
+++ b/playbooks/bootstrap/bootstrap-ssh.yml
@@ -10,6 +10,7 @@
       file:
         path: "{{ lookup('env','HOME') + '/.ssh' }}"
         state: directory
+        mode: 0700
       delegate_to: 127.0.0.1
       run_once: true
 


### PR DESCRIPTION
Fix [208] missing or unsupported `mode` parameter can cause unexpected file permissions based on version of Ansible being used
https://ansible-lint.readthedocs.io/en/latest/default_rules.html#risky-file-permissions

Signed-off-by: Leo Gallucci <elgalu3@gmail.com>