### PR TITLE
Add proxy config to standalone container registry

### DIFF
--- a/roles/standalone-container-registry/defaults/main.yml
+++ b/roles/standalone-container-registry/defaults/main.yml
@@ -19,3 +19,6 @@ standalone_container_registry_cache_enable: false
 standalone_container_registry_cache_upstream: "https://registry-1.docker.io"
 # standalone_container_registry_cache_username: 
 # standalone_container_registry_cache_password:
+
+# standalone_container_registry_http_proxy:
+# standalone_container_registry_https_proxy:

--- a/roles/standalone-container-registry/defaults/main.yml
+++ b/roles/standalone-container-registry/defaults/main.yml
@@ -19,6 +19,3 @@ standalone_container_registry_cache_enable: false
 standalone_container_registry_cache_upstream: "https://registry-1.docker.io"
 # standalone_container_registry_cache_username: 
 # standalone_container_registry_cache_password:
-
-# standalone_container_registry_http_proxy:
-# standalone_container_registry_https_proxy:

--- a/roles/standalone-container-registry/tasks/main.yml
+++ b/roles/standalone-container-registry/tasks/main.yml
@@ -53,5 +53,8 @@
     network_mode: host
     restart: yes
     restart_policy: unless-stopped
+    env:
+      http_proxy: "{{ standalone_container_registry_http_proxy }}"
+      https_proxy: "{{ standalone_container_registry_https_proxy }}"
     volumes:
     - "{{ standalone_container_registry_config_dir }}/config.yml:/etc/docker/registry/config.yml"

--- a/roles/standalone-container-registry/tasks/main.yml
+++ b/roles/standalone-container-registry/tasks/main.yml
@@ -53,8 +53,6 @@
     network_mode: host
     restart: yes
     restart_policy: unless-stopped
-    env:
-      http_proxy: "{{ standalone_container_registry_http_proxy }}"
-      https_proxy: "{{ standalone_container_registry_https_proxy }}"
+    env: "{{ proxy_env if proxy_env is defined else {} }}"
     volumes:
     - "{{ standalone_container_registry_config_dir }}/config.yml:/etc/docker/registry/config.yml"


### PR DESCRIPTION
Current standalone container registry can not work on the proxy environment.
This PR enables us to specify the proxy configurations for standalone container registry.