### PR TITLE
Improve documentation & playbook for DGX firmware upgrade, include paramiko in setup.sh

### DIFF
--- a/docs/deepops/dgx-diagnostic-firmware.md
+++ b/docs/deepops/dgx-diagnostic-firmware.md
@@ -114,7 +114,7 @@ This will do the following:
 * Transfer all logs to the provisioning node
 * List nodes that require a manual power cycle.
 
-For large DGX clusters, it is recommended to first perform a single manual firmware update and verify that node before using any automation cluster-wide.
+For large DGX clusters, it is recommended to first perform a single manual firmware update and verify that node before using any automation cluster-wide. Before running through any firmware update steps, it is recommended to first run through the diagnostics playbook to collect a snapshot of the cluster status.
 
 After verifying that a single node can be successfully upgraded, upgrade the rest of the cluster with the Ansible automation. For larger clusters it is recommended to do this in batches. Perform an initial test of the provisioning node by updating a single node with Ansible and then deploy in batches of ~40 nodes. It is not necessary to do this, but in the case of an error or outage in the provisioning node this will reduce risk of firmware upgrade failure.
 

--- a/docs/deepops/dgx-diagnostic-firmware.md
+++ b/docs/deepops/dgx-diagnostic-firmware.md
@@ -1,6 +1,6 @@
 # NVIDIA Diagnostics & DGX Firmware Upgrades
 
-The `nvidia-dgx-firmware` role has been built to perform several administrative tasks cluster-wide.
+The [`nvidia-dgx-firmware`](roles/nvidia-dgx-firmware) role has been built to perform several administrative tasks cluster-wide.
 
 1. Upgrade the the DGX firmware (*DGX only clusters*)
 2. Run system diagnostics and collect a log bundle (*DGX and non-DGX clusters*)
@@ -9,20 +9,21 @@ While documentation exists to [run system health checks](https://docs.nvidia.com
 
 
 ## Setup
+Ensure that the playbook is being executed from an admin node where the `scripts/setup.sh` script has already been run and the inventory file is properly configured with DGX nodes all listed under the `slurm-node` group. Refer to the [DeepOps Slurm Deployment Guide](docs/slurm-cluster/) for details.
 
 If running on a DGX cluster, it is necessary to provide the DGX firmware container in order to gather installed firmware information or perform firmware updates. If running on a non-DGX cluster skip this first step and set `load_firmware` and `update_firmware` to `false`.
 
-1. Download the latest [DGX firmware container](https://docs.nvidia.com/dgx/dgxa100-fw-container-release-notes/index.html) and put it in `src/containers/dgx-firmware`, keeping the original file name. Update the role variables to reflect the version being used.
+1. Download the latest [DGX firmware container](https://docs.nvidia.com/dgx/dgxa100-fw-container-release-notes/index.html) and put it in `config/containers/dgx-firmware`, keeping the original file name. Add the following variables to `config/group_vars/all.yml` yaml file, reflecting the version being used.
 
 ```yml
 # The Docker repo name
 firmware_update_repo: nvfw-dgxa100
 
 # The Docker tag
-firmware_update_tag: 20.05.12.5
+firmware_update_tag: 21.11.2
 
 # The tarball name
-firmware_update_container: "nvfw-dgxa100_20.10.9_201103.tar.gz"
+firmware_update_container: "nvfw-dgxa100_21.11.2_211102.tar.gz"
 ```
 
 2. Change the `nv_mgmt_interface` variable to reflect the systems being collected from.
@@ -40,9 +41,9 @@ nv_mgmt_interface: enp225s0f0 # DGX A100
 
 ## Collect Diagnostics
 
-The `nvidia-dgx-diag.yml` playbook leverages the `nvidia-dgx-firmware` role to run a diagnostic. This will collect health and configuration information for all nodes across a cluster. After being executed all logs will be copied locally to the provisioning system at `config/logs`. Logs are stored by hostname with timestamps. To change where logs are stored change the `local_log_directory` variable.
+The [nvidia-dgx-diag.yml](../../playbooks/nvidia-dgx/nvidia-dgx-diag.yml) playbook leverages the [nvidia-dgx-firmware](../../roles/nvidia-dgx-firmware) role to run a diagnostic. This will collect health and configuration information for all nodes across a cluster. After being executed all logs will be copied locally to the provisioning system at `config/logs`. Logs are stored by hostname with timestamps. To change where logs are stored change the `local_log_directory` variable.
 
-Diagnostics include the following and easily be expanded by adding tasks to the `run-diagnostics.yml` file:
+Diagnostics include the following and can easily be expanded by adding tasks to the [run-diagnostics.yml](../../roles/nvidia-dgx-firmware/tasks/run-diagnostics.yml) file:
 
 * Running `nvsm show health`
 * Running `nvsm dump health` and gathering logs
@@ -58,7 +59,7 @@ This tool can be used to:
 * Debug a known issue
 * Generate a report bundle for NVIDIA support
 
-Setting `dcgmi_stress` to true will run the dcgm diagnostic at a level of instead of the default of 1. This can be used as a light system stress test and may take up to 20 minutes to complete. `nvsm dump health` can also take up to 15 minutes to complete and may be disabled by setting `nvsm_dump_health` to `false`. These tests can potentially be disruptive or fail to complete if there are existing issues, it is not recommended to them while the nodes are in use,  see [the official docs](https://docs.nvidia.com/datacenter/nvsm/nvsm-user-guide/index.html) for additional details. 
+Setting `dcgmi_stress` to true will run the dcgm diagnostic at a level of instead of `3` the default of `1`. This can be used as a light system stress test and may take up to 20 minutes to complete. `nvsm dump health` can also take up to 15 minutes to complete and may be disabled by setting `nvsm_dump_health` to `false`. These tests can potentially be disruptive or fail to complete if there are existing issues, it is not recommended to run them while the nodes are in use,  see [the official docs](https://docs.nvidia.com/datacenter/nvsm/nvsm-user-guide/index.html) for additional details. 
 
 Because this is a debugging tool Ansible will continue executing tasks on all hosts even if some of the tasks fail. It will execute each step with "best-effort" to gather as much health information as possible. This role is designed to be executed against a homogeneous cluster of DGX systems (all DGX-1, all DGX-2, or all DGX A100), but the majority of the functionality will be effective on any GPU cluster. If running on a non-DGX cluster there will be errors and warnings for the DGX specific tasks.
 
@@ -66,11 +67,25 @@ Logs will temporarily be stored in `fw_dir` on the remote machines and will be c
 
 Run the diagnostics playbook:
 ```sh
-# collect diagnostic info
-ansible-playbook -l slurm-node playbooks/nvidia-dgx/nvidia-dgx-diag.yml
+# NOTE: If SSH requires a password, add: `-k`
+# NOTE: If sudo on remote machine requires a password, add: `-K`
+# NOTE: If SSH user is different than current user, add: `-u ubuntu`
+# NOTE: We specify the connection type as paramikio_ssh to collect stdout from the firmware container
+# NOTE: Forks is specified as the number of nodes in the batch (40), allowing each DGX to run commands in parallel 
+# Collect diagnostic info
+ansible-playbook -l slurm-node --connection=paramiko_ssh --forks 40 playbooks/nvidia-dgx/nvidia-dgx-diag.yml
 ```
 
-After running the diagnostics, it may be helpful to do a quick scan for issues by running:
+> Note: The below tasks may take 15+ minutes per DGX; the playbook will timeout if it is errored or hung, do not cancel the playbook while it is running.
+```
+TASK [nvidia-dgx-firmware : Run NVSM human-readable health show] *******************************************************
+changed: [dgx]
+
+TASK [nvidia-dgx-firmware : Run NVSM dump health] **********************************************************************
+changed: [dgx]
+```
+
+After running the diagnostics look for issues by running:
 
 ```sh
 # Check for failed  NVSM health checks
@@ -86,7 +101,7 @@ grep no config/logs/*/*fw-versions-post-check.log
 
 ## Update Firmware
 
-The `nvidia-dgx-fw-update.yml` playbook leverages the `nvidia-dgx-firmware` role to update the DGX firmware.
+The [nvidia-dgx-fw-update.yml](../../playbooks/nvidia-dgx/nvidia-dgx-fw-update.yml) playbook leverages the [nvidia-dgx-firmware](../../roles/nvidia-dgx-firmware) role to update the DGX firmware.
 
 This will do the following:
 
@@ -101,22 +116,29 @@ This will do the following:
 
 For large DGX clusters, it is recommended to first perform a single manual firmware update and verify that node before using any automation cluster-wide.
 
-After verifying a single node can be successfully upgraded, upgrade the rest of the cluster with the Ansible automation. For larger clusters it is recommended to do this in batches. Perform an initial test of the provisioning node by updating a single node with Ansible and then deploy in batches of ~40 nodes. It is not necessary to do this, but in the case of an error or outage in the provisioning node this will reduce risk of firmware upgrade failure.
+After verifying that a single node can be successfully upgraded, upgrade the rest of the cluster with the Ansible automation. For larger clusters it is recommended to do this in batches. Perform an initial test of the provisioning node by updating a single node with Ansible and then deploy in batches of ~40 nodes. It is not necessary to do this, but in the case of an error or outage in the provisioning node this will reduce risk of firmware upgrade failure.
 
 Depending on the number of nodes and the required firmware updates, this process can take 1-4 hours to complete. For very large clusters it is not uncommon for some nodes to fail to update. This can occur for several reasons such as timeouts or networking issues.  When this occurs manually inspect the logs, run an `nvsm show health` and if healthy attempt to re-run the playbook on those nodes. If failures persist contact NVIDIA support and attempt the upgrade manually.
 
-Updating firmware might require rebooting the systems (depending on what portion of the firmware is being updated). This is done automatically by the playbooks. However, certain components require a system power cycle. This can be disruptive and must be down manually. Follow the guidance in playbook output to safely shutdown these nodes and power cycle them through the BMC.
+Updating firmware might require rebooting the systems, depending on what portion of the firmware is being updated. This is done automatically by the playbooks. However, certain components require a system power cycle. This can be disruptive and must be done manually. Follow the guidance in playbook output to safely shutdown these nodes and power cycle them through the BMC. If the Playbook output does not end with a message indictating a power cycle is needed, this step may be skipped.
+
+To upgrade only a single component, set the `target_fw` variable. To downgrade a component set the `force_update` flag. To update the Standby or Inactive components set the `inactive_update` flag. For example, to use an older firmware container version and downgrade the SBIOS run Ansible with `-e target_fw=SBIOS -e force_update=true` or to upgrade the backup BMC `-e target_fw=BMC -e inactive_update=true`.
 
 > Note, power cycling an entire datacenter's worth of DGX nodes may trigger a datacenter power alarm or trip a breaker. It is recommended to power cycle systems in batches with a several minute delay in-between or to alert the operations team when performing these actions.
 
 Run the firmware update playbook:
 
 ```sh
-# update all firmware
-ansible-playbook -l slurm-node playbooks/nvidia-dgx/nvidia-dgx-fw-update.yml
+# NOTE: If SSH requires a password, add: `-k`
+# NOTE: If sudo on remote machine requires a password, add: `-K`
+# NOTE: If SSH user is different than current user, add: `-u ubuntu`
+# NOTE: We specify the connection type as paramikio_ssh to collect stdout from the firmware container
 
-# reset the BMC on all nodes after a BMC firmware update
-ansible slurm-node -ba "ipmitool mc reset cold"
+# Update all firmware
+ansible-playbook -l slurm-node --connection=paramiko_ssh --forks 40 playbooks/nvidia-dgx/nvidia-dgx-fw-update.yml
+
+# Reset the BMC on all nodes after a BMC firmware update
+ansible slurm-node --forks 40 -ba "ipmitool mc reset cold"
 ```
 
 > Note: This playbook is designed to only allow upgrading of a single component or all components per run; the recommended best-practice is to run `update_fw all`, however when updating individual components it is best to perform some level of manual verification over the logs after each update.

--- a/playbooks/nvidia-dgx/nvidia-dgx-fw-update.yml
+++ b/playbooks/nvidia-dgx/nvidia-dgx-fw-update.yml
@@ -13,5 +13,5 @@
       include_role:
         name: nvidia-dgx-firmware
       vars:
-        run_diagnostics: false
+        run_diagnostics: true
         update_firmware: true

--- a/roles/nvidia-dgx-firmware/defaults/main.yml
+++ b/roles/nvidia-dgx-firmware/defaults/main.yml
@@ -20,12 +20,11 @@ nvsm_dump_health: true
 firmware_update_repo: nvfw-dgxa100
 
 # The Docker tag
-firmware_update_tag: 20.10.9
+firmware_update_tag: 21.11.2
 
 # firmware update container to use and where it is locally stored
-firmware_update_container: "{{ firmware_update_repo }}_{{ firmware_update_tag }}.tar.gz"
-firmware_update_container: "nvfw-dgxa100_20.10.9_201103.tar.gz"
-firmware_container_src_dir: "{{ inventory_dir }}/src/containers/dgx-firmware"
+firmware_update_container: "nvfw-dgxa100_21.11.2_211102.tar.gz"
+firmware_container_src_dir: "{{ inventory_dir }}/containers/dgx-firmware"
 
 # default log directory is set to the location of your inventory file (./deepops/config/)
 local_log_directory: "{{ inventory_dir }}"
@@ -48,8 +47,11 @@ target_fw: all
 # Set force_update to 'true' if you need to downgrade the firmware version
 force_update: false
 
-# Reboot timeout (in seconds)
-reboot_timeout: 600
+# Set inactive_update to 'true' if you need to upgrade inactive components
+inactive_update: false
+
+# Reboot timeout (in seconds) 600s for a normal reboot, longer needed for an SBIOS update
+reboot_timeout: 1200
 
 nv_services:
   - nvsm

--- a/roles/nvidia-dgx-firmware/tasks/check-firmware.yml
+++ b/roles/nvidia-dgx-firmware/tasks/check-firmware.yml
@@ -9,7 +9,7 @@
     state: started
 
 - name: Check firmware manifest
-  shell: "docker run --rm --privileged  -v /:/hostfs {{ firmware_update_repo }}:{{ firmware_update_tag }} show_fw_manifest | tee {{ fw_dir }}/fw-manifests{{ run_diagnostics_type }}.log"
+  shell: "docker run -ti --rm --privileged  -v /:/hostfs {{ firmware_update_repo }}:{{ firmware_update_tag }} show_fw_manifest | tee {{ fw_dir }}/fw-manifests{{ run_diagnostics_type }}.log"
   register: firmware_manifest
 
 # This is an optimization, checking the firmware versions can take a long time, so unless we are forcing an update only do this once
@@ -26,7 +26,19 @@
   debug:
     msg: "{{ firmware_versions_response.stdout }}"
 
-- name: Register firmware as needing upgrade
+- name: Removing Inactive/standby components from consideration for determining firmware_needs_upgrade
+  shell: "grep -v Inactive {{ fw_dir }}/fw-versions{{ run_diagnostics_type }}.log" # Don't count inactive/standby components as needing upgrade
+  register: firmware_versions_response_parsed
+  failed_when: false
+
+- name: Register firmware as needing upgrade - skipping inactive
+  set_fact:
+    firmware_needs_upgrade: "{{ true if 'no' in firmware_versions_response_parsed.stdout or force_update else false }}" # TODO: Parse this from Json?
+  changed_when: firmware_needs_upgrade
+  when: inactive_update is false
+
+- name: Register firmware as needing upgrade - including inactive
   set_fact:
     firmware_needs_upgrade: "{{ true if 'no' in firmware_versions_response.stdout or force_update else false }}" # TODO: Parse this from Json?
   changed_when: firmware_needs_upgrade
+  when: inactive_update

--- a/roles/nvidia-dgx-firmware/tasks/clean.yml
+++ b/roles/nvidia-dgx-firmware/tasks/clean.yml
@@ -21,6 +21,7 @@
 - name: Remove dump tarball
   shell: "rm /tmp/{{ nvsm_dump_file.stdout }}"
   ignore_errors: yes
+  when: nvsm_dump_file.stdout != ''
 
 - name: Remove diagnostic directory
   command: "rm -rf {{ fw_dir }}"

--- a/roles/nvidia-dgx-firmware/tasks/transfer-logs.yml
+++ b/roles/nvidia-dgx-firmware/tasks/transfer-logs.yml
@@ -7,7 +7,25 @@
   register: nvsm_dump_file
   ignore_errors: yes
 
-- name: Copy over all log files, etc.
+# These files are generated when the user requests diagnostics (occurs during firmware update in default playbook)
+- name: Copy over all log files, etc. - from diagnostics
+  ignore_errors: yes
+  fetch:
+    src: "{{ fw_dir }}/{{ item }}"
+    dest: "{{ local_log_directory }}/logs/{{ inventory_hostname }}/{{ inventory_hostname }}-{{ current_time.stdout }}-{{ item }}"
+    flat: yes
+  with_items:
+    - "fw-versions-pre-check.log"
+    - "fw-versions-post-check.log"
+    - "fw-manifests-pre-check.log"
+    - "fw-manifests-post-check.log"
+    - "{{ inventory_hostname }}.log"
+    - "nvsm-show-health.log"
+    - "dcgm_diag_1.log"
+  when: run_diagnostics
+
+# These files are generated when the user reqeuests a firmware update
+- name: Copy over all log files, etc. - from firmware update
   ignore_errors: yes
   fetch:
     src: "{{ fw_dir }}/{{ item }}"
@@ -15,15 +33,37 @@
     flat: yes
   with_items:
     - "fw-manifests.log"
-    - "fw-versions-pre-check.log"
-    - "{{ inventory_hostname }}.log"
-    - "fw-versions-post-check.log"
     - "fw-versions.log"
+  when: update_firmware
+
+# These files are only generated when the firmware is actually updated
+- name: Copy over all log files, etc. - from firmware update output
+  ignore_errors: yes
+  fetch:
+    src: "{{ fw_dir }}/{{ item }}"
+    dest: "{{ local_log_directory }}/logs/{{ inventory_hostname }}/{{ inventory_hostname }}-{{ current_time.stdout }}-{{ item }}"
+    flat: yes
+  with_items:
     - "fw-update.json"
-    - "{{ nvsm_dump_file.stdout }}"
-    - "nvsm-show-health.log"
-    - "dcgm_diag_1.log"
+  when: firmware_needs_upgrade
+ 
+- name: Copy over all log files, etc. - stress tests
+  ignore_errors: yes
+  fetch:
+    src: "{{ fw_dir }}/{{ item }}"
+    dest: "{{ local_log_directory }}/logs/{{ inventory_hostname }}/{{ inventory_hostname }}-{{ current_time.stdout }}-{{ item }}"
+    flat: yes
+  with_items:
     - "dcgm_diag_3.log"
+  when: dcgm_stress
+
+- name: Copy NVSM dump health tarball from /tmp to local machine
+  fetch:
+    src: "/tmp/{{ nvsm_dump_file.stdout }}"
+    dest: "{{ local_log_directory }}/logs/{{ inventory_hostname }}/{{ inventory_hostname }}-{{ current_time.stdout }}-nvsm-dump-health.xz"
+    flat: yes
+  ignore_errors: yes
+  when: nvsm_dump_file.stdout != ''
 
 - name: Copy /var/log/syslog to local machine
   fetch:

--- a/roles/nvidia-dgx-firmware/tasks/transfer-logs.yml
+++ b/roles/nvidia-dgx-firmware/tasks/transfer-logs.yml
@@ -45,7 +45,7 @@
     flat: yes
   with_items:
     - "fw-update.json"
-  when: firmware_needs_upgrade
+  when: update_performed is defined and update_performed is true
  
 - name: Copy over all log files, etc. - stress tests
   ignore_errors: yes

--- a/roles/nvidia-dgx-firmware/tasks/update-firmware.yml
+++ b/roles/nvidia-dgx-firmware/tasks/update-firmware.yml
@@ -13,7 +13,10 @@
   - name: Check if inactive update requested
     set_fact:
       inactive_parameter: "{{ '-i' if inactive_update else '' }}"
-
+  
+  - name: Set update_performed flag
+    set_fact:
+      update_performed: true
 
   - name: Update firmware if required
     shell: "docker run --rm -ti --privileged -v /:/hostfs -e NVSM_MODE=1 {{ firmware_update_repo }}:{{ firmware_update_tag }} set_flags AUTO=1 update_fw {{ target_fw }} {{ inactive_parameter }} {{ force_parameter }} > {{ fw_dir }}/fw-update.json" 

--- a/roles/nvidia-dgx-firmware/tasks/update-firmware.yml
+++ b/roles/nvidia-dgx-firmware/tasks/update-firmware.yml
@@ -9,9 +9,14 @@
   - name: Check if force update requested
     set_fact:
       force_parameter: "{{ '-f' if force_update else '' }}"
+  
+  - name: Check if inactive update requested
+    set_fact:
+      inactive_parameter: "{{ '-i' if inactive_update else '' }}"
+
 
   - name: Update firmware if required
-    shell: "docker run --rm -ti --privileged -v /:/hostfs -e NVSM_MODE=1 {{ firmware_update_repo }}:{{ firmware_update_tag }} set_flags AUTO=1 update_fw {{ target_fw }} {{ force_parameter }} > {{ fw_dir }}/fw-update.json" 
+    shell: "docker run --rm -ti --privileged -v /:/hostfs -e NVSM_MODE=1 {{ firmware_update_repo }}:{{ firmware_update_tag }} set_flags AUTO=1 update_fw {{ target_fw }} {{ inactive_parameter }} {{ force_parameter }} > {{ fw_dir }}/fw-update.json" 
 
   - name: "Parse FW Update output"
     command: "python3 {{ fw_dir }}/parse_manifest.py parse_update_json {{ fw_dir }}/fw-update.json"
@@ -22,7 +27,7 @@
   - name: Register reboot as required
     set_fact:
        reboot_required: true
-    when: fw_update_json.RebootRequired == true
+    when: fw_update_json.RebootRequired is defined and fw_update_json.RebootRequired == true
 
   when:
     - firmware_needs_upgrade | default(false)
@@ -37,7 +42,7 @@
 # TODO: This script does not handle the case of a chassis-levl power cycle being required with ipmitool 
 
 - name: Register power cycle required
-  when: fw_update_json.FirmwareLoadAction == "DC Power Cycle"
+  when: fw_update_json.FirmwareLoadAction is defined and fw_update_json.FirmwareLoadAction == "DC Power Cycle"
   set_fact:
     nv_fw_power_cycle_needed: true
 - name: Tell user to manually power cycle chassis
@@ -55,3 +60,5 @@
     msg: Host is online
 
 - include: verify-firmware.yml
+  when:
+    - firmware_needs_upgrade | default(false)

--- a/roles/nvidia-dgx-firmware/tasks/verify-firmware.yml
+++ b/roles/nvidia-dgx-firmware/tasks/verify-firmware.yml
@@ -2,6 +2,7 @@
 - name: "Parse FW Update output"
   command: "python3 {{ fw_dir }}/parse_manifest.py parse_update_json {{ fw_dir }}/fw-update.json"
   register: result
+  when: firmware_needs_upgrade | default(false)
 
 - name: To json
   set_fact:
@@ -19,7 +20,7 @@
       debug:
         msg: ""
       failed_when: firmware_needs_upgrade | default(true)
-      when: target_fw == 'all' and force_parameter == '' and fw_update_json.State == "Success" # If we forced it or didn't upgrade everything this check would always fail # TODO: parse from json
+      when: target_fw == 'all' and force_parameter | default('')  == '' and fw_update_json.State == "Success" # If we forced it or didn't upgrade everything this check would always fail # TODO: parse from json
   rescue:
     - name: Show debug information for firmware update mismatch
       debug:

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -113,6 +113,7 @@ if command -v virtualenv &> /dev/null ; then
         netaddr \
         ruamel.yaml \
         PyMySQL \
+        parimiko \
         selinux"
 else
     echo "ERROR: Unable to create Python virtual environment, 'virtualenv' command not found"


### PR DESCRIPTION
This is an overall improvement to the documentation flow for updating DGX firmware. In updating these docs I went ahead and made some of the playbooks a bit more robust and improved the usability a bit.

* Install paramiko via pip in setup script
* Improve overall documentation flow with better examples and more details for diagnostics/firmware updates
* Modify playbook to not throw errors if log files/diagnostics were not  generated
* Introduced flag for backing up or skipping inactive firmware components