### PR TITLE
Add basic role for Squid HTTP proxy

### DIFF
--- a/playbooks/generic/squid-http-proxy.yml
+++ b/playbooks/generic/squid-http-proxy.yml
@@ -1,0 +1,5 @@
+---
+- hosts: "{{ hostlist | default('all') }}"
+  become: yes
+  roles:
+  - squid-http-proxy 

--- a/roles/squid-http-proxy/README.md
+++ b/roles/squid-http-proxy/README.md
@@ -1,0 +1,15 @@
+squid-http-proxy
+================
+
+A very basic Ansible role for configuring an http proxy server using
+[Squid](http://www.squid-cache.org/).
+
+This role is included primarily for testing purposes, to make it easier to test deployments behind an HTTP proxy.
+This probably shouldn't be used as a production proxy server.
+
+
+Variables
+---------
+
+* `squid_http_port`: Set the port Squid will listen on (default `'8888'`)
+* `squid_disable_caching`: Prevents Squid from caching any content (default `true`)

--- a/roles/squid-http-proxy/defaults/main.yml
+++ b/roles/squid-http-proxy/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+squid_http_port: '8888'
+squid_disable_caching: true

--- a/roles/squid-http-proxy/handlers/main.yml
+++ b/roles/squid-http-proxy/handlers/main.yml
@@ -1,0 +1,5 @@
+---
+- name: restart squid
+  service:
+    name: "squid"
+    state: "restarted"

--- a/roles/squid-http-proxy/tasks/main.yml
+++ b/roles/squid-http-proxy/tasks/main.yml
@@ -1,0 +1,21 @@
+---
+- name: install squid http proxy
+  package:
+    name: "squid"
+    state: "present"
+
+- name: configure squid
+  template:
+    src: "squid.conf.j2"
+    dest: "/etc/squid/squid.conf"
+    owner: "root"
+    group: "root"
+    mode: "0644"
+  notify:
+  - restart squid
+
+- name: start squid service
+  service:
+    name: "squid"
+    state: "started"
+    enabled: true

--- a/roles/squid-http-proxy/templates/squid.conf.j2
+++ b/roles/squid-http-proxy/templates/squid.conf.j2
@@ -1,0 +1,10 @@
+# Configure the http port to listen on
+http_port {{ squid_http_port }}
+
+# Allow all requests
+http_access allow all
+
+{% if squid_disable_caching|bool %}
+# Never cache requests
+cache deny all
+{% endif %}


### PR DESCRIPTION
## Summary

This commit adds a basic role to set up an HTTP proxy using [Squid](http://www.squid-cache.org/).

This role is primarily intended to make it easier to test deployments in environments which require a proxy server.
While Squid is a production-capable proxy server, this role does very basic configuration and is not optimized for serving large volumes of traffic.

- [x] Add role and playbook to deploy Squid
- [ ] Add CI testing

## Test plan

### Manual testing

Deployed proxy server on a virtual machine using the playbook:

```
$ ansible-playbook -i virtual/config/inventory -l virtual-login01 playbooks/generic/squid-http-proxy.yml
```

Logged into the VM and did a manual test with `curl`:

```
[vagrant@localhost ~]$ export http_proxy=http://localhost:8888/
[vagrant@localhost ~]$ export https_proxy=http://localhost:8888/
[vagrant@localhost ~]$ curl https://www.google.com/
<!doctype html><html itemscope="" itemtype="http://schema.org/WebPage" lang="en">

*snipped rest of output*
```

Checked proxy logs and confirmed that the request had gone through the server:

```
[vagrant@localhost ~]$ sudo cat /var/log/squid/access.log
1625672323.744    395 ::1 TCP_TUNNEL/200 18589 CONNECT www.google.com:443 - HIER_DIRECT/142.250.114.104 -
```

### CI tests

TODO