### PR TITLE
Update ansible-role-hosts for various improvements

### DIFF
--- a/roles/requirements.yml
+++ b/roles/requirements.yml
@@ -17,7 +17,7 @@ roles:
   version: 'e67df1db28bf099aa06d0ab250478963532b4d29'
 
 - src: https://github.com/DeepOps/ansible-role-hosts.git
-  version: '8311d6ecfe39b665a06d1fc55502c6916e9ab5ce'
+  version: 'c21a676088c07db3db3ac9332cf584eeb068e3fd'
   name: DeepOps.hosts
 
 - src: geerlingguy.ntp


### PR DESCRIPTION
Update our requirement for ansible-role-hosts to incorporate the flexibility and reliability improvements from https://github.com/DeepOps/ansible-role-hosts/pull/4.

See my comment on that PR for test plan of the role changes.

Test plan for this PR is passing CI tests.