### PR TITLE
Update ansible-role-enroot to 0.5.0

### DIFF
--- a/roles/requirements.yml
+++ b/roles/requirements.yml
@@ -33,7 +33,7 @@ roles:
   version: "v1.2.3"
 
 - src: nvidia.enroot
-  version: "v0.4.0"
+  version: "v0.5.0"
 
 - src: geerlingguy.filebeat
   version: "2.0.1"


### PR DESCRIPTION
Update DeepOps to use the most recent enroot role dependency.

This update includes some useful new features, including:

- Fix Enroot upgrade workflow with raw packages from Github
- Support installation with http proxy, using regular deepops pattern
- Use Fedora package to install EPEL dependency