### PR TITLE
ood-wrapper fixes for #963

### DIFF
--- a/roles/ood-wrapper/tasks/server.yml
+++ b/roles/ood-wrapper/tasks/server.yml
@@ -212,10 +212,3 @@
     mode: 0755
   tags:
     - configure
-
-- name: fix permissions on regex file
-  file:
-    path: "{{ ood_base_dir }}/ood_auth_map/bin/ood_auth_map.regex"
-    mode: 0755
-  tags:
-    - configure

--- a/roles/ood-wrapper/vars/ubuntu.yml
+++ b/roles/ood-wrapper/vars/ubuntu.yml
@@ -3,8 +3,6 @@ install_from_src: true
 ood_apache_service_name: apache2
 ood_htpasswd_file: /etc/apache2/.htpasswd
 
-ood_portal_generator: false
-
 ood_url_turbovnc_pkg: https://downloads.sourceforge.net/project/turbovnc/2.2.4/turbovnc_2.2.4_amd64.deb
 
 ood_master_sw_deps:


### PR DESCRIPTION
Fixes for Open OnDemand 2.0 to address #963 

- Remove task for non-existent ood_auth_map.rexex file
- Remove unnecessary ood_portal_generator var