### PR TITLE
Migrate CentOS-8 molecule tests to Rocky

### DIFF
--- a/roles/cachefilesd/molecule/default/molecule.yml
+++ b/roles/cachefilesd/molecule/default/molecule.yml
@@ -34,16 +34,16 @@ platforms:
     - /tmp
     pre_build_image: true
     privileged: true
-#  - name: cachefilesd-centos-8
-#    image: geerlingguy/docker-centos8-ansible
-#    volumes:
-#      - /sys/fs/cgroup:/sys/fs/cgroup:ro
-#    command: /sbin/init
-#    tmpfs:
-#    - /run
-#    - /tmp
-#    pre_build_image: true
-#    privileged: true
+  - name: cachefilesd-rockylinux-8
+    image: geerlingguy/docker-rockylinux8-ansible
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    command: /sbin/init
+    tmpfs:
+    - /run
+    - /tmp
+    pre_build_image: true
+    privileged: true
 provisioner:
   name: ansible
   ansible_args:

--- a/roles/facts/molecule/default/molecule.yml
+++ b/roles/facts/molecule/default/molecule.yml
@@ -31,15 +31,15 @@ platforms:
     - /run
     - /tmp
     pre_build_image: true
-#  - name: facts-centos-8
-#    image: geerlingguy/docker-centos8-ansible
-#    volumes:
-#      - /sys/fs/cgroup:/sys/fs/cgroup:ro
-#    command: /sbin/init
-#    tmpfs:
-#    - /run
-#    - /tmp
-#    pre_build_image: true
+  - name: facts-rockylinux-8
+    image: geerlingguy/docker-rockylinux8-ansible
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    command: /sbin/init
+    tmpfs:
+    - /run
+    - /tmp
+    pre_build_image: true
 provisioner:
   name: ansible
   ansible_args:

--- a/roles/facts/tasks/main.yml
+++ b/roles/facts/tasks/main.yml
@@ -6,7 +6,7 @@
 
 - name: yum install pciutils
   yum: name=pciutils update_cache=yes
-  when: ansible_os_family == 'RedHat'
+  when: (ansible_os_family == 'RedHat') or (ansible_os_family == 'Rocky')
   environment: "{{ proxy_env if proxy_env is defined else {} }}"
 
 - name: create fact directory

--- a/roles/kerberos_client/molecule/default/molecule.yml
+++ b/roles/kerberos_client/molecule/default/molecule.yml
@@ -31,15 +31,15 @@ platforms:
     - /run
     - /tmp
     pre_build_image: true
-#  - name: krb-centos-8
-#    image: geerlingguy/docker-centos8-ansible
-#    volumes:
-#      - /sys/fs/cgroup:/sys/fs/cgroup:ro
-#    command: /sbin/init
-#    tmpfs:
-#    - /run
-#    - /tmp
-#    pre_build_image: true
+  - name: krb-rockylinux-8
+    image: geerlingguy/docker-rockylinux8-ansible
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    command: /sbin/init
+    tmpfs:
+    - /run
+    - /tmp
+    pre_build_image: true
 provisioner:
   name: ansible
   ansible_args:

--- a/roles/lmod/molecule/default/molecule.yml
+++ b/roles/lmod/molecule/default/molecule.yml
@@ -22,12 +22,12 @@ platforms:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
     privileged: true
     pre_build_image: true
-#  - name: lmod-centos-8
-#    image: geerlingguy/docker-centos8-ansible
-#    volumes:
-#      - /sys/fs/cgroup:/sys/fs/cgroup:ro
-#    privileged: true
-#    pre_build_image: true
+  - name: lmod-rockylinux-8
+    image: geerlingguy/docker-rockylinux8-ansible
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    privileged: true
+    pre_build_image: true
 provisioner:
   name: ansible
   ansible_args:

--- a/roles/mofed/molecule/default/molecule.yml
+++ b/roles/mofed/molecule/default/molecule.yml
@@ -25,8 +25,8 @@ platforms:
     command: /sbin/init
     pre_build_image: true
     privileged: true
-  - name: mofed-centos-8
-    image: geerlingguy/docker-centos8-ansible
+  - name: mofed-rockylinux-8
+    image: geerlingguy/docker-rockylinux8-ansible
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
     command: /sbin/init

--- a/roles/mofed/vars/rhel8.yml
+++ b/roles/mofed/vars/rhel8.yml
@@ -8,3 +8,6 @@ mofed_pkg_prereqs:
 - tcl
 - tk
 - fuse-libs
+- pciutils-libs
+- libnl3
+- libmnl

--- a/roles/nfs/molecule/default/molecule.yml
+++ b/roles/nfs/molecule/default/molecule.yml
@@ -31,15 +31,15 @@ platforms:
     - /run
     - /tmp
     pre_build_image: true
-#  - name: nfs-centos-8
-#    image: geerlingguy/docker-centos8-ansible
-#    volumes:
-#      - /sys/fs/cgroup:/sys/fs/cgroup:ro
-#    command: /sbin/init
-#    tmpfs:
-#    - /run
-#    - /tmp
-#    pre_build_image: true
+  - name: nfs-rockylinux-8
+    image: geerlingguy/docker-rockylinux8-ansible
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    command: /sbin/init
+    tmpfs:
+    - /run
+    - /tmp
+    pre_build_image: true
 provisioner:
   name: ansible
   ansible_args:

--- a/roles/nhc/molecule/default/molecule.yml
+++ b/roles/nhc/molecule/default/molecule.yml
@@ -22,12 +22,12 @@ platforms:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
     privileged: true
     pre_build_image: true
-#  - name: nhc-centos-8
-#    image: geerlingguy/docker-centos8-ansible
-#    volumes:
-#      - /sys/fs/cgroup:/sys/fs/cgroup:ro
-#    privileged: true
-#    pre_build_image: true
+  - name: nhc-rockylinux-8
+    image: geerlingguy/docker-rockylinux8-ansible
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    privileged: true
+    pre_build_image: true
 provisioner:
   name: ansible
   ansible_args:

--- a/roles/nhc/tasks/main.yml
+++ b/roles/nhc/tasks/main.yml
@@ -33,6 +33,9 @@
     state: present
   with_items: "{{ nhc_build_deps }}"
 
+- name: re-gather facts so we can generate config
+  gather_facts:
+
 - name: ensure build dir exists
   file:
     path: "{{ nhc_build_dir }}"

--- a/roles/nhc/vars/rocky.yml
+++ b/roles/nhc/vars/rocky.yml
@@ -5,4 +5,3 @@ nhc_build_deps:
 - unzip
 - xz
 - iproute
-- pciutils

--- a/roles/nis_client/molecule/default/molecule.yml
+++ b/roles/nis_client/molecule/default/molecule.yml
@@ -25,13 +25,13 @@ platforms:
     command: /sbin/init
     pre_build_image: true
     privileged: true
-#  - name: nis-centos-8
-#    image: geerlingguy/docker-centos8-ansible
-#    volumes:
-#      - /sys/fs/cgroup:/sys/fs/cgroup:ro
-#    command: /sbin/init
-#    pre_build_image: true
-#    privileged: true
+  - name: nis-rockylinux-8
+    image: geerlingguy/docker-rockylinux8-ansible
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    command: /sbin/init
+    pre_build_image: true
+    privileged: true
 provisioner:
   name: ansible
   ansible_args:

--- a/roles/nvidia_cuda/molecule/default/molecule.yml
+++ b/roles/nvidia_cuda/molecule/default/molecule.yml
@@ -22,12 +22,12 @@ platforms:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
     privileged: true
     pre_build_image: true
-#  - name: nvidia-cuda-centos-8
-#    image: geerlingguy/docker-centos8-ansible
-#    volumes:
-#      - /sys/fs/cgroup:/sys/fs/cgroup:ro
-#    privileged: true
-#    pre_build_image: true
+  - name: nvidia-cuda-rockylinux-8
+    image: geerlingguy/docker-rockylinux8-ansible
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    privileged: true
+    pre_build_image: true
 provisioner:
   name: ansible
   ansible_args:

--- a/roles/nvidia_dcgm/molecule/default/molecule.yml
+++ b/roles/nvidia_dcgm/molecule/default/molecule.yml
@@ -34,16 +34,16 @@ platforms:
     - /tmp
     pre_build_image: true
     privileged: true
-#  - name: dcgm-centos-8
-#    image: geerlingguy/docker-centos8-ansible
-#    volumes:
-#      - /sys/fs/cgroup:/sys/fs/cgroup:ro
-#    command: /sbin/init
-#    tmpfs:
-#    - /run
-#    - /tmp
-#    pre_build_image: true
-#    privileged: true
+  - name: dcgm-rockylinux-8
+    image: geerlingguy/docker-rockylinux8-ansible
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    command: /sbin/init
+    tmpfs:
+    - /run
+    - /tmp
+    pre_build_image: true
+    privileged: true
 provisioner:
   name: ansible
   ansible_args:

--- a/roles/nvidia_hpc_sdk/molecule/default/molecule.yml
+++ b/roles/nvidia_hpc_sdk/molecule/default/molecule.yml
@@ -13,9 +13,9 @@ platforms:
   - name: nvhpc-centos-7
     image: geerlingguy/docker-centos7-ansible
     pre_build_image: true
-#  - name: nvhpc-centos-8
-#    image: geerlingguy/docker-centos8-ansible
-#    pre_build_image: true
+  - name: nvhpc-rockylinux-8
+    image: geerlingguy/docker-rockylinux8-ansible
+    pre_build_image: true
 provisioner:
   name: ansible
   ansible_args:

--- a/roles/openmpi/molecule/default/molecule.yml
+++ b/roles/openmpi/molecule/default/molecule.yml
@@ -13,9 +13,9 @@ platforms:
   - name: openmpi-centos-7
     image: geerlingguy/docker-centos7-ansible
     pre_build_image: true
-#  - name: openmpi-centos-8
-#    image: geerlingguy/docker-centos8-ansible
-#    pre_build_image: true
+  - name: openmpi-rockylinux-8
+    image: geerlingguy/docker-rockylinux8-ansible
+    pre_build_image: true
 provisioner:
   name: ansible
   ansible_args:

--- a/roles/openshift/molecule/default/molecule.yml
+++ b/roles/openshift/molecule/default/molecule.yml
@@ -13,9 +13,9 @@ platforms:
   - name: openshift-centos-7
     image: geerlingguy/docker-centos7-ansible
     pre_build_image: true
-#  - name: openshift-centos-8
-#    image: geerlingguy/docker-centos8-ansible
-#    pre_build_image: true
+  - name: openshift-rockylinux-8
+    image: geerlingguy/docker-rockylinux8-ansible
+    pre_build_image: true
 provisioner:
   name: ansible
   ansible_args:

--- a/roles/rsyslog_client/molecule/default/molecule.yml
+++ b/roles/rsyslog_client/molecule/default/molecule.yml
@@ -34,16 +34,16 @@ platforms:
     - /tmp
     pre_build_image: true
     privileged: true
-#  - name: rsyslog-client-centos-8
-#    image: geerlingguy/docker-centos8-ansible
-#    volumes:
-#      - /sys/fs/cgroup:/sys/fs/cgroup:ro
-#    command: /sbin/init
-#    tmpfs:
-#    - /run
-#    - /tmp
-#    pre_build_image: true
-#    privileged: true
+  - name: rsyslog-client-rockylinux-8
+    image: geerlingguy/docker-rockylinux8-ansible
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    command: /sbin/init
+    tmpfs:
+    - /run
+    - /tmp
+    pre_build_image: true
+    privileged: true
 provisioner:
   name: ansible
   ansible_args:

--- a/roles/rsyslog_server/molecule/default/molecule.yml
+++ b/roles/rsyslog_server/molecule/default/molecule.yml
@@ -34,16 +34,16 @@ platforms:
     - /tmp
     pre_build_image: true
     privileged: true
-#  - name: rsyslog-server-centos-8
-#    image: geerlingguy/docker-centos8-ansible
-#    volumes:
-#      - /sys/fs/cgroup:/sys/fs/cgroup:ro
-#    command: /sbin/init
-#    tmpfs:
-#    - /run
-#    - /tmp
-#    pre_build_image: true
-#    privileged: true
+  - name: rsyslog-server-rockylinux-8
+    image: geerlingguy/docker-rockylinux8-ansible
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    command: /sbin/init
+    tmpfs:
+    - /run
+    - /tmp
+    pre_build_image: true
+    privileged: true
 provisioner:
   name: ansible
   ansible_args:

--- a/roles/singularity_wrapper/molecule/default/molecule.yml
+++ b/roles/singularity_wrapper/molecule/default/molecule.yml
@@ -15,9 +15,9 @@ platforms:
   - name: singularity-centos-7
     image: geerlingguy/docker-centos7-ansible
     pre_build_image: true
-#  - name: singularity-centos-8
-#    image: geerlingguy/docker-centos8-ansible
-#    pre_build_image: true
+  - name: singularity-rockylinux-8
+    image: geerlingguy/docker-rockylinux8-ansible
+    pre_build_image: true
 provisioner:
   name: ansible
   ansible_args:

--- a/roles/slurm/molecule/default/molecule.yml
+++ b/roles/slurm/molecule/default/molecule.yml
@@ -43,19 +43,19 @@ platforms:
     groups:
     - slurm-master
     - slurm-node
-#  - name: slurm-centos-8
-#    image: geerlingguy/docker-centos8-ansible
-#    volumes:
-#      - /sys/fs/cgroup:/sys/fs/cgroup:ro
-#    command: /sbin/init
-#    tmpfs:
-#    - /run
-#    - /tmp
-#    pre_build_image: true
-#    privileged: true
-#    groups:
-#    - slurm-master
-#    - slurm-node
+  - name: slurm-rockylinux-8
+    image: geerlingguy/docker-rockylinux8-ansible
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    command: /sbin/init
+    tmpfs:
+    - /run
+    - /tmp
+    pre_build_image: true
+    privileged: true
+    groups:
+    - slurm-master
+    - slurm-node
 provisioner:
   name: ansible
   ansible_args:

--- a/roles/spack/molecule/default/molecule.yml
+++ b/roles/spack/molecule/default/molecule.yml
@@ -22,12 +22,12 @@ platforms:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
     privileged: true
     pre_build_image: true
-#  - name: spack-centos-8
-#    image: geerlingguy/docker-centos8-ansible
-#    volumes:
-#      - /sys/fs/cgroup:/sys/fs/cgroup:ro
-#    privileged: true
-#    pre_build_image: true
+  - name: spack-rockylinux-8
+    image: geerlingguy/docker-rockylinux8-ansible
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    privileged: true
+    pre_build_image: true
 provisioner:
   name: ansible
   ansible_args:


### PR DESCRIPTION
Starting on Jan 31, the CentOS 8 mirror lists are no longer working.
This is causing our CentOS 8 tests in Molecule to fail because we can't
install packages.

While I've tested using the CentOS Vault instead of the canonical mirror
list, this isn't a great solution:

- It's a bit on the slow side, because we don't have a global network of mirrors
- CentOS 8 is no longer supported, so we'd just be targeting an increasingly old distribution

As a proposed solution, I've converted the molecule tests to use [Rocky
Linux](https://rockylinux.org/). This is mostly a drop-in replacement,
with some minor changes needed in the facts and nhc roles due to the
Rocky container being a little more minimal than the CentOS one.