### PR TITLE
Make it optional to use pam_slurm_adopt

### DIFF
--- a/config.example/group_vars/slurm-cluster.yml
+++ b/config.example/group_vars/slurm-cluster.yml
@@ -39,8 +39,17 @@ slurm_ha_state_save_location: "/sw/slurm"
 ################################################################################
 # Login on compute
 ################################################################################
+# Restrict user SSH access to only allow users with a running job
+slurm_restrict_node_access: true
+
+# List users who should always be able to SSH, even without a running job
 slurm_allow_ssh_user: []
+
+# Enable a Slurm compute node to also function as a login node.
+# This is needed for the "single node Slurm cluster" configuration.
+# See docs/slurm-cluster/slurm-single-node.md
 slurm_login_on_compute: false
+
 
 ################################################################################
 # Optional installs                                                            #

--- a/roles/slurm/defaults/main.yml
+++ b/roles/slurm/defaults/main.yml
@@ -87,6 +87,11 @@ epilog_fileglob:
 # Disable clearing of shared memory when user login shell exits
 slurm_fix_shm: true
 
+# Configure pam_slurm_adopt to adopt processes from user SSH into a job cgroup
+slurm_enable_pam_slurm_adopt: true
+# Restrict user SSH access to only allow users with a running job
+slurm_restrict_node_access: true
+
 slurm_include_hwloc: yes
 hwloc_version: 2.5.0
 hwloc_tag: "v{{ hwloc_version.split('.')[0] }}.{{ hwloc_version.split('.')[1] }}"

--- a/roles/slurm/tasks/compute.yml
+++ b/roles/slurm/tasks/compute.yml
@@ -137,7 +137,7 @@
   tags:
     - localusers
 
-- name: setup /etc/pam.d/sshd
+- name: configure /etc/pam.d/sshd to restrict node access without jobs
   blockinfile:
     path: /etc/pam.d/sshd
     block: |
@@ -148,13 +148,32 @@
     marker: "# {mark} ANSIBLE MANAGED BLOCK (ansible-role-slurm)"
   tags:
     - config
+  when:
+  - slurm_enable_pam_slurm_adopt
+  - slurm_restrict_node_access
+
+- name: configure /etc/pam.d/sshd to adopt processes but not otherwise deny access
+  blockinfile:
+    path: /etc/pam.d/sshd
+    block: |
+      -account required {{ slurm_pam_lib_dir }}/pam_slurm_adopt.so action_no_jobs=ignore
+      -account sufficient pam_listfile.so item=user sense=allow file=/etc/localusers
+    insertafter: EOF
+    marker: "# {mark} ANSIBLE MANAGED BLOCK (ansible-role-slurm)"
+  tags:
+    - config
+  when:
+  - slurm_enable_pam_slurm_adopt
+  - not slurm_restrict_node_access
 
 - name: comment out pam_systemd.so as it conflicts with pam_slurm_adapt.so, see https://slurm.schedmd.com/pam_slurm_adopt.html
   replace:
     path: /etc/pam.d/common-session
     regexp: '^([^#].*pam_systemd.so.*)'
     replace: '# \1 # ANSIBLE MANAGED (ansible-role-slurm)'
-  when: ansible_distribution == 'Ubuntu'
+  when: 
+  - ansible_distribution == 'Ubuntu'
+  - slurm_enable_pam_slurm_adopt
   tags:
     - config
 
@@ -163,7 +182,9 @@
     path: /etc/pam.d/password-auth
     regexp: '^([^#].*pam_systemd.so.*)'
     replace: '# \1 # ANSIBLE MANAGED (ansible-role-slurm)'
-  when: ansible_os_family == "RedHat"
+  when:
+  - ansible_os_family == "RedHat"
+  - slurm_enable_pam_slurm_adopt
   tags:
     - config
 

--- a/roles/slurm/tasks/compute.yml
+++ b/roles/slurm/tasks/compute.yml
@@ -141,7 +141,7 @@
   blockinfile:
     path: /etc/pam.d/sshd
     block: |
-      -account required {{ slurm_pam_lib_dir }}/pam_slurm_adopt.so action_no_jobs=ignore
+      -account sufficient {{ slurm_pam_lib_dir }}/pam_slurm_adopt.so action_no_jobs=ignore
       -account sufficient pam_listfile.so item=user sense=allow file=/etc/localusers
       -account required {{ slurm_pam_lib_dir }}/pam_slurm_adopt.so
     insertafter: EOF
@@ -156,7 +156,7 @@
   blockinfile:
     path: /etc/pam.d/sshd
     block: |
-      -account required {{ slurm_pam_lib_dir }}/pam_slurm_adopt.so action_no_jobs=ignore
+      -account sufficient {{ slurm_pam_lib_dir }}/pam_slurm_adopt.so action_no_jobs=ignore
       -account sufficient pam_listfile.so item=user sense=allow file=/etc/localusers
     insertafter: EOF
     marker: "# {mark} ANSIBLE MANAGED BLOCK (ansible-role-slurm)"


### PR DESCRIPTION
## Summary

We currently configure DeepOps Slurm clusters to use `pam_slurm_adopt.so` in the SSH authentication process. This module does two things:

- When the user has a job on the node, it adopts the SSH process into the job so it can be killed when the job ends
- When the user *doesn't* have a job on the node, it denies access

This behavior is exactly what you want on a production system, in order to prevent one user from interfering with another's workload. However, it often causes confusion for users new to Slurm, and doesn't always correspond to what you want on a development system which may be undergoing frequent change.

This PR adds two new role variables to the Slurm role:

- `slurm_restrict_node_access`: When enabled, denies SSH to users without a job on the node
- `slurm_enable_pam_slurm_adopt`: When enabled, sets up pam_slurm_adopt to adopt SSH processes into the job

By default, both of these are `true`. If `slurm_restrict_node_access` is set to false, SSH processes will still be adopted into the job for accounting and cleanup purposes, but otherwise allow access without a job on the node. If `slurm_enable_pam_slurm_adopt` is set to false, then `pam_slurm_adopt.so` will not be used at all.

## Test plan

- [x] Set `slurm_restrict_node_access: false` and create a new user who is not included in `slurm_allow_ssh_user`. Confirm that the user can SSH from the login node to the compute node.
- [x] Set `slurm_enable_pam_slurm_adopt: false`. Run a job, SSH in from another terminal, and confirm the SSH process isn't adopted.
- [x] Confirm regular DeepOps CI tests still work as expected.