### PR TITLE
Update nvidia.nvidia_docker dependency to v1.2.4

### DIFF
--- a/roles/requirements.yml
+++ b/roles/requirements.yml
@@ -30,7 +30,7 @@ roles:
   version: "v2.0.2"
 
 - src: nvidia.nvidia_docker
-  version: "v1.2.3"
+  version: "v1.2.4"
 
 - src: nvidia.enroot
   version: "v0.5.0"


### PR DESCRIPTION
## Summary

Picks up a bug fix to ensure the systemd unit is reloaded when reconfiguring Docker for the NVIDIA container runtime.

## Test plan

Passing Jenkins tests.