### PR TITLE
Update roles/rsyslog-server/tasks/main.yml

### DIFF
--- a/roles/rsyslog-server/tasks/main.yml
+++ b/roles/rsyslog-server/tasks/main.yml
@@ -12,12 +12,24 @@
     group: "root"
     mode: "0644"
 
-- name: create directory for clients logs
+- name: create directory for clients logs in ubuntu
   file:
     path: "{{ rsyslog_log_file_path }}"
     state: directory
     owner: "syslog"
     group: "syslog"
     mode: "0755"
+  when: ansible_facts['distribution'] == "Ubuntu"
+  notify:
+  - reload rsyslog
+
+- name: create directory for clients logs in rhel
+  file:
+    path: "{{ rsyslog_log_file_path }}"
+    state: directory
+    owner: "root"
+    group: "root"
+    mode: "0755"
+  when: ansible_os_family == "RedHat"
   notify:
   - reload rsyslog


### PR DESCRIPTION
This role doesn't work in CentOS. CentOS doesn't have dedicated user for rsyslog service. This commit fixes this.