### PR TITLE
Update Slurm ElasticSearch logging playbook for log4shell

### DIFF
--- a/playbooks/slurm-cluster/files/cve_2021_44228.options
+++ b/playbooks/slurm-cluster/files/cve_2021_44228.options
@@ -1,0 +1,1 @@
+-Dlog4j2.formatMsgNoLookups=true

--- a/playbooks/slurm-cluster/logging.yml
+++ b/playbooks/slurm-cluster/logging.yml
@@ -3,21 +3,59 @@
   become: true
   vars:
     elasticsearch_network_host: 0.0.0.0
-    logstash_listen_port_beats: 5000
   roles:
-    - geerlingguy.java
-    - geerlingguy.elasticsearch
-    - geerlingguy.logstash
-    - geerlingguy.kibana
+    - robertdebock.java
+    - robertdebock.elastic_repo
+    - robertdebock.elasticsearch
+    - robertdebock.logstash
+    - robertdebock.kibana
+
+- hosts: slurm-master[0]
+  become: true
+  vars:
+    filebeat_port: "5000"
   tasks:
-    - name: fix bug in logstash role
-      command: /usr/share/logstash/bin/logstash-plugin install logstash-filter-multiline
+  - name: configure logstash to accept logs from filebeat
+    template:
+      src: "filebeat.conf"
+      dest: "/etc/logstash/conf.d/filebeat.conf"
+      owner: "root"
+      group: "root"
+      mode: "0644"
+
+# Mitigation for CVE-2021-44228 impacting Log4j2
+# https://discuss.elastic.co/t/apache-log4j2-remote-code-execution-rce-vulnerability-cve-2021-44228-esa-2021-31/291476
+- hosts: slurm-master[0]
+  become: yes
+  tasks:
+  - name: configure elasticsearch to mitigate CVE-2021-44228
+    copy:
+      src: "cve_2021_44228.options"
+      dest: "/etc/elasticsearch/jvm.options.d/cve_2021_44228.options"
+      owner: "root"
+      group: "root"
+      mode: "0644"
+    notify:
+    - restart-elasticsearch
+  - name: configure logstash to mitigate CVE-2021-44228
+    shell: zip -q -d /usr/share/logstash/logstash-core/lib/jars/log4j-core-2.* org/apache/logging/log4j/core/lookup/JndiLookup.class
+    notify:
+    - restart-logstash
+  handlers:
+  - name: restart-elasticsearch
+    service:
+      name: elasticsearch
+      state: restarted
+  - name: restart-logstash
+    service:
+      name: logstash
+      state: restarted
 
 - hosts: slurm-cluster
   become: true
   vars:
     filebeat_create_config: true
-    filebeat_prospectors:
+    filebeat_inputs:
       - input_type: log
         paths:
           - "/var/log/*.log"

--- a/playbooks/slurm-cluster/logging.yml
+++ b/playbooks/slurm-cluster/logging.yml
@@ -3,6 +3,11 @@
   become: true
   vars:
     elasticsearch_network_host: 0.0.0.0
+  pre_tasks:
+    - name: debian - ensure apt cache updated
+      apt:
+        update_cache: true
+      when: ansible_os_family == "Debian"
   roles:
     - robertdebock.java
     - robertdebock.elastic_repo

--- a/playbooks/slurm-cluster/logging.yml
+++ b/playbooks/slurm-cluster/logging.yml
@@ -42,10 +42,16 @@
       mode: "0644"
     notify:
     - restart-elasticsearch
+  - name: check for relevant class in logstash
+    shell: unzip -l /usr/share/logstash/logstash-core/lib/jars/log4j-core-2.* | grep JndiLookup.class
+    register: logstash_jndi
+    changed_when: logstash_jndi.rc == 0
+    failed_when: logstash_jndi.rc == 2
   - name: configure logstash to mitigate CVE-2021-44228
     shell: zip -q -d /usr/share/logstash/logstash-core/lib/jars/log4j-core-2.* org/apache/logging/log4j/core/lookup/JndiLookup.class
     notify:
     - restart-logstash
+    when: logstash_jndi.changed
   handlers:
   - name: restart-elasticsearch
     service:

--- a/playbooks/slurm-cluster/logging.yml
+++ b/playbooks/slurm-cluster/logging.yml
@@ -52,6 +52,13 @@
     notify:
     - restart-logstash
     when: logstash_jndi.changed
+  - name: manually stop logstash as restart is not consistently working later
+    service:
+      name: logstash
+      state: stopped
+    notify:
+    - restart-logstash
+    when: logstash_jndi.changed
   handlers:
   - name: restart-elasticsearch
     service:

--- a/playbooks/slurm-cluster/templates/filebeat.conf
+++ b/playbooks/slurm-cluster/templates/filebeat.conf
@@ -1,0 +1,12 @@
+input {
+  beats {
+    port => {{ filebeat_port }} 
+  }
+}
+
+output {
+  elasticsearch {
+    hosts => ["http://localhost:9200"]
+    index => "%{[@metadata][beat]}-%{[@metadata][version]}" 
+  }
+}

--- a/roles/requirements.yml
+++ b/roles/requirements.yml
@@ -36,19 +36,22 @@ roles:
   version: "v0.5.0"
 
 - src: geerlingguy.filebeat
-  version: "2.0.1"
+  version: "3.3.0"
 
-- src: geerlingguy.logstash
-  version: "4.0.0"
+- src: robertdebock.java
+  version: "4.1.1"
 
-- src: geerlingguy.elasticsearch
-  version: "3.0.1"
+- src: robertdebock.elastic_repo
+  version: "1.0.3"
 
-- src: geerlingguy.java
-  version: "1.9.5"
+- src: robertdebock.logstash
+  version: "1.1.1"
 
-- src: geerlingguy.kibana
-  version: "3.2.1"
+- src: robertdebock.elasticsearch
+  version: "1.1.3"
+
+- src: robertdebock.kibana
+  version: "1.2.4"
 
 - src: https://github.com/DeepOps/ansible-maas.git
   name: ansible-maas


### PR DESCRIPTION
Summary
-------

- Update Ansible Galaxy requirements to use a different set of roles
(due to the old ones not working)

- Update logging.yml playbook to make use of the new Galaxy roles

- Add mitigations for CVE-2021-44228 as documented in
https://discuss.elastic.co/t/apache-log4j2-remote-code-execution-rce-vulnerability-cve-2021-44228-esa-2021-31/291476

Note that mitigations are applied for ElasticSearch and Logstash.
Kibana and Filebeat are confirmed to not be impacted.

Test plan
---------

Successful execution of the logging.yml playbook