### PR TITLE
Break out functional host groups for slurm cluster

### DIFF
--- a/config.example/inventory
+++ b/config.example/inventory
@@ -45,6 +45,9 @@ kube-node
 [slurm-master]
 #login01
 
+[slurm-nfs]
+#login01
+
 [slurm-node]
 #gpu01
 #gpu02
@@ -56,8 +59,8 @@ kube-node
 [slurm-cache:children]
 slurm-master
 
-[slurm-nfs:children]
-slurm-master
+[slurm-nfs-client:children]
+slurm-node
 
 [slurm-metric:children]
 slurm-master

--- a/config.example/inventory
+++ b/config.example/inventory
@@ -49,9 +49,30 @@ kube-node
 #gpu01
 #gpu02
 
+# The following groups are used to break out individual cluster services onto
+# different nodes. By default, we put all these functions on the cluster head
+# node. To break these out into different nodes, replace the
+# [group:children] section with [group], and list individual nodes.
+[slurm-cache:children]
+slurm-master
+
+[slurm-nfs:children]
+slurm-master
+
+[slurm-metric:children]
+slurm-master
+
+[slurm-login:children]
+slurm-master
+
+# Single group for the whole cluster
 [slurm-cluster:children]
 slurm-master
 slurm-node
+slurm-cache
+slurm-nfs
+slurm-metric
+slurm-login
 
 ######
 # SSH connection configuration

--- a/docs/slurm-cluster/large-deployments.md
+++ b/docs/slurm-cluster/large-deployments.md
@@ -67,34 +67,24 @@ The most common case in which you will want to add additional service nodes, is 
 This provides a level of isolation between user activity and the Slurm cluster services, so that user activity is less likely to negatively impact the cluster services.
 Multiple login nodes may also be deployed to allow you to provide services to a larger number of users, or for high availability.
 
-Separate user login nodes need to have the Slurm packages installed, but should not run any Slurm services such as `slurmd` or `slurmctld`.
-In DeepOps, this can be accomplished by adding these machines to the `slurm-cluster` inventory group, but not to the `slurm-master` or `slurm-node` groups.
-
-For example, the following inventory file can be used to set up a cluster with one controller, two login nodes, and two compute nodes.
+Separate login nodes may be configured in the inventory file using the `slurm-login` group.
+Replace the following section, which adds the `slurm-master` hosts to `slurm-login` by default:
 
 ```
-[slurm-master]
-slurm-controller01
-
-[slurm-login]
-slurm-login01
-slurm-login02
-
-[slurm-node]
-slurm-compute01
-slurm-compute02
-
-[slurm-cluster:children]
+[slurm-login:children]
 slurm-master
-slurm-login
-slurm-node
 ```
+
+With a list of login nodes:
+
+```
+[slurm-login]
+login01
+login02
+```
+
 
 ### Separate monitoring node
-
-| Variable | Default value |
-| -------- | ------------- |
-| `slurm_monitoring_group` | `slurm-master` |
 
 The Slurm monitoring services are deployed to whichever hosts are specified in the variable `slurm_monitoring_group`.
 This should be the name of an Ansible inventory hostgroup with one node.
@@ -103,97 +93,48 @@ In the default configuration, we run the monitoring services on the Slurm contro
 Note that in order to correctly monitor Slurm, the monitoring node must have Slurm installed and have access to the cluster.
 As with the login nodes, the easiest way to do this is to add the monitoring node to the `slurm-cluster` group, but not to `slurm-master` or `slurm-node`.
 
-So, for example, the following inventory file should allow a monitoring node to be deployed:
+Separate monitoring nodes may be configured in the inventory file using the `slurm-metric` group.
+Replace this section:
 
 ```
-[slurm-master]
-slurm-controller01
-
-[slurm-monitoring]
-slurm-mon01
-
-[slurm-node]
-slurm-compute01
-slurm-compute02
-
-[slurm-cluster:children]
+[slurm-metric:children]
 slurm-master
-slurm-monitoring
-slurm-node
-``` 
+```
 
-With the following variable configured:
+With a list of monitoring nodes:
 
 ```
-slurm_monitoring_group: "slurm-monitoring"
+[slurm-metric]
+metric01
+metric02
 ```
+
 
 ### Separate NFS server
 
 Our Slurm cluster deployment relies on a shared NFS filesystem across the cluster.
 One machine is used to run the NFS server, and all other machines in the cluster are NFS clients.
-We specify these machines using these variables:
+By default, the NFS server is the first host in the `slurm-master` group.
 
-| Variable | Default value |
-| -------- | ------------- |
-| `nfs_server_group` | `slurm-master[0]` |
-| `nfs_client_group` | `slurm-master[1:],slurm-node` |
-
-To change this topology, you can change these variables to run the NFS server and client playbooks on a different set of hosts.
-
-### Example: NFS on login node, with separate Slurm controller
-
-Inventory:
+To change this topology, you can use the `slurm-nfs` and `slurm-nfs-client` host groups.
+For example, to specify a separate NFS server from the cluster head node, change this:
 
 ```
-[slurm-master]
-slurm-controller01
+# Where login01 is also a member of slurm-master
+[slurm-nfs]
+login01
 
-[slurm-login]
-slurm-login01
-
-[slurm-node]
-slurm-compute01
-slurm-compute02
-
-[slurm-cluster:children]
-slurm-master
-slurm-login
+[slurm-nfs-client:children]
 slurm-node
 ```
 
-Variables:
+To this:
 
 ```
-nfs_server_group: "slurm-login[0]"
-nfs_client_group: "slurm-master,slurm-node"
+[slurm-nfs]
+nfs01
+
+[slurm-nfs-client:children]
+slurm-master
+slurm-node
 ```
-
-#### Example: NFS on separate machine not in the Slurm cluster 
-
-In many cases, large deployments will have pre-existing NFS filesystems available which DeepOps should mount.
-In this case, we can choose not to deploy an NFS server, but instead simply configure all nodes as clients.
-
-In order to disable NFS server deployment, you should set:
-
-```
-slurm_enable_nfs_server: false
-```
-
-Then, to configure all hosts to mount from one or more external servers, configure:
-
-```
-nfs_client_group: "slurm-cluster"
-
-nfs_mounts:
-- mountpoint: /home
-  server: external-nfs-server-01.example.com
-  path: /export/home
-  options: async,vers=3
-- mountpoint: /shared
-  server: external-nfs-server-02.example.com
-  path: /export/shared
-  options: async,vers=3
-```
-
-Where the parameters to `nfs_mounts` should be adjusted based on your local environment.

--- a/playbooks/slurm-cluster.yml
+++ b/playbooks/slurm-cluster.yml
@@ -29,7 +29,7 @@
 # Set up NGINX-based container caching
 - include: container/nginx-docker-registry-cache-server.yml
   vars:
-    hostlist: "{{ nginx_docker_cache_hostgroup | default('slurm-master') }}"
+    hostlist: "{{ nginx_docker_cache_hostgroup | default('slurm-cache') }}"
   when: slurm_enable_nginx_docker_cache | default(false)
 - include: container/nginx-docker-registry-cache-client.yml
   vars:
@@ -54,7 +54,7 @@
 # Set up NFS filesystem
 - include: generic/nfs-server.yml
   vars:
-    hostlist: "{{ nfs_server_group | default('slurm-master[0]') }}"
+    hostlist: "{{ nfs_server_group | default('slurm-nfs[0]') }}"
   when: slurm_enable_nfs_server
 - include: generic/nfs-client.yml
   vars:
@@ -83,7 +83,7 @@
 # Install the NVIDIA HPC SDK
 - include: nvidia-software/nvidia-hpc-sdk.yml
   vars:
-    hostlist: "{{ sm_install_host | default('slurm-master[0]')}}"
+    hostlist: "{{ sm_install_host | default('slurm-login[0]')}}"
   when: slurm_install_hpcsdk
 
 # Install monitoring services

--- a/playbooks/slurm-cluster.yml
+++ b/playbooks/slurm-cluster.yml
@@ -58,7 +58,7 @@
   when: slurm_enable_nfs_server
 - include: generic/nfs-client.yml
   vars:
-    hostlist: "{{ nfs_client_group | default('slurm-master[1:],slurm-node') }}"
+    hostlist: "{{ nfs_client_group | default('slurm-nfs-client') }}"
   when: slurm_enable_nfs_client_nodes
 
 # Install DCGM

--- a/virtual/virtual_inventory
+++ b/virtual/virtual_inventory
@@ -35,6 +35,9 @@ kube-node
 [slurm-master]
 virtual-login01
 
+[slurm-nfs]
+virtual-login01
+
 [slurm-node]
 virtual-gpu01
 
@@ -45,8 +48,8 @@ virtual-gpu01
 [slurm-cache:children]
 slurm-master
 
-[slurm-nfs:children]
-slurm-master
+[slurm-nfs-client:children]
+slurm-node
 
 [slurm-metric:children]
 slurm-master

--- a/virtual/virtual_inventory
+++ b/virtual/virtual_inventory
@@ -38,9 +38,30 @@ virtual-login01
 [slurm-node]
 virtual-gpu01
 
+# The following groups are used to break out individual cluster services onto
+# different nodes. By default, we put all these functions on the cluster head
+# node. To break these out into different nodes, replace the
+# [group:children] section with [group], and list individual nodes.
+[slurm-cache:children]
+slurm-master
+
+[slurm-nfs:children]
+slurm-master
+
+[slurm-metric:children]
+slurm-master
+
+[slurm-login:children]
+slurm-master
+
+# Single group for the whole cluster
 [slurm-cluster:children]
 slurm-master
 slurm-node
+slurm-cache
+slurm-nfs
+slurm-metric
+slurm-login
 
 ######
 # SSH connection configuration

--- a/virtual/virtual_inventory_full
+++ b/virtual/virtual_inventory_full
@@ -46,6 +46,9 @@ kube-node
 [slurm-master]
 virtual-login01
 
+[slurm-nfs]
+virtual-login01
+
 [slurm-node]
 virtual-gpu01
 virtual-gpu02
@@ -57,8 +60,8 @@ virtual-gpu02
 [slurm-cache:children]
 slurm-master
 
-[slurm-nfs:children]
-slurm-master
+[slurm-nfs-client:children]
+slurm-node
 
 [slurm-metric:children]
 slurm-master

--- a/virtual/virtual_inventory_full
+++ b/virtual/virtual_inventory_full
@@ -50,9 +50,30 @@ virtual-login01
 virtual-gpu01
 virtual-gpu02
 
+# The following groups are used to break out individual cluster services onto
+# different nodes. By default, we put all these functions on the cluster head
+# node. To break these out into different nodes, replace the
+# [group:children] section with [group], and list individual nodes.
+[slurm-cache:children]
+slurm-master
+
+[slurm-nfs:children]
+slurm-master
+
+[slurm-metric:children]
+slurm-master
+
+[slurm-login:children]
+slurm-master
+
+# Single group for the whole cluster
 [slurm-cluster:children]
 slurm-master
 slurm-node
+slurm-cache
+slurm-nfs
+slurm-metric
+slurm-login
 
 ######
 # SSH connection configuration

--- a/virtual/virtual_inventory_large_slurm
+++ b/virtual/virtual_inventory_large_slurm
@@ -46,6 +46,9 @@ virtual-gpu02
 [slurm-nfs]
 virtual-nfs01
 
+[slurm-nfs-client:children]
+slurm-node
+
 [slurm-cluster:children]
 slurm-master
 slurm-node


### PR DESCRIPTION
Summary
-------

- Add new hostgroups to the example inventory file based on the
different functional node types we expect on a Slurm cluster
- Use those hostgroup names as the defaults when selecting which hosts
to run on in the slurm-cluster.yml playbook

Detail
------

DeepOps supports breaking out Slurm cluster topology in a few different
ways.

This includes simple clusters with a single "head node" that runs all
the services like slurmctld, nfs, and monitoring... All the way up to
SuperPODs, where we have 5 different types of management node and split
up the functionality between them.

We support all of this in a single slurm-cluster.yml playbook by using
include tasks that look like this:

```
- include: generic/nfs-server.yml
  vars:
    hostlist: "{{ nfs_server_group | default('slurm-master[0]') }}"
  when: slurm_enable_nfs_server
```

And the playbook uses that hostlist var like so to decide what hosts to
run on:

```
---
- hosts: "{{ hostlist | default('all') }}"
  become: yes
  roles:
    - { role: nfs, nfs_is_server: yes }
  tags:
    - nfs_server
```
So that, for example, we default to putting the NFS server on the first
member of the slurm-master group.

But in theory we can define a variable nfs_server_group to be called
something like slurm-nfs, and put a different host in there.

Maksim Kunin discovered that this works when the variable is defined in
an --extra-vars file, but not when it's defined in group_vars. See issue
https://github.com/NVIDIA/deepops/issues/1085

I dug into this, and I think I know why.

When Ansible executes the included playbook, it appears to evaluate this
line:

```
- hosts: "{{ hostlist | default('all') }}"
```

to something like this:

```
- hosts: "{{ (slurm_monitoring_group | default('slurm-master[0]') ) | default('all') }}"
```

It turns out that Ansible only sources variables from group_vars/ when
it is executing on hosts that are members of the specified inventory
group.

However, when Ansible is evaluating the hosts: ... line of a play, it
doesn't know yet what hosts it will be running on. So it doesn't include
any of the variables defined in group_vars/ or host_vars/

Unfortunately, that means that slurm_monitoring_group is effectively
undefined here, even if it's defined in group_vars/slurm-cluster.yml.
Because Ansible hasn't decided it's running on a host in the
slurm-cluster group, it hasn't sourced that file.

--extra-vars works because it's specified at the level of the
ansible-playbook execution, so the variable is already defined.

This is really annoying! It's really helpful to be able to decide
dynamically which hosts to run on, and it would be nice to be able to
control this in our DeepOps config directly.

To solve this, we add new groups to the inventory based on our different
functional node types, and then use those group names in the playbook directly.