### PR TITLE
Default to testing in Ubuntu 20.04

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -8,7 +8,7 @@
 #                         or: curl -sL git.io/deepops | bash -s -- 19.07
 
 # Configuration
-ANSIBLE_VERSION="${ANSIBLE_VERSION:-2.9.21}"     # Ansible version to install
+ANSIBLE_VERSION="${ANSIBLE_VERSION:-2.9.27}"     # Ansible version to install
 ANSIBLE_TOO_NEW="${ANSIBLE_TOO_NEW:-2.10.0}"    # Ansible version too new
 CONFIG_DIR="${CONFIG_DIR:-./config}"            # Default configuration directory location
 DEEPOPS_TAG="${1:-master}"                      # DeepOps branch to set up

--- a/virtual/vagrant_startup.sh
+++ b/virtual/vagrant_startup.sh
@@ -8,7 +8,7 @@ VIRT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 # The default Vagrant Operating System is Ubuntu 18.04
 # To override thise, change these variables to a supported OS
 DEEPOPS_VAGRANT_OS=${DEEPOPS_VAGRANT_OS:-ubuntu}
-DEEPOPS_OS_VERSION=${DEEPOPS_OS_VERSION:-18.04}
+DEEPOPS_OS_VERSION=${DEEPOPS_OS_VERSION:-20.04}
 
 # Startup the specified VM OS, defaulting to Ubuntu
 

--- a/workloads/jenkins/Jenkinsfile
+++ b/workloads/jenkins/Jenkinsfile
@@ -3,7 +3,7 @@ pipeline {
   environment {
     DEEPOPS_FULL_INSTALL = ''
     DEEPOPS_VAGRANT_OS = 'ubuntu'
-    DEEPOPS_OS_VERSION = '18.04'
+    DEEPOPS_OS_VERSION = '20.04'
   }
   stages {
     stage('Stop Any Old Builds') {

--- a/workloads/jenkins/scripts/jenkins-common.sh
+++ b/workloads/jenkins/scripts/jenkins-common.sh
@@ -50,3 +50,4 @@ export PATH="${K8S_CONFIG_DIR}/artifacts:${PATH}"
 
 # Let setup script know we're running from a Jenkins job
 export JENKINS=1
+export VENV_DIR="./env"


### PR DESCRIPTION
Summary
-------

Propose that we switch our default for DeepOps testing from Ubuntu 18.04 to Ubuntu 20.04. This is largely to align with DGX OS 5, and to test on the platform that will be most likely to deploy on future systems.

- Jenkinsfile for PR testing to use Ubuntu 20.04 instead of 18.04
- Default to using Ubuntu 20.04 in the virtual cluster

Test plan
---------

Passing tests in Jenkins