### PR TITLE
Enable repos for Singularity on EL8

### DIFF
--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -1,0 +1,30 @@
+---
+name: test ansible roles with molecule
+on:
+  - push
+  - pull_request
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+    strategy:
+      max-parallel: 4
+      matrix:
+        deepops-role:
+          - singularity_wrapper
+    steps:
+      - name: check out repo
+        uses: actions/checkout@v2
+        with:
+          path: "${{ github.repository }}"
+      - name: set up python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.10
+      - name: install dependencies
+        run: |
+          python3 -m pip install --upgrade pip
+          python3 -m pip install "molecule[docker,lint]"
+      - name: run molecule test
+        run: |
+          cd "${{ github.repository }}/roles/${{ matrix.deepops-role }}"
+          molecule test

--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -24,6 +24,7 @@ jobs:
         run: |
           python3 -m pip install --upgrade pip
           python3 -m pip install "molecule[docker,lint]"
+          python3 -m pip install docker
       - name: run molecule test
         run: |
           cd "${{ github.repository }}/roles/${{ matrix.deepops-role }}"

--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -19,7 +19,7 @@ jobs:
       - name: set up python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.10
+          python-version: "3.10"
       - name: install dependencies
         run: |
           python3 -m pip install --upgrade pip

--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -24,7 +24,7 @@ jobs:
         run: |
           python3 -m pip install --upgrade pip
           python3 -m pip install "molecule[docker,lint]"
-          python3 -m pip install docker
+          python3 -m pip install docker requests
       - name: run molecule test
         run: |
           cd "${{ github.repository }}/roles/${{ matrix.deepops-role }}"

--- a/playbooks/container/singularity.yml
+++ b/playbooks/container/singularity.yml
@@ -2,6 +2,20 @@
 - hosts: all
   become: yes
   pre_tasks:
+  - name: centos 8 - ensure powertools installed
+    block:
+      - name: ensure prereq packages installed
+        yum:
+          name: "dnf-plugins-core"
+          state: "present"
+      - name: enable powertools
+        command: "yum config-manager --set-enabled powertools"
+        warn: false
+    when: (ansible_distribution == "CentOS") and (ansible_distribution_major_version == "8")
+  - name: rhel 8 - ensure CRB repository is enabled
+    rhsm_repository:
+      name: "codeready-builder-for-rhel-8-x86_64-rpms"
+    when: (ansible_distribution == "Red Hat Enterprise Linux") and (ansible_distribution_major_version == "8")
   - name: create a folder for go
     file:
       path: "{{ golang_install_dir }}"

--- a/roles/requirements.yml
+++ b/roles/requirements.yml
@@ -9,7 +9,7 @@ collections:
 
 roles:
 
-- include: singularity_wrapper/requirements.yml
+- include: singularity_wrapper/roles.yml
 
 - src: dev-sec.ssh-hardening
   version: "6.1.3"

--- a/roles/requirements.yml
+++ b/roles/requirements.yml
@@ -9,6 +9,8 @@ collections:
 
 roles:
 
+- include: singularity_wrapper/requirements.yml
+
 - src: dev-sec.ssh-hardening
   version: "6.1.3"
 
@@ -60,9 +62,3 @@ roles:
 
 - src: https://github.com/OSC/ood-ansible.git
   version: 'v2.0.3'
-
-- src: gantsign.golang
-  version: 2.4.0
-
-- src: lecorguille.singularity
-  version: 1.2.0

--- a/roles/singularity_wrapper/.yamllint
+++ b/roles/singularity_wrapper/.yamllint
@@ -1,0 +1,33 @@
+---
+# Based on ansible-lint config
+extends: default
+
+rules:
+  braces:
+    max-spaces-inside: 1
+    level: error
+  brackets:
+    max-spaces-inside: 1
+    level: error
+  colons:
+    max-spaces-after: -1
+    level: error
+  commas:
+    max-spaces-after: -1
+    level: error
+  comments: disable
+  comments-indentation: disable
+  document-start: disable
+  empty-lines:
+    max: 3
+    level: error
+  hyphens:
+    level: error
+  indentation: disable
+  key-duplicates: enable
+  line-length: disable
+  new-line-at-end-of-file: disable
+  new-lines:
+    type: unix
+  trailing-spaces: disable
+  truthy: disable

--- a/roles/singularity_wrapper/defaults/main.yml
+++ b/roles/singularity_wrapper/defaults/main.yml
@@ -5,6 +5,5 @@ singularity_conf_path: "/etc/singularity/singularity.conf"
 bind_paths: []
 
 # vars for gantsign.golang
-golang_version: "1.16.12"
 golang_install_dir: "/opt/go/{{ golang_version }}"
 golang_gopath: "/opt/go/packages"

--- a/roles/singularity_wrapper/defaults/main.yml
+++ b/roles/singularity_wrapper/defaults/main.yml
@@ -1,0 +1,10 @@
+---
+# vars for lecorguille.singularity
+singularity_version: "3.7.3"
+singularity_conf_path: "/etc/singularity/singularity.conf"
+bind_paths: []
+
+# vars for gantsign.golang
+golang_version: "1.16.12"
+golang_install_dir: "/opt/go/{{ golang_version }}"
+golang_gopath: "/opt/go/packages"

--- a/roles/singularity_wrapper/defaults/main.yml
+++ b/roles/singularity_wrapper/defaults/main.yml
@@ -5,5 +5,6 @@ singularity_conf_path: "/etc/singularity/singularity.conf"
 bind_paths: []
 
 # vars for gantsign.golang
+golang_version: "1.14.4"
 golang_install_dir: "/opt/go/{{ golang_version }}"
 golang_gopath: "/opt/go/packages"

--- a/roles/singularity_wrapper/meta/main.yml
+++ b/roles/singularity_wrapper/meta/main.yml
@@ -1,0 +1,9 @@
+---
+galaxy_info:
+  role_name: singularity_wrapper
+  namespace: deepops
+  author: DeepOps Team
+  company: NVIDIA
+  description: Wrap lecourguille.singularity role
+  license: 3-Clause BSD
+  min_ansible_version: 2.9

--- a/roles/singularity_wrapper/molecule/default/converge.yml
+++ b/roles/singularity_wrapper/molecule/default/converge.yml
@@ -1,0 +1,7 @@
+---
+- name: Converge
+  hosts: all
+  tasks:
+    - name: "Include singularity_wrapper"
+      include_role:
+        name: "singularity_wrapper"

--- a/roles/singularity_wrapper/molecule/default/molecule.yml
+++ b/roles/singularity_wrapper/molecule/default/molecule.yml
@@ -1,0 +1,17 @@
+---
+dependency:
+  name: galaxy
+  options:
+    requirements-file: requirements.yml
+driver:
+  name: docker
+platforms:
+  - name: ubuntu-1804
+    image: geerlingguy/docker-ubuntu1804-ansible
+    pre_build_image: true
+provisioner:
+  name: ansible
+  ansible_args:
+  - -vv
+verifier:
+  name: ansible

--- a/roles/singularity_wrapper/molecule/default/verify.yml
+++ b/roles/singularity_wrapper/molecule/default/verify.yml
@@ -1,0 +1,10 @@
+---
+# This is an example playbook to execute Ansible tests.
+
+- name: Verify
+  hosts: all
+  gather_facts: false
+  tasks:
+  - name: Example assertion
+    assert:
+      that: true

--- a/roles/singularity_wrapper/requirements.yml
+++ b/roles/singularity_wrapper/requirements.yml
@@ -1,4 +1,3 @@
-- src: abims_sbr.singularity
-  version: 3.7.1-1
-- src: gantsign.golang
-  version: 2.4.0
+---
+roles:
+- include: roles.yml

--- a/roles/singularity_wrapper/requirements.yml
+++ b/roles/singularity_wrapper/requirements.yml
@@ -3,4 +3,4 @@ roles:
 - src: abims_sbr.singularity
   version: 3.7.1-1
 - src: gantsign.golang
-  version: 2.9.5
+  version: 2.4.0

--- a/roles/singularity_wrapper/requirements.yml
+++ b/roles/singularity_wrapper/requirements.yml
@@ -1,0 +1,6 @@
+---
+roles:
+- src: abims_sbr.singularity
+  version: 3.7.1-1
+- src: gantsign.golang
+  version: 2.9.5

--- a/roles/singularity_wrapper/requirements.yml
+++ b/roles/singularity_wrapper/requirements.yml
@@ -1,5 +1,3 @@
----
-roles:
 - src: abims_sbr.singularity
   version: 3.7.1-1
 - src: gantsign.golang

--- a/roles/singularity_wrapper/roles.yml
+++ b/roles/singularity_wrapper/roles.yml
@@ -1,0 +1,4 @@
+- src: abims_sbr.singularity
+  version: 3.7.1-1
+- src: gantsign.golang
+  version: 2.4.0

--- a/roles/singularity_wrapper/tasks/main.yml
+++ b/roles/singularity_wrapper/tasks/main.yml
@@ -1,0 +1,35 @@
+---
+- name: centos 8 - ensure powertools installed
+  block:
+    - name: ensure prereq packages installed
+      yum:
+        name: "dnf-plugins-core"
+        state: "present"
+    - name: enable powertools
+      command: "yum config-manager --set-enabled powertools"
+      register: enable_powertools
+      changed_when: enable_powertools.rc != 0
+  when: (ansible_distribution == "CentOS") and (ansible_distribution_major_version == "8")
+
+- name: rhel 8 - ensure CRB repository is enabled
+  rhsm_repository:
+    name: "codeready-builder-for-rhel-8-x86_64-rpms"
+  when: (ansible_distribution == "Red Hat Enterprise Linux") and (ansible_distribution_major_version == "8")
+
+- name: debian - ensure apt cache is up to date
+  apt:
+    update_cache: yes
+  when: ansible_os_family == "Debian"
+
+- name: create a folder for go
+  file:
+    path: "{{ golang_install_dir }}"
+    recurse: yes
+
+- name: install golang explicitly
+  include_role:
+    name: gantsign.golang
+
+- name: install singularity
+  include_role:
+    name: abims_sbr.singularity

--- a/roles/singularity_wrapper/vars/main.yml
+++ b/roles/singularity_wrapper/vars/main.yml
@@ -1,0 +1,2 @@
+---
+golang_version: "1.15.15"

--- a/roles/singularity_wrapper/vars/main.yml
+++ b/roles/singularity_wrapper/vars/main.yml
@@ -1,2 +1,0 @@
----
-golang_version: "1.15.15"


### PR DESCRIPTION
Installing Singularity on CentOS 8 or RHEL 8 requires the `gpgme-devel` package be installed, but this isn't available in the default repos.

On CentOS 8, we need to enable the PowerTools repo.

On RHEL 8, we need to enable the Code Ready Builder repo.

This should address #1072.

Test plan
----------

Successful run of `playbooks/container/singularity.yml`.