### PR TITLE
`docs/deepops/testing.md` fixes.

### DIFF
--- a/docs/deepops/testing.md
+++ b/docs/deepops/testing.md
@@ -81,17 +81,18 @@ To add Molecule tests to a new role, the following procedure can be used.
 
 1. Ensure you have Docker installed in your development environment
 
-2. Install Ansible Molecule in your development environment
+2. Install Ansible Molecule and `community.docker` Ansible Galaxy collection in your development environment
 
 ```
 $ python3 -m pip install "molecule[docker,lint]"
+$ ansible-galaxy collection install community.docker
 ```
 
 3. Initialize Molecule in your new role
 
 ```
 $ cd deepops/roles/<your-role>
-$ molecule init scenario -r <your-role> --driver docker
+$ molecule init scenario -r <your-role> --driver-name docker
 ```
 
 4. In the file `molecule/default/molecule.yml`, define the list of platforms to be tested.


### PR DESCRIPTION
1. The `molecule init` command has not a correct parameter. Instead of `--driver`, it should be `--driver-name`.

2. It is necessary to install  `community.docker` Ansible Galaxy collection. It is not mentioned in any place. However, without this collection, it is not possible to work with molecule.