### PR TITLE
Fix for #1085.

### DIFF
--- a/playbooks/slurm-cluster.yml
+++ b/playbooks/slurm-cluster.yml
@@ -89,17 +89,17 @@
 # Install monitoring services
 - include: slurm-cluster/prometheus.yml
   vars:
-    hostlist: "{{ slurm_monitoring_group | default('slurm-master[0]') }}"
+    hostlist: "{{ slurm_monitoring_group | default('slurm-metric') }}"
   when: slurm_enable_monitoring
 - include: slurm-cluster/grafana.yml
   vars:
-    hostlist: "{{ slurm_monitoring_group | default('slurm-master[0]') }}"
+    hostlist: "{{ slurm_monitoring_group | default('slurm-metric') }}"
   when: slurm_enable_monitoring
 
 # Install monitoring exporters
 - include: slurm-cluster/prometheus-slurm-exporter.yml
   vars:
-    hostlist: "{{ slurm_monitoring_group | default('slurm-master[0]') }}"
+    hostlist: "{{ slurm_monitoring_group | default('slurm-metric') }}"
   when: slurm_enable_monitoring
 - include: slurm-cluster/prometheus-node-exporter.yml
   when: slurm_enable_monitoring


### PR DESCRIPTION
Instead of using `slurm-master[0]` as default value for 'slurm_monitoring_group` variable use `slurm-metric`. In this case it is necessary to assign some node in `slurm-metric` group in the inventory.