### PR TITLE
Fixing rsyslog-server role.

### DIFF
--- a/docs/deepops/testing.md
+++ b/docs/deepops/testing.md
@@ -81,17 +81,18 @@ To add Molecule tests to a new role, the following procedure can be used.
 
 1. Ensure you have Docker installed in your development environment
 
-2. Install Ansible Molecule in your development environment
+2. Install Ansible Molecule and `community.docker` Ansible Galaxy collection in your development environment
 
 ```
 $ python3 -m pip install "molecule[docker,lint]"
+$ ansible-galaxy collection install community.docker
 ```
 
 3. Initialize Molecule in your new role
 
 ```
 $ cd deepops/roles/<your-role>
-$ molecule init scenario -r <your-role> --driver docker
+$ molecule init scenario -r <your-role> --driver-name docker
 ```
 
 4. In the file `molecule/default/molecule.yml`, define the list of platforms to be tested.

--- a/roles/rsyslog-server/defaults/main.yml
+++ b/roles/rsyslog-server/defaults/main.yml
@@ -2,4 +2,5 @@
 rsyslog_server_tcp_port: 514
 rsyslog_server_udp_port: 514
 rsyslog_enable_journal: yes
-rsyslog_log_file_path_pattern: "/var/log/deepops-hosts/%HOSTNAME%/%$YEAR%-%$MONTH%-%$DAY%/syslog.log"
+rsyslog_log_file_path: "/var/log/deepops-hosts"
+rsyslog_log_file_path_pattern: "{{ rsyslog_log_file_path }}/%HOSTNAME%/%$YEAR%-%$MONTH%-%$DAY%/syslog.log"

--- a/roles/rsyslog-server/tasks/main.yml
+++ b/roles/rsyslog-server/tasks/main.yml
@@ -11,5 +11,13 @@
     owner: "root"
     group: "root"
     mode: "0644"
+
+- name: create directory for clients logs
+  file:
+    path: "{{ rsyslog_log_file_path }}"
+    state: directory
+    owner: "syslog"
+    group: "syslog"
+    mode: "0755"
   notify:
   - reload rsyslog


### PR DESCRIPTION
The role didn't create the directory for storing the client's logs.

In addition, I added an additional variable for the logs location: `rsyslog_log_file_path`.