### PR TITLE
Increase timeout for multinode monitoring test in k8s

### DIFF
--- a/workloads/jenkins/Jenkinsfile-multi-nightly
+++ b/workloads/jenkins/Jenkinsfile-multi-nightly
@@ -80,7 +80,7 @@ pipeline {
 
           echo "Test Monitoring installation"
           sh '''
-             timeout 800 bash -x ./workloads/jenkins/scripts/test-monitoring.sh
+             timeout 2000 bash -x ./workloads/jenkins/scripts/test-monitoring.sh
           '''
 
           echo "Test Dashboard installation"


### PR DESCRIPTION
Looks like the flow of recent changes caused this test to timeout for some reason. It is still valid, just increasing the threshold here.