### PR TITLE
Fix python interpreter key

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -17,7 +17,7 @@ local_tmp=/tmp
 remote_tmp=/tmp
 forks = 25
 force_valid_group_names = ignore
-ansible_python_interpreter = /usr/bin/python3
+interpreter_python = /usr/bin/python3
 
 [ssh_connection]
 pipelining = True


### PR DESCRIPTION
Fix python interpreter key.

ansible.cfg should use `interpreter_python` as documented in https://docs.ansible.com/ansible/2.9/reference_appendices/interpreter_discovery.html