### PR TITLE
Fix: Failed to execute vagrant_startup.sh in Ubuntu 20.04

### DIFF
--- a/virtual/vagrant_startup.sh
+++ b/virtual/vagrant_startup.sh
@@ -78,7 +78,7 @@ case "$ID" in
     if [[ ! ${VERSION_ID} =~ ^20\.* ]]; then
       APT_DEPENDENCIES=${APT_DEPENDENCIES}" libvirt-bin"
     fi
-    export ${APT_DEPENDENCIES}
+    export APT_DEPENDENCIES
 
     # shellcheck disable=SC2086
     if ! (dpkg -s $APT_DEPENDENCIES) >/dev/null 2>&1; then


### PR DESCRIPTION
This patch fixes below issues.

* From Ubuntu 18.10 libvirt-bin is dropped
* LIBVIRT_GROUP should be libvert on Ubuntu 20.04