### PR TITLE
Change default Interpreter in Ansible system default instead of Python3

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -17,7 +17,7 @@ local_tmp=/tmp
 remote_tmp=/tmp
 forks = 25
 force_valid_group_names = ignore
-interpreter_python = /usr/bin/python3
+ansible_python_interpreter = /usr/bin/python3
 
 [ssh_connection]
 pipelining = True

--- a/workloads/jenkins/scripts/run-gpu-job.sh
+++ b/workloads/jenkins/scripts/run-gpu-job.sh
@@ -16,6 +16,9 @@ if kubectl get pods -n gpu-operator-resources | grep feature-discovery ; then
     kubectl wait --for=condition=ready --timeout=600s pod -n gpu-operator-resources -l app=gpu-feature-discovery
 fi
 
+# Wait a couple minutes for the GPU operator to do its thing
+sleep 120
+
 # Verify GPU Feature Discovery was installed and one or more nodes were labeled, run queries and remove new lines/white space/non-gpu node output
 strategy=$(kubectl get node -o=custom-columns=:.metadata.labels.nvidia\\.com/mig\\.strategy | grep -v none | tr -d '\040\011\012\015')
 product=$(kubectl get node -o=custom-columns=:.metadata.labels.nvidia\\.com/gpu\\.product | grep -v none | tr -d '\040\011\012\015')

--- a/workloads/jenkins/scripts/run-gpu-job.sh
+++ b/workloads/jenkins/scripts/run-gpu-job.sh
@@ -11,13 +11,10 @@ chmod 755 "$K8S_CONFIG_DIR/artifacts/kubectl"
 kubectl get nodes
 kubectl describe nodes
 
-# Wait for GPU feature discovery to finish
-if kubectl get pods -n gpu-operator-resources | grep feature-discovery ; then
-    kubectl wait --for=condition=ready --timeout=600s pod -n gpu-operator-resources -l app=gpu-feature-discovery
+# Wait for GPU operator to finish
+if kubectl get pods -n gpu-operator-resources | grep nvidia-operator-validator ; then
+    kubectl wait --for=condition=ready --timeout=600s pod -n gpu-operator-resources -l app=nvidia-operator-validator
 fi
-
-# Wait a couple minutes for the GPU operator to do its thing
-sleep 120
 
 # Verify GPU Feature Discovery was installed and one or more nodes were labeled, run queries and remove new lines/white space/non-gpu node output
 strategy=$(kubectl get node -o=custom-columns=:.metadata.labels.nvidia\\.com/mig\\.strategy | grep -v none | tr -d '\040\011\012\015')

--- a/workloads/jenkins/scripts/run-gpu-job.sh
+++ b/workloads/jenkins/scripts/run-gpu-job.sh
@@ -11,6 +11,11 @@ chmod 755 "$K8S_CONFIG_DIR/artifacts/kubectl"
 kubectl get nodes
 kubectl describe nodes
 
+# Wait for GPU feature discovery to finish
+if kubectl get pods -n gpu-operator-resources | grep feature-discovery ; then
+    kubectl wait --for=condition=ready --timeout=600s pod -n gpu-operator-resources -l app=gpu-feature-discovery
+fi
+
 # Verify GPU Feature Discovery was installed and one or more nodes were labeled, run queries and remove new lines/white space/non-gpu node output
 strategy=$(kubectl get node -o=custom-columns=:.metadata.labels.nvidia\\.com/mig\\.strategy | grep -v none | tr -d '\040\011\012\015')
 product=$(kubectl get node -o=custom-columns=:.metadata.labels.nvidia\\.com/gpu\\.product | grep -v none | tr -d '\040\011\012\015')

--- a/workloads/jenkins/scripts/test-local-registry.sh
+++ b/workloads/jenkins/scripts/test-local-registry.sh
@@ -37,4 +37,4 @@ ssh \
 kubectl apply -f workloads/jenkins/scripts/files/nginx-from-local-registry.yml
 
 # Wait for the pod to be ready
-kubectl wait --for=condition=ready --timeout=420s pod/nginx-registry-local
+kubectl wait --for=condition=ready --timeout=300s pod/nginx-registry-local

--- a/workloads/jenkins/scripts/test-local-registry.sh
+++ b/workloads/jenkins/scripts/test-local-registry.sh
@@ -37,4 +37,4 @@ ssh \
 kubectl apply -f workloads/jenkins/scripts/files/nginx-from-local-registry.yml
 
 # Wait for the pod to be ready
-kubectl wait --for=condition=ready --timeout=300s pod/nginx-registry-local
+kubectl wait --for=condition=ready --timeout=420s pod/nginx-registry-local


### PR DESCRIPTION
With this commit the Testing jobs on CentOS 7 began failing: https://github.com/NVIDIA/deepops/commit/2df93228dc0d9048b37759b290480fbf9e384e52

I am changing the reference to python3 to simply be default python. Hopefully this executes the correct Python version on each platform.