### PR TITLE
Add Log4Shell mitigation to ES statefulset example

### DIFF
--- a/workloads/examples/k8s/services/logging/es-statefulset.yaml
+++ b/workloads/examples/k8s/services/logging/es-statefulset.yaml
@@ -98,6 +98,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: "ES_JAVA_OPTS"
+          value: "-Dlog4j2.formatMsgNoLookups=true"
       volumes:
       - name: elasticsearch-logging
         persistentVolumeClaim:


### PR DESCRIPTION
As documented in
https://discuss.elastic.co/t/apache-log4j2-remote-code-execution-rce-vulnerability-cve-2021-44228-esa-2021-31/291476
and
https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-customize-pods.html#k8s-customize-pods,
adds a custom option ES_JAVA_OPTS to disable message lookups in Log4j2