### PR TITLE
Temporarily disable CentOS 8 tests in Molecule

### DIFF
--- a/roles/cachefilesd/molecule/default/molecule.yml
+++ b/roles/cachefilesd/molecule/default/molecule.yml
@@ -34,16 +34,16 @@ platforms:
     - /tmp
     pre_build_image: true
     privileged: true
-  - name: cachefilesd-centos-8
-    image: geerlingguy/docker-centos8-ansible
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
-    command: /sbin/init
-    tmpfs:
-    - /run
-    - /tmp
-    pre_build_image: true
-    privileged: true
+#  - name: cachefilesd-centos-8
+#    image: geerlingguy/docker-centos8-ansible
+#    volumes:
+#      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+#    command: /sbin/init
+#    tmpfs:
+#    - /run
+#    - /tmp
+#    pre_build_image: true
+#    privileged: true
 provisioner:
   name: ansible
   ansible_args:

--- a/roles/facts/molecule/default/molecule.yml
+++ b/roles/facts/molecule/default/molecule.yml
@@ -31,15 +31,15 @@ platforms:
     - /run
     - /tmp
     pre_build_image: true
-  - name: facts-centos-8
-    image: geerlingguy/docker-centos8-ansible
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
-    command: /sbin/init
-    tmpfs:
-    - /run
-    - /tmp
-    pre_build_image: true
+#  - name: facts-centos-8
+#    image: geerlingguy/docker-centos8-ansible
+#    volumes:
+#      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+#    command: /sbin/init
+#    tmpfs:
+#    - /run
+#    - /tmp
+#    pre_build_image: true
 provisioner:
   name: ansible
   ansible_args:

--- a/roles/kerberos_client/molecule/default/molecule.yml
+++ b/roles/kerberos_client/molecule/default/molecule.yml
@@ -31,15 +31,15 @@ platforms:
     - /run
     - /tmp
     pre_build_image: true
-  - name: krb-centos-8
-    image: geerlingguy/docker-centos8-ansible
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
-    command: /sbin/init
-    tmpfs:
-    - /run
-    - /tmp
-    pre_build_image: true
+#  - name: krb-centos-8
+#    image: geerlingguy/docker-centos8-ansible
+#    volumes:
+#      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+#    command: /sbin/init
+#    tmpfs:
+#    - /run
+#    - /tmp
+#    pre_build_image: true
 provisioner:
   name: ansible
   ansible_args:

--- a/roles/lmod/molecule/default/molecule.yml
+++ b/roles/lmod/molecule/default/molecule.yml
@@ -22,12 +22,12 @@ platforms:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
     privileged: true
     pre_build_image: true
-  - name: lmod-centos-8
-    image: geerlingguy/docker-centos8-ansible
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
-    privileged: true
-    pre_build_image: true
+#  - name: lmod-centos-8
+#    image: geerlingguy/docker-centos8-ansible
+#    volumes:
+#      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+#    privileged: true
+#    pre_build_image: true
 provisioner:
   name: ansible
   ansible_args:

--- a/roles/nfs/molecule/default/molecule.yml
+++ b/roles/nfs/molecule/default/molecule.yml
@@ -31,15 +31,15 @@ platforms:
     - /run
     - /tmp
     pre_build_image: true
-  - name: nfs-centos-8
-    image: geerlingguy/docker-centos8-ansible
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
-    command: /sbin/init
-    tmpfs:
-    - /run
-    - /tmp
-    pre_build_image: true
+#  - name: nfs-centos-8
+#    image: geerlingguy/docker-centos8-ansible
+#    volumes:
+#      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+#    command: /sbin/init
+#    tmpfs:
+#    - /run
+#    - /tmp
+#    pre_build_image: true
 provisioner:
   name: ansible
   ansible_args:

--- a/roles/nhc/molecule/default/molecule.yml
+++ b/roles/nhc/molecule/default/molecule.yml
@@ -22,12 +22,12 @@ platforms:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
     privileged: true
     pre_build_image: true
-  - name: nhc-centos-8
-    image: geerlingguy/docker-centos8-ansible
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
-    privileged: true
-    pre_build_image: true
+#  - name: nhc-centos-8
+#    image: geerlingguy/docker-centos8-ansible
+#    volumes:
+#      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+#    privileged: true
+#    pre_build_image: true
 provisioner:
   name: ansible
   ansible_args:

--- a/roles/nis_client/molecule/default/molecule.yml
+++ b/roles/nis_client/molecule/default/molecule.yml
@@ -25,13 +25,13 @@ platforms:
     command: /sbin/init
     pre_build_image: true
     privileged: true
-  - name: nis-centos-8
-    image: geerlingguy/docker-centos8-ansible
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
-    command: /sbin/init
-    pre_build_image: true
-    privileged: true
+#  - name: nis-centos-8
+#    image: geerlingguy/docker-centos8-ansible
+#    volumes:
+#      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+#    command: /sbin/init
+#    pre_build_image: true
+#    privileged: true
 provisioner:
   name: ansible
   ansible_args:

--- a/roles/nvidia_cuda/molecule/default/molecule.yml
+++ b/roles/nvidia_cuda/molecule/default/molecule.yml
@@ -22,12 +22,12 @@ platforms:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
     privileged: true
     pre_build_image: true
-  - name: nvidia-cuda-centos-8
-    image: geerlingguy/docker-centos8-ansible
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
-    privileged: true
-    pre_build_image: true
+#  - name: nvidia-cuda-centos-8
+#    image: geerlingguy/docker-centos8-ansible
+#    volumes:
+#      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+#    privileged: true
+#    pre_build_image: true
 provisioner:
   name: ansible
   ansible_args:

--- a/roles/nvidia_dcgm/molecule/default/molecule.yml
+++ b/roles/nvidia_dcgm/molecule/default/molecule.yml
@@ -34,16 +34,16 @@ platforms:
     - /tmp
     pre_build_image: true
     privileged: true
-  - name: dcgm-centos-8
-    image: geerlingguy/docker-centos8-ansible
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
-    command: /sbin/init
-    tmpfs:
-    - /run
-    - /tmp
-    pre_build_image: true
-    privileged: true
+#  - name: dcgm-centos-8
+#    image: geerlingguy/docker-centos8-ansible
+#    volumes:
+#      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+#    command: /sbin/init
+#    tmpfs:
+#    - /run
+#    - /tmp
+#    pre_build_image: true
+#    privileged: true
 provisioner:
   name: ansible
   ansible_args:

--- a/roles/nvidia_hpc_sdk/molecule/default/molecule.yml
+++ b/roles/nvidia_hpc_sdk/molecule/default/molecule.yml
@@ -13,9 +13,9 @@ platforms:
   - name: nvhpc-centos-7
     image: geerlingguy/docker-centos7-ansible
     pre_build_image: true
-  - name: nvhpc-centos-8
-    image: geerlingguy/docker-centos8-ansible
-    pre_build_image: true
+#  - name: nvhpc-centos-8
+#    image: geerlingguy/docker-centos8-ansible
+#    pre_build_image: true
 provisioner:
   name: ansible
   ansible_args:

--- a/roles/openmpi/molecule/default/molecule.yml
+++ b/roles/openmpi/molecule/default/molecule.yml
@@ -13,9 +13,9 @@ platforms:
   - name: openmpi-centos-7
     image: geerlingguy/docker-centos7-ansible
     pre_build_image: true
-  - name: openmpi-centos-8
-    image: geerlingguy/docker-centos8-ansible
-    pre_build_image: true
+#  - name: openmpi-centos-8
+#    image: geerlingguy/docker-centos8-ansible
+#    pre_build_image: true
 provisioner:
   name: ansible
   ansible_args:

--- a/roles/openshift/molecule/default/molecule.yml
+++ b/roles/openshift/molecule/default/molecule.yml
@@ -13,9 +13,9 @@ platforms:
   - name: openshift-centos-7
     image: geerlingguy/docker-centos7-ansible
     pre_build_image: true
-  - name: openshift-centos-8
-    image: geerlingguy/docker-centos8-ansible
-    pre_build_image: true
+#  - name: openshift-centos-8
+#    image: geerlingguy/docker-centos8-ansible
+#    pre_build_image: true
 provisioner:
   name: ansible
   ansible_args:

--- a/roles/rsyslog_client/molecule/default/molecule.yml
+++ b/roles/rsyslog_client/molecule/default/molecule.yml
@@ -34,16 +34,16 @@ platforms:
     - /tmp
     pre_build_image: true
     privileged: true
-  - name: rsyslog-client-centos-8
-    image: geerlingguy/docker-centos8-ansible
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
-    command: /sbin/init
-    tmpfs:
-    - /run
-    - /tmp
-    pre_build_image: true
-    privileged: true
+#  - name: rsyslog-client-centos-8
+#    image: geerlingguy/docker-centos8-ansible
+#    volumes:
+#      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+#    command: /sbin/init
+#    tmpfs:
+#    - /run
+#    - /tmp
+#    pre_build_image: true
+#    privileged: true
 provisioner:
   name: ansible
   ansible_args:

--- a/roles/rsyslog_server/molecule/default/molecule.yml
+++ b/roles/rsyslog_server/molecule/default/molecule.yml
@@ -34,16 +34,16 @@ platforms:
     - /tmp
     pre_build_image: true
     privileged: true
-  - name: rsyslog-server-centos-8
-    image: geerlingguy/docker-centos8-ansible
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
-    command: /sbin/init
-    tmpfs:
-    - /run
-    - /tmp
-    pre_build_image: true
-    privileged: true
+#  - name: rsyslog-server-centos-8
+#    image: geerlingguy/docker-centos8-ansible
+#    volumes:
+#      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+#    command: /sbin/init
+#    tmpfs:
+#    - /run
+#    - /tmp
+#    pre_build_image: true
+#    privileged: true
 provisioner:
   name: ansible
   ansible_args:

--- a/roles/singularity_wrapper/molecule/default/molecule.yml
+++ b/roles/singularity_wrapper/molecule/default/molecule.yml
@@ -15,9 +15,9 @@ platforms:
   - name: singularity-centos-7
     image: geerlingguy/docker-centos7-ansible
     pre_build_image: true
-  - name: singularity-centos-8
-    image: geerlingguy/docker-centos8-ansible
-    pre_build_image: true
+#  - name: singularity-centos-8
+#    image: geerlingguy/docker-centos8-ansible
+#    pre_build_image: true
 provisioner:
   name: ansible
   ansible_args:

--- a/roles/slurm/molecule/default/molecule.yml
+++ b/roles/slurm/molecule/default/molecule.yml
@@ -43,19 +43,19 @@ platforms:
     groups:
     - slurm-master
     - slurm-node
-  - name: slurm-centos-8
-    image: geerlingguy/docker-centos8-ansible
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
-    command: /sbin/init
-    tmpfs:
-    - /run
-    - /tmp
-    pre_build_image: true
-    privileged: true
-    groups:
-    - slurm-master
-    - slurm-node
+#  - name: slurm-centos-8
+#    image: geerlingguy/docker-centos8-ansible
+#    volumes:
+#      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+#    command: /sbin/init
+#    tmpfs:
+#    - /run
+#    - /tmp
+#    pre_build_image: true
+#    privileged: true
+#    groups:
+#    - slurm-master
+#    - slurm-node
 provisioner:
   name: ansible
   ansible_args:

--- a/roles/spack/molecule/default/molecule.yml
+++ b/roles/spack/molecule/default/molecule.yml
@@ -22,12 +22,12 @@ platforms:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
     privileged: true
     pre_build_image: true
-  - name: spack-centos-8
-    image: geerlingguy/docker-centos8-ansible
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
-    privileged: true
-    pre_build_image: true
+#  - name: spack-centos-8
+#    image: geerlingguy/docker-centos8-ansible
+#    volumes:
+#      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+#    privileged: true
+#    pre_build_image: true
 provisioner:
   name: ansible
   ansible_args:


### PR DESCRIPTION
Starting on Jan 31, the CentOS 8 mirror lists are no longer working. This
is causing our CentOS 8 tests in Molecule to fail because we can't
install packages.

While I've tested using the CentOS Vault instead of the canonical mirror
list, this isn't a great solution:

- It's a bit on the slow side, because we don't have a global network of
mirrors
- CentOS 8 is no longer supported, so we'd just be targeting an
increasingly old distribution

We're discussing how to address this in our automated tests. But for
now, we'll disable these tests so that our other Molecule tests will
run.