### PR TITLE
Adjust Github stale workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -22,7 +22,7 @@ jobs:
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         stale-issue-message: 'This issue is stale because it has been open for 60 days with no activity. Please update the issue or it will be closed in 7 days.'
-        stale-pr-message: 'This PR is stale because it has been open for 60 days with no activity. Please update the PR or it will be closed in 7 days.'
+        stale-pr-message: 'This PR is stale because it has been open for 180 days with no activity. Please update the PR or it will be closed in 7 days.'
         stale-issue-label: 'no-issue-activity'
         stale-pr-label: 'no-pr-activity'
         days-before-issue-stale: 60

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -25,3 +25,7 @@ jobs:
         stale-pr-message: 'This PR is stale because it has been open for 60 days with no activity. Please update the PR or it will be closed in 7 days.'
         stale-issue-label: 'no-issue-activity'
         stale-pr-label: 'no-pr-activity'
+        days-before-issue-stale: 60
+        days-before-pr-stale: 180
+        exempt-pr-labels: 'no-stale'
+        exempt-issue-labels: 'no-stale'


### PR DESCRIPTION
- Increase timeout for PRs to 180 days
- Explicitly specify timeout for issues as 60 days
- Add support for a `no-stale` label to mark PRs and issues as exempt

Note: docs for stale action found here: https://github.com/actions/stale/blob/main/README.md