### PR TITLE
[Open OnDemand] Remove task for ood_auth_map.regex permisisons

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,27 @@
+# This workflow warns and then closes issues and PRs that have had no activity for a specified amount of time.
+#
+# You can adjust the behavior by modifying this file.
+# For more information, see:
+# https://github.com/actions/stale
+name: Mark stale issues and pull requests
+
+on:
+  schedule:
+  - cron: '40 0 * * *'
+
+jobs:
+  stale:
+
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+
+    steps:
+    - uses: actions/stale@v3
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        stale-issue-message: 'This issue is stale because it has been open for 60 days with no activity. Please update the issue or it will be closed in 7 days.'
+        stale-pr-message: 'This PR is stale because it has been open for 60 days with no activity. Please update the PR or it will be closed in 7 days.'
+        stale-issue-label: 'no-issue-activity'
+        stale-pr-label: 'no-pr-activity'

--- a/roles/ood-wrapper/tasks/server.yml
+++ b/roles/ood-wrapper/tasks/server.yml
@@ -212,10 +212,3 @@
     mode: 0755
   tags:
     - configure
-
-- name: fix permissions on regex file
-  file:
-    path: "{{ ood_base_dir }}/ood_auth_map/bin/ood_auth_map.regex"
-    mode: 0755
-  tags:
-    - configure


### PR DESCRIPTION
Per the [OOD release notes](https://osc.github.io/ood-documentation/latest/release-notes/v2.0-release-notes.html#no-longer-providing-ood-auth-map-regex), the file `/opt/ood/ood_auth_map/bin/ood_auth_map.regex` is no longer being provided by default by OOD.

Including this task can lead to errors when setting up new OOD instances.

So let's remove it!

Test plan
---------

Successfully execute open-ondemand.yml playbook