### PR TITLE
Automatically run ansible-lint on each role

### DIFF
--- a/.github/workflows/ansible-lint-roles.yml
+++ b/.github/workflows/ansible-lint-roles.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: run lint script
         env:
-          ANSIBLE_LINT_EXCLUDE: "nvidia-dgx|netapp|nvidia-gpu-tests"
+          ANSIBLE_LINT_EXCLUDE: "nvidia-dgx|nvidia-gpu-tests"
         run: |
           cd "${{ github.repository }}"
           bash ./scripts/deepops/ansible-lint-roles.sh

--- a/.github/workflows/ansible-lint-roles.yml
+++ b/.github/workflows/ansible-lint-roles.yml
@@ -7,19 +7,25 @@ jobs:
   lint:
     runs-on: ubuntu-20.04
     steps:
+
       - name: check out repo
         uses: actions/checkout@v2
         with:
           path: "${{ github.repository }}"
+
       - name: set up python
         uses: actions/setup-python@v2
         with:
           python-version: "3.9"
+
       - name: install dependencies
         run: |
           python3 -m pip install --upgrade pip
           python3 -m pip install ansible-lint ansible
+
       - name: run lint script
+        env:
+          ANSIBLE_LINT_EXCLUDE: "nvidia-dgx|netapp|nvidia-gpu-tests"
         run: |
           cd "${{ github.repository }}"
           bash ./scripts/deepops/ansible-lint-roles.sh

--- a/.github/workflows/ansible-lint-roles.yml
+++ b/.github/workflows/ansible-lint-roles.yml
@@ -21,7 +21,7 @@ jobs:
       - name: install dependencies
         run: |
           python3 -m pip install --upgrade pip
-          python3 -m pip install ansible-lint ansible
+          python3 -m pip install ansible-lint==5.4.0
 
       - name: run lint script
         env:

--- a/.github/workflows/ansible-lint-roles.yml
+++ b/.github/workflows/ansible-lint-roles.yml
@@ -1,0 +1,25 @@
+---
+name: run ansible-lint on deepops roles
+on:
+  - push
+  - pull_request
+jobs:
+  lint:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: check out repo
+        uses: actions/checkout@v2
+        with:
+          path: "${{ github.repository }}"
+      - name: set up python
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.9"
+      - name: install dependencies
+        run: |
+          python3 -m pip install --upgrade pip
+          python3 -m pip install ansible-lint ansible
+      - name: run lint script
+        run: |
+          cd "${{ github.repository }}"
+          bash ./scripts/deepops/ansible-lint-roles.sh

--- a/.github/workflows/ansible-lint-roles.yml
+++ b/.github/workflows/ansible-lint-roles.yml
@@ -21,7 +21,7 @@ jobs:
       - name: install dependencies
         run: |
           python3 -m pip install --upgrade pip
-          python3 -m pip install ansible-lint==5.4.0
+          python3 -m pip install ansible-lint==5.4.0 ansible==2.9.27
 
       - name: run lint script
         env:

--- a/docs/deepops/testing.md
+++ b/docs/deepops/testing.md
@@ -1,11 +1,24 @@
 # DeepOps Testing, CI/CD, and Validation
 
+## Linting
+
+`ansible-lint` is automatically run for each role in the `roles/` directory using a [Github action](../../.github/workflows/ansible-lint-roles.yml).
+This action runs `ansible-lint` for each role, and provides both the full output and a list of roles that failed linting.
+If the Github action reports success, all roles should have passed linting.
+
+The linting process can also be executed manually in a checkout of the DeepOps repo,
+by running `./scripts/deepops/ansible-lint-roles.sh`.
+
+Note that the linting script can be configured to skip a subset of roles,
+by providing a regex of roles to skip in the envionment variable `ANSIBLE_LINT_EXCLUDE`.
+(For example, `ANSIBLE_LINT_EXCLUDE='role-1|role-2|role-3'`.)
+This can be useful for excluding specific roles that have known issues or are still in development.
 
 ## DeepOps end-to-end testing
 
-The DeepOps project leverages a private Jenkins server to run continuous integration tests. Testing is done using the [virtual](../../virtual) deployment mechanism. Several Vagrant VMs are created, the cluster is deployed, tests are executed, and then the VMs are destroyed. 
+The DeepOps project leverages a private Jenkins server to run continuous integration tests. Testing is done using the [virtual](../../virtual) deployment mechanism. Several Vagrant VMs are created, the cluster is deployed, tests are executed, and then the VMs are destroyed.
 
-The goal of the DeepOps CI is to prevent bugs from being introduced into the code base and to identify when changes in 3rd party platforms have occurred or impacted the DeepOps deployment mechanisms. In general, K8s and Slurm deployment issues are detected and resolved with urgency. Many components of DeepOps are 3rd party open source tools that may silently fail or suddenly change without notice. The team will make a best-effort to resolve these issues and include regression tests, however there may be times where a fix is unavailable. Historically, this has been an issue with Rook-Ceph and Kubeflow, and those GitHub communities are best equipped to help with resolutions. 
+The goal of the DeepOps CI is to prevent bugs from being introduced into the code base and to identify when changes in 3rd party platforms have occurred or impacted the DeepOps deployment mechanisms. In general, K8s and Slurm deployment issues are detected and resolved with urgency. Many components of DeepOps are 3rd party open source tools that may silently fail or suddenly change without notice. The team will make a best-effort to resolve these issues and include regression tests, however there may be times where a fix is unavailable. Historically, this has been an issue with Rook-Ceph and Kubeflow, and those GitHub communities are best equipped to help with resolutions.
 
 ### Testing Method
 

--- a/roles/autofs/tasks/main.yml
+++ b/roles/autofs/tasks/main.yml
@@ -22,7 +22,12 @@
     - configuration
 
 - name: ensure mountpoint exists
-  file: path={{ autofs_mount }} state=directory
+  file: 
+    path: "{{ autofs_mount }}"
+    state: directory
+    owner: "root"
+    group: "root"
+    mode: "0755"
   when: autofs_mount is defined
 
 - name: make sure autofs is running

--- a/roles/cachefilesd/tasks/main.yml
+++ b/roles/cachefilesd/tasks/main.yml
@@ -8,11 +8,17 @@
   template:
     src: cachefilesd.j2
     dest: /etc/default/cachefilesd
+    owner: "root"
+    group: "root"
+    mode: "0644"
 
 - name: configure
   template:
     src: cachefilesd_config.j2
     dest: /etc/cachefilesd.conf
+    owner: "root"
+    group: "root"
+    mode: "0644"
 
 # Service start not tested in molecule as we require a kernel module
 - name: start

--- a/roles/docker-rootless/tasks/main.yml
+++ b/roles/docker-rootless/tasks/main.yml
@@ -61,8 +61,7 @@
 
 - name: Execute setup rootless docker script
   become: true
-  shell:
-    /tmp/rootless_docker_setup.sh
+  command: /tmp/rootless_docker_setup.sh
   args:
     executable: /bin/bash
     creates: '{{ rootlessdocker_install_dir }}/config/install_success'
@@ -82,3 +81,6 @@
     path: /etc/modules
     create: yes
     line: "br_netfilter"
+    owner: "root"
+    group: "root"
+    mode: "0644"

--- a/roles/easy-build-packages/.ansible-lint
+++ b/roles/easy-build-packages/.ansible-lint
@@ -1,0 +1,4 @@
+warn_list:  # or 'skip_list' to silence them completely
+  - meta-no-info  # meta/main.yml should contain relevant info
+  - no-changed-when  # Commands should not change things if nothing needs doing
+  - role-name

--- a/roles/easy-build-packages/.ansible-lint
+++ b/roles/easy-build-packages/.ansible-lint
@@ -1,4 +1,4 @@
-warn_list:  # or 'skip_list' to silence them completely
+skip_list:
   - meta-no-info  # meta/main.yml should contain relevant info
   - no-changed-when  # Commands should not change things if nothing needs doing
   - role-name

--- a/roles/easy-build-packages/defaults/main.yml
+++ b/roles/easy-build-packages/defaults/main.yml
@@ -1,1 +1,2 @@
 sm_files_path: "{{ sm_prefix }}/easybuild_files"
+sm_files_repo_version: "4ef7ae6cc2284f69412a8db5e10dddd92024eeab"

--- a/roles/easy-build-packages/tasks/main.yml
+++ b/roles/easy-build-packages/tasks/main.yml
@@ -15,6 +15,7 @@
     repo: "{{ sm_files_url }}"
     dest: "{{ sm_files_path }}"
     update: yes
+    version: "{{ sm_files_repo_version }}"
   when: sm_install_default
 
 - name: "check the sm_files_path is reachable"

--- a/roles/easy-build/.ansible-lint
+++ b/roles/easy-build/.ansible-lint
@@ -1,3 +1,3 @@
-warn_list:  # or 'skip_list' to silence them completely
+skip_list:  # or 'skip_list' to silence them completely
   - meta-no-info
   - role-name

--- a/roles/easy-build/.ansible-lint
+++ b/roles/easy-build/.ansible-lint
@@ -1,0 +1,3 @@
+warn_list:  # or 'skip_list' to silence them completely
+  - meta-no-info
+  - role-name

--- a/roles/easy-build/tasks/main.yml
+++ b/roles/easy-build/tasks/main.yml
@@ -4,12 +4,12 @@
 ---
 - name: "install needed packages"
   become: yes
-  action: apt name=python3-setuptools state=latest
+  action: apt name=python3-setuptools state=present
   when: ansible_os_family == "Debian"
 
 - name: "install needed packages"
   become: yes
-  action: yum name=python3-setuptools state=latest
+  action: yum name=python3-setuptools state=present
   when: ansible_os_family == "RedHat"
 
 - name: "rm previous tmp folders"    
@@ -56,7 +56,7 @@
 
 - name: "get EasyBuild version"
   become: yes
-  shell: ls {{ eb_tmp_dir }}/software/EasyBuild/
+  command: ls {{ eb_tmp_dir }}/software/EasyBuild/
   args:
     executable: /bin/bash
   register: ebsw_version

--- a/roles/grafana/tasks/main.yml
+++ b/roles/grafana/tasks/main.yml
@@ -3,24 +3,30 @@
   file:
     path: "{{ grafana_config_dir }}"
     state: directory
+    owner: "root"
+    group: "root"
+    mode: "0755"
 
 - name: create data dir
   file:
     path: "{{ grafana_data_dir }}"
     state: directory
     owner: "{{ grafana_user_id }}"
+    mode: "0755"
 
 - name: create dashboard dir
   file:
     path: "{{ grafana_cfg_dashboard_path }}"
     state: directory
     owner: "{{ grafana_user_id }}"
+    mode: "0755"
 
 - name: create provisioning dirs
   file:
     path: "{{ grafana_config_dir }}/provisioning/{{ item }}"
     state: directory
     owner: "{{ grafana_user_id }}"
+    mode: "0755"
   with_items:
     - datasources
     - dashboards
@@ -30,6 +36,7 @@
     src: "{{ item }}"
     dest: "{{ grafana_cfg_dashboard_path }}"
     owner: "{{ grafana_user_id }}"
+    mode: "0644"
   with_items:
     - ../../../src/dashboards/gpu-dashboard.json
   notify: restart grafana

--- a/roles/k8s-internal-container-registry/tasks/main.yml
+++ b/roles/k8s-internal-container-registry/tasks/main.yml
@@ -6,9 +6,11 @@
 
 - name: install stable helm repository
   command: "{{ helm_cmd }} repo add {{ container_registry_repo_name }} {{ container_registry_chart_location }}"
+  changed_when: false
 
 - name: update helm repos
   command: "{{ helm_cmd }} repo update"
+  changed_when: false
 
 - name: copy values.yaml into place
   template:
@@ -20,3 +22,4 @@
 
 - name: install container-registry
   command: "{{ helm_cmd }} upgrade --install -f {{ container_registry_values_path }} --version {{ container_registry_version }} --create-namespace --namespace {{ container_registry_namespace }} {{ container_registry_installed_name }} {{ container_registry_chart_name }}" 
+  changed_when: false

--- a/roles/kerberos_client/.ansible-lint
+++ b/roles/kerberos_client/.ansible-lint
@@ -1,0 +1,3 @@
+warn_list:  # or 'skip_list' to silence them completely
+  - meta-no-info  # meta/main.yml should contain relevant info
+  - meta-no-tags  # Tags must contain lowercase letters and digits only

--- a/roles/kerberos_client/.ansible-lint
+++ b/roles/kerberos_client/.ansible-lint
@@ -1,3 +1,3 @@
-warn_list:  # or 'skip_list' to silence them completely
+skip_list:
   - meta-no-info  # meta/main.yml should contain relevant info
   - meta-no-tags  # Tags must contain lowercase letters and digits only

--- a/roles/kerberos_client/tasks/main.yml
+++ b/roles/kerberos_client/tasks/main.yml
@@ -27,4 +27,7 @@
   when: ansible_distribution == "Ubuntu" and ansible_distribution_major_version == "20"
 
 - name: Copy the client configuration file
-  template: src=krb5.conf.j2 dest=/etc/krb5.conf
+  template: 
+    src: "krb5.conf.j2"
+    dest: "/etc/krb5.conf"
+    mode: "0644"

--- a/roles/lmod/tasks/main.yml
+++ b/roles/lmod/tasks/main.yml
@@ -13,8 +13,8 @@
   yum:
     name: 
       - "{{ epel_package }}"
-    state: latest
-  environment: "{{proxy_env if proxy_env is defined else {}}}"
+    state: present
+  environment: "{{ proxy_env if proxy_env is defined else {} }}"
   when: ansible_os_family == "RedHat"
 
 - name: "install packages"
@@ -49,11 +49,17 @@
 
 - name: "mkdir software path"
   become: yes
-  file: path={{ sm_software_path }} state=directory
+  file:
+    path: "{{ sm_software_path }}"
+    state: directory
+    mode: "0755"
 
 - name: "mkdir module path"
   become: yes
-  file: path={{ sm_module_path }} state=directory 
+  file:
+    path: "{{ sm_module_path }}"
+    state: directory 
+    mode: 0755
 
 - name: "configure sh profile"
   become: yes
@@ -62,7 +68,7 @@
     dest: /etc/profile.d
     owner: root
     group: root
-    mode: 0777
+    mode: 0755
   tags:
     - configuration
 
@@ -73,7 +79,7 @@
     dest: /etc/profile.d
     owner: root
     group: root
-    mode: 0777
+    mode: 0755
   tags:
     - configuration
 
@@ -81,38 +87,44 @@
 - name: "bugfix for lmod posix_c"
   become: yes
   register: lmod_bugfix_posix
-  shell: |
-    ln -s -f /usr/lib/x86_64-linux-gnu/lua/5.1/posix_c.so /usr/lib/x86_64-linux-gnu/lua/5.1/posix.so
-    ln -s -f /usr/lib/x86_64-linux-gnu/lua/5.2/posix_c.so /usr/lib/x86_64-linux-gnu/lua/5.2/posix.so
-    ln -s -f /usr/lib/x86_64-linux-gnu/lua/5.3/posix_c.so /usr/lib/x86_64-linux-gnu/lua/5.3/posix.so
+  file:
+    src: "/usr/lib/x86_64-linux-gnu/lua/{{ item }}/posix_c.so"
+    dest: "/usr/lib/x86_64-linux-gnu/lua/{{ item }}/posix.so"
+    owner: "root"
+    group: "root"
+    state: "link"
+    force: true
   when: 
     - ansible_distribution == 'Ubuntu'
     - ansible_distribution_version == '18.04'
-  changed_when: lmod_bugfix_posix.rc != 0
+  with_items:
+    - "5.1"
+    - "5.2"
+    - "5.3"
 
 - name: "unset previous lmod setup"
-  shell: unset MODULEPATH_ROOT
+  shell: unset MODULEPATH_ROOT  # noqa command-instead-of-shell
   register: unset_lmod_bash
   args:
     executable: /bin/bash
   changed_when: unset_lmod_bash.rc != 0
 
 - name: "unset previous lmod setup"
-  shell: unsetenv MODULEPATH_ROOT
+  shell: unsetenv MODULEPATH_ROOT  # noqa command-instead-of-shell
   register: unset_lmod_csh
   args:
     executable: /bin/csh
   changed_when: unset_lmod_csh.rc != 0
 
 - name: "auto load lmod"
-  shell: . /etc/profile.d/z00_lmod.sh
+  shell: . /etc/profile.d/z00_lmod.sh  # noqa command-instead-of-shell
   register: load_lmod_bash
   args:
     executable: /bin/bash
   changed_when: load_lmod_bash.rc != 0
 
 - name: "auto load lmod "
-  shell: source /etc/profile.d/z00_lmod.csh
+  shell: source /etc/profile.d/z00_lmod.csh  # noqa command-instead-of-shell
   register: load_lmod_csh
   args:
     executable: /bin/csh

--- a/roles/move-home-dirs/tasks/main.yml
+++ b/roles/move-home-dirs/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: find non-system users who need moving
-  shell: awk '-F:' '($1!="nobody")&&($1!="{{ tmp_user }}")&&($3>=1000){print $6,$1}' /etc/passwd | grep -v "^{{ move_home_dirs_new_root }}" | awk '{print $2}'
+  shell: set -o pipefail && awk '-F:' '($1!="nobody")&&($1!="{{ tmp_user }}")&&($3>=1000){print $6,$1}' /etc/passwd | grep -v "^{{ move_home_dirs_new_root }}" | awk '{print $2}'
   changed_when: false
   register: user_list
 

--- a/roles/move-home-dirs/tasks/move_user.yml
+++ b/roles/move-home-dirs/tasks/move_user.yml
@@ -1,7 +1,9 @@
 ---
 - name: kill user processes for {{ user }}
   command: killall -u {{ user }}
-  ignore_errors: true
+  register: kill_user_procs
+  failed_when: false
+  changed_when: kill_user_procs.rc == 0
 
 - name: move home directory for {{ user }}
   user:

--- a/roles/move-home-dirs/tasks/move_users.yml
+++ b/roles/move-home-dirs/tasks/move_users.yml
@@ -5,6 +5,7 @@
 - name: create {{ move_home_dirs_new_root }}
   file:
     path: "{{ move_home_dirs_new_root }}"
+    mode: "0755"
     state: directory
 
 - name: set key path
@@ -40,6 +41,7 @@
   copy:
     content: "{{ tmp_user }} ALL=(ALL) NOPASSWD:ALL"
     dest: "/etc/sudoers.d/{{ tmp_user }}"
+    mode: "0700"
 
 # Useful for slurm clusters
 - name: grant SSH access to temporary user
@@ -47,6 +49,7 @@
     path: /etc/localusers
     line: "{{ tmp_user }}"
     create: yes
+    mode: "0644"
 
 - name: move each user
   include_tasks: move_user.yml

--- a/roles/netapp-trident/.ansible-lint
+++ b/roles/netapp-trident/.ansible-lint
@@ -1,0 +1,2 @@
+skip_list:
+- var-naming

--- a/roles/netapp-trident/tasks/main.yml
+++ b/roles/netapp-trident/tasks/main.yml
@@ -11,6 +11,7 @@
   template:
     src: namespace.j2
     dest: '{{ deepops_dir }}/trident-installer/namespace.yaml'
+    mode: "0644"
   run_once: true
 
 - name: Create Trident namespace
@@ -24,13 +25,15 @@
 - name: Install Trident using Helm
   command: '/usr/local/bin/helm -n {{ trident_namespace }} install trident {{ deepops_dir }}/trident-installer/helm/trident-operator-{{ trident_version }}.tgz'
   run_once: true
+  changed_when: false
 
 - name: Copy backend config file(s) to control node
   template:
     src: backend.j2
     dest: '{{ deepops_dir }}/trident-installer/backend-{{ item.backendName }}.json'
+    mode: "0644"
   with_items: '{{ backends_to_create }}'
-  when: create_backends == true
+  when: create_backends
   run_once: true
 
 - name: Create Trident backend(s)
@@ -40,15 +43,16 @@
   delay: 30
   register: result
   until: result.rc == 0
-  when: create_backends == true
+  when: create_backends
   run_once: true
 
 - name: Copy StorageClass config file(s) to control node
   copy:
     content: '{{ item }}'
     dest: '{{ deepops_dir }}/trident-installer/sc-{{ item.metadata.name }}.yaml'
+    mode: "0644"
   with_items: '{{ storageClasses_to_create }}'
-  when: create_StorageClasses == true
+  when: create_StorageClasses
   run_once: true
 
 - name: Create StorageClasses
@@ -58,7 +62,7 @@
     name: '{{ item.metadata.name }}'
     filename: '{{ deepops_dir }}/trident-installer/sc-{{ item.metadata.name }}.yaml'
   with_items: '{{ storageClasses_to_create }}'
-  when: create_StorageClasses == true
+  when: create_StorageClasses
   run_once: true
 
 - name: Create volume snapshot CRDs
@@ -66,7 +70,7 @@
     state: present
     filename: '{{ item }}'
   with_items: '{{ volume_snapshot_CRD_manifest_URLs }}'
-  when: enable_volume_snapshots == true
+  when: enable_volume_snapshots
   run_once: true
 
 - name: Create snapshot controller
@@ -74,15 +78,16 @@
     state: present
     filename: '{{ item }}'
   with_items: '{{ snapshot_controller_manifest_URLs }}'
-  when: enable_volume_snapshots == true
+  when: enable_volume_snapshots
   run_once: true
 
 - name: Copy volume snapshot class config file(s) to control node
   copy:
     content: '{{ item }}'
     dest: '{{ deepops_dir }}/trident-installer/snapclass-{{ item.metadata.name }}.yaml'
+    mode: "0644"
   with_items: '{{ volume_snapshot_classes_to_create }}'
-  when: enable_volume_snapshots == true
+  when: enable_volume_snapshots
   run_once: true
 
 - name: Create volume snapshot classes
@@ -92,7 +97,7 @@
     name: '{{ item.metadata.name }}'
     filename: '{{ deepops_dir }}/trident-installer/snapclass-{{ item.metadata.name }}.yaml'
   with_items: '{{ volume_snapshot_classes_to_create }}'
-  when: enable_volume_snapshots == true
+  when: enable_volume_snapshots
   run_once: true
 
 - name: Fetch tridentctl from control node
@@ -100,7 +105,7 @@
     src: '{{ deepops_dir }}/trident-installer/tridentctl'
     dest: '{{ tridentctl_copy_to_directory }}'
     flat: yes
-  when: copy_tridentctl_to_localhost == true
+  when: copy_tridentctl_to_localhost
   run_once: true
 
 - name: Make tridentctl on localhost executable
@@ -109,4 +114,4 @@
   file:
     path: "{{ tridentctl_copy_to_directory }}/tridentctl"
     mode: '0755'
-  when: copy_tridentctl_to_localhost == true
+  when: copy_tridentctl_to_localhost

--- a/roles/nfs-client-provisioner/tasks/main.yml
+++ b/roles/nfs-client-provisioner/tasks/main.yml
@@ -2,13 +2,16 @@
 # See the GitHub code repo: https://github.com/kubernetes-sigs/nfs-subdir-external-provisioner
 
 - name: install nfs-client-provisioner helm repo
-  command: /usr/local/bin/helm repo add --force-update "{{k8s_nfs_client_repo_name}}" "{{ k8s_nfs_client_helm_repo }}"
+  command: /usr/local/bin/helm repo add --force-update "{{ k8s_nfs_client_repo_name }}" "{{ k8s_nfs_client_helm_repo }}"
   delegate_to: localhost
+  changed_when: false
 
 - name: update helm repos
   command: /usr/local/bin/helm repo update
   delegate_to: localhost
+  changed_when: false
 
 - name: install nfs-client-provisioner
   command: /usr/local/bin/helm upgrade --kubeconfig {{ artifacts_dir }}/admin.conf --install "{{ k8s_nfs_client_release_name }}" "{{ k8s_nfs_client_chart_name }}" --create-namespace --namespace deepops-nfs-client-provisioner --version "{{ k8s_nfs_client_chart_version }}" --set nfs.server="{{ k8s_nfs_server }}" --set nfs.path="{{ k8s_nfs_export_path }}" --set storageClass.defaultClass="{{ k8s_nfs_default_sc }}" --wait
   delegate_to: localhost
+  changed_when: false

--- a/roles/nfs/tasks/client.yml
+++ b/roles/nfs/tasks/client.yml
@@ -3,6 +3,7 @@
   file:
     path: '{{ item.mountpoint }}'
     state: directory
+    mode: "0755"
   with_items: '{{ nfs_mounts }}'
   when: nfs_mounts|length
   tags:

--- a/roles/nfs/tasks/main.yml
+++ b/roles/nfs/tasks/main.yml
@@ -15,7 +15,7 @@
 - name: install ubuntu packages
   apt:
     name: nfs-common
-    state: latest
+    state: present
   when: ansible_os_family == "Debian"
   tags:
     - nfs
@@ -23,7 +23,7 @@
 - name: install rhel packages
   yum:
     name: nfs-utils
-    state: latest
+    state: present
   when: ansible_os_family == "RedHat"
   tags:
     - nfs

--- a/roles/nfs/tasks/server.yml
+++ b/roles/nfs/tasks/server.yml
@@ -2,13 +2,16 @@
 - name: install ubuntu packages
   apt:
     name: nfs-kernel-server
-    state: latest
+    state: present
   when: ansible_os_family == "Debian"
   tags:
     - nfs
 
 - name: ensure export path exists
-  file: path={{ item.path }} state=directory
+  file:
+    path: "{{ item.path }}"
+    state: "directory"
+    mode: "0755"
   with_items: '{{ nfs_exports }}'
   notify: restart nfs
   tags:

--- a/roles/nginx-docker-registry-cache/tasks/client-el.yml
+++ b/roles/nginx-docker-registry-cache/tasks/client-el.yml
@@ -20,8 +20,10 @@
       owner: "root"
       group: "root"
       mode: "0644"
+    register: copy_ca_cert
   - name: update CA cert bundle
     command: update-ca-trust
+    when: copy_ca_cert.changed
 
 - name: install CA certificate from live proxy
   when: nginx_docker_cache_ca is not defined
@@ -33,5 +35,7 @@
       owner: "root"
       group: "root"
       mode: "0644"
+    register: download_ca_cert
   - name: update CA cert bundle
     command: update-ca-trust
+    when: download_ca_cert.changed

--- a/roles/nginx-docker-registry-cache/tasks/client-ubuntu.yml
+++ b/roles/nginx-docker-registry-cache/tasks/client-ubuntu.yml
@@ -20,12 +20,15 @@
       owner: "root"
       group: "root"
       mode: "0644"
+    register: copy_ca_cert
   - name: add CA certificate to list
     lineinfile:
       path: "/etc/ca-certificates.conf"
       line: "{{ nginx_docker_cache_ca_client_name }}"
+    register: update_ca_cert_cfg
   - name: update CA cert bundle
     command: update-ca-certificates --fresh
+    when: copy_ca_cert.changed or update_ca_cert_cfg.changed
 
 - name: install CA certificate from live proxy
   when: nginx_docker_cache_ca is not defined
@@ -37,9 +40,12 @@
       owner: "root"
       group: "root"
       mode: "0644"
+    register: download_ca_cert
   - name: add CA certificate to list
     lineinfile:
       path: "/etc/ca-certificates.conf"
       line: "{{ nginx_docker_cache_ca_client_name }}"
+    register: update_ca_cert_cfg
   - name: update CA cert bundle
     command: update-ca-certificates --fresh
+    when: download_ca_cert.changed or update_ca_cert_cfg.changed

--- a/roles/nhc/.ansible-lint
+++ b/roles/nhc/.ansible-lint
@@ -1,2 +1,2 @@
-warn_list:  # or 'skip_list' to silence them completely
+skip_list:
   - meta-no-info  # meta/main.yml should contain relevant info

--- a/roles/nhc/.ansible-lint
+++ b/roles/nhc/.ansible-lint
@@ -1,0 +1,2 @@
+warn_list:  # or 'skip_list' to silence them completely
+  - meta-no-info  # meta/main.yml should contain relevant info

--- a/roles/nhc/tasks/main.yml
+++ b/roles/nhc/tasks/main.yml
@@ -47,7 +47,7 @@
     url: "{{ nhc_src_url }}"
     dest: "{{ nhc_build_dir }}/nhc-{{ nhc_version }}.tar.xz"
     mode: "0644"
-  environment: "{{proxy_env if proxy_env is defined else {}}}"
+  environment: "{{ proxy_env if proxy_env is defined else {} }}"
   when: nhc_build
 
 - name: extract nhc src

--- a/roles/nis_client/tasks/main.yml
+++ b/roles/nis_client/tasks/main.yml
@@ -17,11 +17,11 @@
   changed_when: false
 
 - name: install Ubuntu packages
-  apt: name=nis,rpcbind state=latest
+  apt: name=nis,rpcbind state=present
   when: ansible_os_family == "Debian"
 
 - name: install CentOS NIS packages
-  yum: name=ypbind state=latest
+  yum: name=ypbind state=present
   when: ansible_os_family == "RedHat"
 
 - name: ensure rpcbind is running

--- a/roles/nvidia-dcgm-exporter/tasks/main.yml
+++ b/roles/nvidia-dcgm-exporter/tasks/main.yml
@@ -3,11 +3,13 @@
   file:
     path: "{{ prometheus_config_dir }}"
     state: directory
+    mode: "0755"
 
 - name: create endpoints config dir
   file:
     path: "{{ prometheus_cfg_endpoint_dir }}"
     state: directory
+    mode: "0755"
 
 - name: install config file
   template:
@@ -21,6 +23,7 @@
   file:
     path: "{{ nvidia_dcgm_container_config_dir }}"
     state: directory
+    mode: "0755"
   when: has_gpus
 
 - name: copy metrics file

--- a/roles/nvidia-dgx-firmware/tasks/get-data.yml
+++ b/roles/nvidia-dgx-firmware/tasks/get-data.yml
@@ -3,6 +3,6 @@
 - name: Run NVSM human-readable health show
   shell: "osversion=`cat /etc/dgx-release | grep 'DGX_SWBUILD_VERSION'`; host=`hostname`; copper_mac=`ip addr | grep -A 1 enp6s0 | grep link | awk '{print $2}'`; bmc_ip=`sudo ipmitool lan print | grep -i 'IP Address              :' | awk '{print $4}'`; bmc_mac=`sudo ipmitool lan print | grep -i 'MAC Address' | awk '{print $4}'`;host_mac=`ifconfig {{ nv_mgmt_interface }} | grep 'ether' | awk '{print $2}'`;host_ip=`ifconfig {{ nv_mgmt_interface }} | grep 'inet ' | awk '{print $2}'`;data=\"${host_ip},${host_mac},${bmc_ip},${bmc_mac},${copper_mac},${host},${osversion}\";echo ${data}"
   register: command_output
-  - debug:
+- debug:
     msg: "{{ command_output.stdout }}"
   ignore_errors: yes

--- a/roles/nvidia-gpu-operator-node-prep/tasks/main.yml
+++ b/roles/nvidia-gpu-operator-node-prep/tasks/main.yml
@@ -7,7 +7,7 @@
   modprobe:
     name: nouveau
     state: absent
-  ignore_errors: true
+  failed_when: false
 
 - name: blocklist nouveau
   copy:

--- a/roles/nvidia-gpu-operator/.ansible-lint
+++ b/roles/nvidia-gpu-operator/.ansible-lint
@@ -1,3 +1,3 @@
-warn_list:
+skip_list:
 - meta-no-info
 - role-name

--- a/roles/nvidia-gpu-operator/.ansible-lint
+++ b/roles/nvidia-gpu-operator/.ansible-lint
@@ -1,0 +1,3 @@
+warn_list:
+- meta-no-info
+- role-name

--- a/roles/nvidia-gpu-operator/tasks/k8s.yml
+++ b/roles/nvidia-gpu-operator/tasks/k8s.yml
@@ -5,12 +5,16 @@
 # So for now we will run /usr/local/bin/helm commands directly...
 - name: install gpu-operator helm repo
   command: /usr/local/bin/helm repo add nvidia "{{ gpu_operator_helm_repo }}"
+  changed_when: false
 
 - name: update helm repos
   command: /usr/local/bin/helm repo update
+  changed_when: false
 
 - name: Remove existing GPU Operator labels to accommodate potenial configuration changes
-  shell: kubectl label node --all nvidia.com/gpu.deploy.container-toolkit-  nvidia.com/gpu.deploy.dcgm- nvidia.com/gpu.deploy.dcgm-exporter- nvidia.com/gpu.deploy.device-plugin- nvidia.com/gpu.deploy.driver- nvidia.com/gpu.deploy.gpu-feature-discovery- nvidia.com/gpu.deploy.node-status-exporter- nvidia.com/gpu.deploy.operator-validator-
+  command: kubectl label node --all nvidia.com/gpu.deploy.container-toolkit-  nvidia.com/gpu.deploy.dcgm- nvidia.com/gpu.deploy.dcgm-exporter- nvidia.com/gpu.deploy.device-plugin- nvidia.com/gpu.deploy.driver- nvidia.com/gpu.deploy.gpu-feature-discovery- nvidia.com/gpu.deploy.node-status-exporter- nvidia.com/gpu.deploy.operator-validator-
+  changed_when: false
 
 - name: install nvidia gpu operator
   command: /usr/local/bin/helm upgrade --install "{{ gpu_operator_release_name }}" "{{ gpu_operator_chart_name }}" --version "{{ gpu_operator_chart_version }}" --create-namespace --namespace {{ gpu_operator_namespace }} --set driver.version="{{ gpu_operator_driver_version }}" --set mig.strategy="{{ k8s_gpu_mig_strategy |lower }}" --set driver.enabled="{{ gpu_operator_enable_driver |lower }}" --set toolkit.enabled="{{ gpu_operator_enable_toolkit |lower }}" --set dcgm.enabled="{{ gpu_operator_enable_dcgm |lower }}" --set migManager.enabled="{{ gpu_operator_enable_migmanager |lower }}" --wait
+  changed_when: false

--- a/roles/nvidia-gpu-operator/tasks/nvaie.yml
+++ b/roles/nvidia-gpu-operator/tasks/nvaie.yml
@@ -5,7 +5,8 @@
     gpu_operator_enable_migmanager: false
 
 - name: Create namespace for GPU Operator resources
-  shell: kubectl create namespace {{ gpu_operator_namespace }} -o yaml --dry-run=client | kubectl apply -f -
+  shell: set -o pipefail && kubectl create namespace {{ gpu_operator_namespace }} -o yaml --dry-run=client | kubectl apply -f -
+  changed_when: false
 
 - name: create local directory for gpu operator configuration
   file:
@@ -32,10 +33,12 @@
     mode: "0600"
 
 - name: Create a docker gridd.conf license configmap
-  shell: kubectl create configmap licensing-config -n "{{ gpu_operator_namespace }}" --from-file="{{ gpu_operator_grid_config_dir }}/gridd.conf" --from-file="{{ gpu_operator_grid_config_dir }}/client_configuration_token.tok" -o yaml --dry-run=client | kubectl apply -f -
+  shell: set -o pipefail && kubectl create configmap licensing-config -n "{{ gpu_operator_namespace }}" --from-file="{{ gpu_operator_grid_config_dir }}/gridd.conf" --from-file="{{ gpu_operator_grid_config_dir }}/client_configuration_token.tok" -o yaml --dry-run=client | kubectl apply -f -
+  changed_when: false
 
 - name: Create a docker secret for private GPU Operator containers
-  shell: kubectl create secret docker-registry registry-secret --docker-server='{{ gpu_operator_driver_registry }}' --docker-username='{{ gpu_operator_registry_username }}' --docker-password={{ gpu_operator_registry_password }} --docker-email={{ gpu_operator_registry_email }} -n {{ gpu_operator_namespace }} -o yaml --dry-run=client | kubectl apply -f -
+  shell: set -o pipefail && kubectl create secret docker-registry registry-secret --docker-server='{{ gpu_operator_driver_registry }}' --docker-username='{{ gpu_operator_registry_username }}' --docker-password={{ gpu_operator_registry_password }} --docker-email={{ gpu_operator_registry_email }} -n {{ gpu_operator_namespace }} -o yaml --dry-run=client | kubectl apply -f -
+  changed_when: false
 
 # While we would prefer to use the Ansible helm module, it's broken! :-(
 # See https://github.com/ansible/ansible/pull/57897
@@ -43,11 +46,14 @@
 # So for now we will run /usr/local/bin/helm commands directly...
 - name: install NVAIE gpu-operator helm repo
   command: /usr/local/bin/helm repo add nvaie "{{ gpu_operator_nvaie_helm_repo }}" --username='{{ gpu_operator_registry_username }}' --password="{{ gpu_operator_registry_password }}"
+  changed_when: false
 
 - name: update helm repos
   command: /usr/local/bin/helm repo update
+  changed_when: false
 
 # TODO: This is no longer the cae # XXX: This currently installs into the default namespace, as per the GPU Operator docs
 # https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/getting-started.html
 - name: install nvidia gpu operator
   command: /usr/local/bin/helm upgrade --install "{{ gpu_operator_release_name }}" "{{ gpu_operator_nvaie_chart_name }}" --version "{{ gpu_operator_chart_version }}" --namespace "{{ gpu_operator_namespace }}" --create-namespace --set driver.licensingConfig.configMapName=licensing-config --set driver.licensingConfig.nlsEnabled="{{ gpu_operator_nvaie_nls_enabled }}"  --set driver.imagePullSecrets[0]="registry-secret" --set operator.imagePullSecrets[0]="registry-secret" --set driver.repository="{{ gpu_operator_driver_registry }}" --set driver.version="{{ gpu_operator_driver_version }}"  --set mig.strategy="{{ k8s_gpu_mig_strategy }}"  --set driver.enabled="{{ gpu_operator_enable_driver }}" --set toolkit.enabled="{{ gpu_operator_enable_toolkit }}" --set dcgm.enabled="{{ gpu_operator_enable_dcgm }}" --set migManager.enabled="{{ gpu_operator_enable_migmanager }}" --wait
+  changed_when: false

--- a/roles/nvidia-k8s-gpu-device-plugin/.ansible-lint
+++ b/roles/nvidia-k8s-gpu-device-plugin/.ansible-lint
@@ -1,0 +1,3 @@
+warn_list:  # or 'skip_list' to silence them completely
+  - meta-no-info  # meta/main.yml should contain relevant info
+  - role-name

--- a/roles/nvidia-k8s-gpu-device-plugin/.ansible-lint
+++ b/roles/nvidia-k8s-gpu-device-plugin/.ansible-lint
@@ -1,3 +1,3 @@
-warn_list:  # or 'skip_list' to silence them completely
+skip_list:
   - meta-no-info  # meta/main.yml should contain relevant info
   - role-name

--- a/roles/nvidia-k8s-gpu-device-plugin/tasks/main.yml
+++ b/roles/nvidia-k8s-gpu-device-plugin/tasks/main.yml
@@ -6,9 +6,12 @@
 
 - name: install nvidia k8s gpu device plugin helm repo
   command: /usr/local/bin/helm repo add nvdp "{{ k8s_gpu_plugin_helm_repo }}"
+  changed_when: false
 
 - name: update helm repos
   command: /usr/local/bin/helm repo update
+  changed_when: false
 
 - name: install nvidia k8s gpu device plugin
   command: /usr/local/bin/helm upgrade --install "{{ k8s_gpu_plugin_release_name }}" "{{ k8s_gpu_plugin_chart_name }}" --version "{{ k8s_gpu_plugin_chart_version }}" --set "migStrategy={{ k8s_gpu_mig_strategy }}" --set "failOnInitError={{ k8s_gpu_plugin_init_error }}" --set affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].key="nvidia\.com\/gpu\.count",affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].operator="Exists" --wait
+  changed_when: false

--- a/roles/nvidia-k8s-gpu-feature-discovery/.ansible-lint
+++ b/roles/nvidia-k8s-gpu-feature-discovery/.ansible-lint
@@ -1,0 +1,3 @@
+warn_list:  # or 'skip_list' to silence them completely
+  - meta-no-info  # meta/main.yml should contain relevant info
+  - role-name

--- a/roles/nvidia-k8s-gpu-feature-discovery/.ansible-lint
+++ b/roles/nvidia-k8s-gpu-feature-discovery/.ansible-lint
@@ -1,3 +1,3 @@
-warn_list:  # or 'skip_list' to silence them completely
+skip_list:
   - meta-no-info  # meta/main.yml should contain relevant info
   - role-name

--- a/roles/nvidia-k8s-gpu-feature-discovery/tasks/main.yml
+++ b/roles/nvidia-k8s-gpu-feature-discovery/tasks/main.yml
@@ -6,9 +6,12 @@
 
 - name: install nvidia k8s gpu feature discovery helm repo
   command: /usr/local/bin/helm repo add nvgfd "{{ k8s_gpu_feature_discovery_helm_repo }}"
+  changed_when: false
 
 - name: update helm repos
   command: /usr/local/bin/helm repo update
+  changed_when: false
 
 - name: install nvidia k8s gpu feature discovery
   command: /usr/local/bin/helm upgrade --install "{{ k8s_gpu_feature_discovery_release_name }}" "{{ k8s_gpu_feature_discovery_chart_name }}" --version "{{ k8s_gpu_feature_discovery_chart_version }}" --set "migStrategy={{ k8s_gpu_mig_strategy }}" --wait
+  changed_when: false

--- a/roles/nvidia-mig-manager/tasks/main.yml
+++ b/roles/nvidia-mig-manager/tasks/main.yml
@@ -9,7 +9,7 @@
   changed_when: false
 
 - name: check for NVIDIA MIG parted
-  command: which nvidia-mig-parted
+  shell: which nvidia-mig-parted  # noqa command-instead-of-shell
   register: has_mig_parted
   failed_when: false
   changed_when: false

--- a/roles/nvidia-mig-manager/tasks/main.yml
+++ b/roles/nvidia-mig-manager/tasks/main.yml
@@ -3,13 +3,16 @@
 
 # Check node state
 - name: check for MIG capable devices
-  shell: nvidia-smi --query-gpu=mig.mode.current --format=csv,noheader | grep -v 'N/A'
+  shell: set -o pipefail && nvidia-smi --query-gpu=mig.mode.current --format=csv,noheader | grep -v 'N/A'
   register: has_mig
   failed_when: false
+  changed_when: false
+
 - name: check for NVIDIA MIG parted
-  shell: which nvidia-mig-parted
+  command: which nvidia-mig-parted
   register: has_mig_parted
   failed_when: false
+  changed_when: false
 
 # Install NVIDIA MIG Manager Systemd service
 - name: Install MIG Manager (apt)

--- a/roles/nvidia-ml/tasks/redhat-pre-install.yml
+++ b/roles/nvidia-ml/tasks/redhat-pre-install.yml
@@ -8,7 +8,7 @@
   yum:
     name: 
       - "{{ epel_package }}"
-    state: latest
+    state: present
 
 - name: add repo
   yum_repository:

--- a/roles/nvidia-peer-memory/tasks/main.yml
+++ b/roles/nvidia-peer-memory/tasks/main.yml
@@ -8,7 +8,7 @@
   command: dkms autoinstall
   when:
     - ansible_local['gpus']['count']
-    - is_dgx.stat.exists == True
+    - is_dgx.stat.exists
 
 - name: Modprobe nv_peer_mem
   modprobe:
@@ -16,7 +16,7 @@
     state: present
   when:
     - ansible_local['gpus']['count']
-    - is_dgx.stat.exists == True
+    - is_dgx.stat.exists
 
 - name: Start nv_peer_mem service
   service:
@@ -24,4 +24,4 @@
     state: started
   when:
     - ansible_local['gpus']['count']
-    - is_dgx.stat.exists == True
+    - is_dgx.stat.exists

--- a/roles/nvidia_cuda/molecule/default/prepare.yml
+++ b/roles/nvidia_cuda/molecule/default/prepare.yml
@@ -9,6 +9,7 @@
       owner: "root"
       group: "root"
       state: "directory"
+      mode: "0755"
     when: ansible_distribution == "Ubuntu"
 
   - name: Ensure dependencies are present for apt key management

--- a/roles/nvidia_cuda/tasks/install-redhat.yml
+++ b/roles/nvidia_cuda/tasks/install-redhat.yml
@@ -9,8 +9,8 @@
   yum:
     name: 
       - "{{ epel_package }}"
-    state: latest
-  environment: "{{proxy_env if proxy_env is defined else {}}}"
+    state: present
+  environment: "{{ proxy_env if proxy_env is defined else {} }}"
 
 - name: RedHat | add CUDA repo
   yum_repository:
@@ -18,9 +18,9 @@
     description: NVIDIA CUDA YUM Repo
     baseurl: "{{ nvidia_driver_rhel_cuda_repo_baseurl }}"
     gpgkey: "{{ nvidia_driver_rhel_cuda_repo_gpgkey }}"
-  environment: "{{proxy_env if proxy_env is defined else {}}}"
+  environment: "{{ proxy_env if proxy_env is defined else {} }}"
 
 - name: RedHat | install cuda
   package:
-    name: "{{ cuda_version}}"
+    name: "{{ cuda_version }}"
     state: present

--- a/roles/nvidia_cuda/tasks/install-ubuntu.yml
+++ b/roles/nvidia_cuda/tasks/install-ubuntu.yml
@@ -16,13 +16,13 @@
   apt_key:
     url: "{{ nvidia_driver_ubuntu_cuda_repo_gpgkey_url }}"
     id: "{{ nvidia_driver_ubuntu_cuda_repo_gpgkey_id }}"
-  environment: "{{proxy_env if proxy_env is defined else {}}}"
+  environment: "{{ proxy_env if proxy_env is defined else {} }}"
 
 - name: Ubuntu | add CUDA repo
   apt_repository:
     repo: "deb {{ nvidia_driver_ubuntu_cuda_repo_baseurl }} /"
     update_cache: yes
-  environment: "{{proxy_env if proxy_env is defined else {}}}"
+  environment: "{{ proxy_env if proxy_env is defined else {} }}"
 
 - name: Ubuntu | install cuda
   package:

--- a/roles/nvidia_dcgm/molecule/default/prepare.yml
+++ b/roles/nvidia_dcgm/molecule/default/prepare.yml
@@ -9,6 +9,7 @@
       owner: "root"
       group: "root"
       state: "directory"
+      mode: "0755"
     when: ansible_distribution == "Ubuntu"
 
   - name: Ensure dependencies are present for apt key management

--- a/roles/nvidia_dcgm/tasks/install-redhat.yml
+++ b/roles/nvidia_dcgm/tasks/install-redhat.yml
@@ -9,8 +9,8 @@
   yum:
     name:
       - "{{ epel_package }}"
-    state: latest
-  environment: "{{proxy_env if proxy_env is defined else {}}}"
+    state: present
+  environment: "{{ proxy_env if proxy_env is defined else {} }}"
 
 - name: RedHat | add CUDA repo
   yum_repository:
@@ -18,7 +18,7 @@
     description: NVIDIA CUDA YUM Repo
     baseurl: "{{ nvidia_driver_rhel_cuda_repo_baseurl }}"
     gpgkey: "{{ nvidia_driver_rhel_cuda_repo_gpgkey }}"
-  environment: "{{proxy_env if proxy_env is defined else {}}}"
+  environment: "{{ proxy_env if proxy_env is defined else {} }}"
 
 - name: RedHat | install package
   package:

--- a/roles/nvidia_dcgm/tasks/install-ubuntu.yml
+++ b/roles/nvidia_dcgm/tasks/install-ubuntu.yml
@@ -11,13 +11,13 @@
   apt_key:
     url: "{{ nvidia_driver_ubuntu_cuda_repo_gpgkey_url }}"
     id: "{{ nvidia_driver_ubuntu_cuda_repo_gpgkey_id }}"
-  environment: "{{proxy_env if proxy_env is defined else {}}}"
+  environment: "{{ proxy_env if proxy_env is defined else {} }}"
 
 - name: Ubuntu | add CUDA repo
   apt_repository:
     repo: "deb {{ nvidia_driver_ubuntu_cuda_repo_baseurl }} /"
     update_cache: yes
-  environment: "{{proxy_env if proxy_env is defined else {}}}"
+  environment: "{{ proxy_env if proxy_env is defined else {} }}"
 
 - name: Ubuntu | install package
   apt:

--- a/roles/ood-wrapper/tasks/linuxhost-adapter.yml
+++ b/roles/ood-wrapper/tasks/linuxhost-adapter.yml
@@ -21,6 +21,7 @@
 - name: configure linuxhost-adapter
   blockinfile:
     path: "{{ ood_cluster_config_dir }}/linuxhost.yml"
+    mode: "0644"
     block: |
       {{ ood_linuxhost_adapter_config }}
     create: yes
@@ -31,6 +32,7 @@
 - name: create singularity image directory
   file:
     path: "{{ singularity_image_dir }}"
+    mode: "0755"
     state: directory
   tags:
     - linuxhost-adapter

--- a/roles/ood-wrapper/tasks/server.yml
+++ b/roles/ood-wrapper/tasks/server.yml
@@ -106,7 +106,7 @@
   systemd:
     service: "{{ ood_apache_service_name }}"
     state: restarted
-  when: mod_install.changed
+  when: mod_install.changed  # noqa no-handler
   tags:
     - configure
 

--- a/roles/ood-wrapper/tasks/server.yml
+++ b/roles/ood-wrapper/tasks/server.yml
@@ -32,6 +32,7 @@
 - name: create clusters dir
   file:
     path: "{{ ood_cluster_config_dir }}"
+    mode: "0755"
     state: directory
   tags:
     - configure
@@ -39,6 +40,7 @@
 - name: configure slurm cluster connector
   template:
     src: cluster.yml.j2
+    mode: "0644"
     dest: "{{ ood_cluster_config_dir }}/{{ ood_cluster_name }}.yml"
   tags:
     - configure
@@ -77,6 +79,7 @@
     path: "{{ ood_htpasswd_file }}"
     name: "{{ user }}"
     password: "{{ ood_default_password }}"
+    mode: "0600"
     create: yes
   tags:
     - configure
@@ -147,6 +150,7 @@
 - name: create desktop app dir
   file:
     path: "{{ ood_desktops_dir }}/submit"
+    mode: "0755"
     state: directory
   tags:
     - configure
@@ -155,6 +159,7 @@
   template:
     src: desktop.yml.j2
     dest: "{{ ood_desktops_dir }}/{{ ood_cluster_name }}.yml"
+    mode: "0644"
   tags:
     - configure
 
@@ -162,6 +167,7 @@
   template:
     src: desktop-submit.yml.erb.j2
     dest: "{{ ood_desktops_dir }}/submit/{{ ood_cluster_name }}_desktop.yml.erb"
+    mode: "0644"
   tags:
     - configure
 
@@ -169,6 +175,7 @@
   template:
     src: desktop-form.yml.j2
     dest: "{{ ood_desktop_app_dir }}/form.yml"
+    mode: "0644"
   tags:
     - configure
 
@@ -188,6 +195,7 @@
   template:
     src: bc_osc_codeserver/form.yml.j2
     dest: "{{ ood_codeserver_app_dir }}/form.yml"
+    mode: "0644"
   tags:
     - configure
 
@@ -195,6 +203,7 @@
   template:
     src: bc_osc_codeserver/manifest.yml.j2
     dest: "{{ ood_codeserver_app_dir }}/manifest.yml"
+    mode: "0644"
   tags:
     - configure
 
@@ -202,6 +211,7 @@
   template:
     src: bc_osc_codeserver/submit.yml.erb.j2
     dest: "{{ ood_codeserver_app_dir }}/submit.yml.erb"
+    mode: "0644"
   tags:
     - configure
 

--- a/roles/openmpi/tasks/main.yml
+++ b/roles/openmpi/tasks/main.yml
@@ -20,7 +20,7 @@
 
 - name: update ld cache
   command: ldconfig
-  when: updated_openmpi_ld.changed
+  when: updated_openmpi_ld.changed  # noqa no-handler
 
 - name: default to building openmpi
   set_fact:
@@ -59,7 +59,7 @@
     - openmpi-common
     - libopenmpi-dev
   when: ansible_distribution == 'Ubuntu'
-  ignore_errors: yes
+  failed_when: false
 
 - name: remove openmpi packages
   yum:
@@ -69,12 +69,13 @@
     - openmpi
     - openmpi-devel
   when: ansible_os_family == 'RedHat'
-  ignore_errors: yes
+  failed_when: false
 
 - name: make openmpi build directory
   file:
     path: "{{ openmpi_build_dir }}"
     state: directory
+    mode: "0755"
   when: openmpi_build
 
 - name: download openmpi source
@@ -90,7 +91,7 @@
   command: make -j uninstall
   args:
     chdir: "{{ openmpi_build_dir }}"
-  ignore_errors: yes
+  failed_when: false
   when: openmpi_build
   tags:
     - uninstall
@@ -99,7 +100,7 @@
   command: make distclean
   args:
     chdir: "{{ openmpi_build_dir }}"
-  ignore_errors: yes
+  failed_when: false
   when: openmpi_build
 
 - name: configure openmpi

--- a/roles/openshift/tasks/main.yml
+++ b/roles/openshift/tasks/main.yml
@@ -7,19 +7,20 @@
     - "virtualenv"
     - "python3-setuptools"
   when: ansible_distribution == 'Ubuntu'
-  environment: "{{proxy_env if proxy_env is defined else {}}}"
+  environment: "{{ proxy_env if proxy_env is defined else {} }}"
 
 - name: create location for deepops files
   file:
     path: "{{ deepops_dir }}"
     state: directory
+    mode: "0755"
 
 - name: install openshift python client for k8s_raw module
   pip:
     name: openshift
     virtualenv: "{{ deepops_venv }}"
   when: ansible_distribution == 'Ubuntu'
-  environment: "{{proxy_env if proxy_env is defined else {}}}"
+  environment: "{{ proxy_env if proxy_env is defined else {} }}"
 
 - name: trust GPG key for EPEL
   rpm_key:
@@ -37,10 +38,10 @@
   yum:
     name: python2-openshift
   when: ansible_os_family == 'RedHat' and ansible_distribution_major_version == "7"
-  environment: "{{proxy_env if proxy_env is defined else {}}}"
+  environment: "{{ proxy_env if proxy_env is defined else {} }}"
 
 - name: install openshift python client for k8s_raw module
   yum:
     name: python3-openshift
   when: ansible_os_family == 'RedHat' and ansible_distribution_major_version == "8"
-  environment: "{{proxy_env if proxy_env is defined else {}}}"
+  environment: "{{ proxy_env if proxy_env is defined else {} }}"

--- a/roles/prometheus-node-exporter/tasks/main.yml
+++ b/roles/prometheus-node-exporter/tasks/main.yml
@@ -3,11 +3,13 @@
   file:
     path: "{{ prometheus_config_dir }}"
     state: directory
+    mode: "0755"
 
 - name: create endpoints config dir
   file:
     path: "{{ prometheus_cfg_endpoint_dir }}"
     state: directory
+    mode: "0755"
 
 - name: install config file
   template:

--- a/roles/prometheus-slurm-exporter/handlers/main.yml
+++ b/roles/prometheus-slurm-exporter/handlers/main.yml
@@ -8,4 +8,4 @@
   service:
     name: "{{ grafana_svc_name }}"
     state: restarted
-  ignore_errors: true
+  failed_when: false

--- a/roles/prometheus-slurm-exporter/tasks/main.yml
+++ b/roles/prometheus-slurm-exporter/tasks/main.yml
@@ -3,11 +3,13 @@
   file:
     path: "{{ prometheus_config_dir }}"
     state: directory
+    mode: "0755"
 
 - name: create endpoints config dir
   file:
     path: "{{ prometheus_cfg_endpoint_dir }}"
     state: directory
+    mode: "0755"
 
 - name: install config file
   template:
@@ -22,18 +24,21 @@
     path: "{{ grafana_data_dir }}"
     state: directory
     owner: "{{ grafana_user_id }}"
+    mode: "0755"
 
 - name: create dashboard dir
   file:
     path: "{{ grafana_cfg_dashboard_path }}"
     state: directory
     owner: "{{ grafana_user_id }}"
+    mode: "0755"
 
 - name: copy dashboards
   copy:
     src: "{{ item }}"
     dest: "{{ grafana_cfg_dashboard_path }}"
     owner: "{{ grafana_user_id }}"
+    mode: "0644"
   with_items:
     - slurm-dashboard.json
   notify: restart grafana

--- a/roles/prometheus/tasks/main.yml
+++ b/roles/prometheus/tasks/main.yml
@@ -3,11 +3,13 @@
   file:
     path: "{{ prometheus_config_dir }}"
     state: directory
+    mode: "0755"
 
 - name: create endpoints config dir
   file:
     path: "{{ prometheus_cfg_endpoint_dir }}"
     state: directory
+    mode: "0755"
 
 - name: install config file
   template:

--- a/roles/pyxis/tasks/pyxis.yml
+++ b/roles/pyxis/tasks/pyxis.yml
@@ -3,6 +3,7 @@
   file:
     path: /usr/local/src/pyxis
     state: directory
+    mode: "0755"
   tags: pyxis
 
 - name: copy pyxis source
@@ -20,7 +21,9 @@
     argv:
       - make
       - clean
-  ignore_errors: true
+  register: pyxis_make_clean
+  failed_when: false
+  changed_when: pyxis_make_clean.rc == 0
   tags: pyxis
 
 - name: build pyxis
@@ -43,6 +46,7 @@
   template:
     src: etc/slurm/plugstack.conf
     dest: "{{ slurm_config_dir }}/"
+    mode: "0644"
   notify:
     - restart slurmctld
     - restart slurmd
@@ -52,6 +56,7 @@
   template:
     src: etc/slurm/plugstack.conf.d/pyxis.conf
     dest: "{{ slurm_config_dir }}/plugstack.conf.d/"
+    mode: "0644"
   notify:
     - restart slurmctld
     - restart slurmd

--- a/roles/roce_backend/tasks/allhosts.yaml
+++ b/roles/roce_backend/tasks/allhosts.yaml
@@ -63,7 +63,7 @@
     name:
       - python3-pip
       - python3-setuptools
-    state: latest
+    state: present
     update_cache: true
   tags:
     - roce_host

--- a/roles/roce_backend/tasks/mofed-install.yaml
+++ b/roles/roce_backend/tasks/mofed-install.yaml
@@ -11,7 +11,7 @@
         path: /usr/bin/ofed_info
       register: ofed_installed
     - name: Check Mellanox OFED version
-      command: /usr/bin/ofed_info -n
+      shell: /usr/bin/ofed_info -n  # noqa command-instead-of-shell
       register: current_mofed_version
       when: ofed_installed.stat.exists
     - name: Mellanox OFED version

--- a/roles/roce_backend/tasks/mofed-install.yaml
+++ b/roles/roce_backend/tasks/mofed-install.yaml
@@ -1,7 +1,8 @@
 ---
 - name: Check MLNX NIC's
-  shell: lspci | grep Mellanox | awk '{print $1}' | wc -l
+  shell: set -o pipefail && lspci | grep Mellanox | awk '{print $1}' | wc -l
   register: check_mlnx_adapter
+  changed_when: false
 
 - name: MOFED install
   block:
@@ -10,7 +11,7 @@
         path: /usr/bin/ofed_info
       register: ofed_installed
     - name: Check Mellanox OFED version
-      shell: /usr/bin/ofed_info -n
+      command: /usr/bin/ofed_info -n
       register: current_mofed_version
       when: ofed_installed.stat.exists
     - name: Mellanox OFED version
@@ -28,8 +29,9 @@
       args:
         executable: /bin/bash
         warn: no
-      when: (ofed_installed.stat.exists == False) or (mofed_version not in current_mofed_version.stdout)
+      when: (not ofed_installed.stat.exists) or (mofed_version not in current_mofed_version.stdout)
       register: install_mofed
+      changed_when: install_mofed.rc == 0
     - name: Reboot host after installing mellanox OFED
       reboot:
       when: install_mofed.changed

--- a/roles/roce_backend/tasks/vf-activate.yaml
+++ b/roles/roce_backend/tasks/vf-activate.yaml
@@ -1,8 +1,9 @@
 ---
 - name: Check activation
   register: result
-  shell: "grep -i {{ item.pf_name }} /etc/rc.local"
+  command: "grep -i {{ item.pf_name }} /etc/rc.local"
   failed_when: result.rc == 2
+  changed_when: result.rc == 1 
   tags: roce_host
 
 - name: VF activation

--- a/roles/singularity_wrapper/.ansible-lint
+++ b/roles/singularity_wrapper/.ansible-lint
@@ -1,2 +1,2 @@
-warn_list:  # or 'skip_list' to silence them completely
+skip_list:
   - meta-no-info  # meta/main.yml should contain relevant info

--- a/roles/singularity_wrapper/.ansible-lint
+++ b/roles/singularity_wrapper/.ansible-lint
@@ -1,0 +1,2 @@
+warn_list:  # or 'skip_list' to silence them completely
+  - meta-no-info  # meta/main.yml should contain relevant info

--- a/roles/singularity_wrapper/tasks/main.yml
+++ b/roles/singularity_wrapper/tasks/main.yml
@@ -6,7 +6,7 @@
         name: "dnf-plugins-core"
         state: "present"
     - name: enable powertools
-      command: "yum config-manager --set-enabled powertools"
+      command: "yum config-manager --set-enabled powertools" # noqa command-instead-of-module
       register: enable_powertools
       changed_when: enable_powertools.rc != 0
   when: (ansible_distribution == "CentOS") and (ansible_distribution_major_version == "8")

--- a/roles/slurm/.ansible-lint
+++ b/roles/slurm/.ansible-lint
@@ -1,2 +1,2 @@
-warn_list:
+skip_list:
 - meta-no-info

--- a/roles/slurm/.ansible-lint
+++ b/roles/slurm/.ansible-lint
@@ -1,0 +1,2 @@
+warn_list:
+- meta-no-info

--- a/roles/slurm/tasks/build-cleanup.yml
+++ b/roles/slurm/tasks/build-cleanup.yml
@@ -3,7 +3,7 @@
   command: make clean
   args:
     chdir: "{{ slurm_build_dir }}"
-  ignore_errors: yes
+  failed_when: false
   when: slurm_build_make_clean
 
 - name: remove build directory

--- a/roles/slurm/tasks/build.yml
+++ b/roles/slurm/tasks/build.yml
@@ -14,7 +14,7 @@
 
 - name: update ld cache
   command: ldconfig
-  when: updated_slurm_ld.changed
+  when: updated_slurm_ld.changed # noqa no-handler
 
 - include: munge.yml
 
@@ -95,7 +95,7 @@
     - slurmdbd
     - slurmd
   when: ansible_distribution == 'Ubuntu'
-  ignore_errors: yes
+  failed_when: false
 
 - name: remove slurm packages
   yum:
@@ -104,12 +104,13 @@
   with_items:
     - slurm
   when: ansible_os_family == 'RedHat'
-  ignore_errors: yes
+  failed_when: false
 
 - name: make build directory
   file:
     path: "{{ slurm_build_dir }}"
     state: directory
+    mode: "0755"
   when: slurm_build
 
 - name: download source
@@ -119,14 +120,14 @@
     dest: "{{ slurm_build_dir }}"
     extra_opts:
       - --strip-components=1
-  environment: "{{proxy_env if proxy_env is defined else {}}}"
+  environment: "{{ proxy_env if proxy_env is defined else {} }}"
   when: slurm_build
 
 - name: uninstall old version
   command: make -j uninstall
   args:
     chdir: "{{ slurm_build_dir }}"
-  ignore_errors: yes
+  failed_when: false
   when: slurm_build
   tags:
     - uninstall
@@ -135,7 +136,7 @@
   command: make distclean
   args:
     chdir: "{{ slurm_build_dir }}"
-  ignore_errors: yes
+  failed_when: false
   when: slurm_build
 
 - name: configure

--- a/roles/slurm/tasks/compute.yml
+++ b/roles/slurm/tasks/compute.yml
@@ -28,6 +28,8 @@
   block:
     - name: update grub
       command: update-grub
+      register: update_grub_cmd
+      changed_when: update_grub_cmd.rc == 0
     - name: reboot after updating grub config
       reboot:
         reboot_timeout: "{{ slurm_node_reboot_timeout }}"
@@ -37,6 +39,8 @@
   block:
     - name: update grub
       command: grub2-mkconfig -o /boot/grub2/grub.cfg
+      register: grub2_mkconfig_cmd
+      changed_when: grub2_mkconfig_cmd.rc == 0
     - name: reboot after updating grub config
       reboot:
         reboot_timeout: "{{ slurm_node_reboot_timeout }}"
@@ -69,6 +73,7 @@
   blockinfile:
     path: "{{ slurm_sysconf_dir }}/slurmd"
     create: yes
+    mode: "0644"
     block: |
       PMIX_MCA_ptl=^usock
       PMIX_MCA_psec=none
@@ -96,6 +101,7 @@
   template:
     src: "{{ slurm_conf_template }}"
     dest: "{{ slurm_config_dir }}/slurm.conf"
+    mode: "0644"
   notify:
   - restart slurmd
   tags:
@@ -105,6 +111,7 @@
   template:
     src: "{{ slurm_cgroup_conf_template }}"
     dest: "{{ slurm_config_dir }}/cgroup.conf"
+    mode: "0644"
   notify:
   - restart slurmd
   tags:
@@ -114,6 +121,7 @@
   template:
     src: "{{ slurm_gres_conf_template }}"
     dest: "{{ slurm_config_dir }}/gres.conf"
+    mode: "0644"
   notify:
   - restart slurmd
   tags:

--- a/roles/slurm/tasks/controller.yml
+++ b/roles/slurm/tasks/controller.yml
@@ -78,12 +78,13 @@
     state: directory
     owner: slurm
     mode: 0755
-  when: "{{ slurm_enable_ha }}"
+  when: slurm_enable_ha
 
 - name: configure slurm.conf
   template:
     src: "{{ slurm_conf_template }}"
     dest: "{{ slurm_config_dir }}/slurm.conf"
+    mode: "0644"
   notify:
   - restart slurmctld
   tags:
@@ -152,7 +153,7 @@
 
 - name: kill slurmctld
   command: killall slurmctld
-  ignore_errors: yes
+  failed_when: false
   when: slurm_downgrade
 
 - name: restart slurmctld

--- a/roles/slurm/tasks/hwloc.yml
+++ b/roles/slurm/tasks/hwloc.yml
@@ -36,7 +36,7 @@
     - libhwloc-dev
     - libhwloc5
   when: ansible_distribution == 'Ubuntu'
-  ignore_errors: yes
+  failed_when: false
 
 - name: remove hwloc packages
   yum:
@@ -47,12 +47,13 @@
     - hwloc-libs
     - hwloc
   when: ansible_os_family == 'RedHat'
-  ignore_errors: yes
+  failed_when: false
 
 - name: make hwloc build directory
   file:
     path: "{{ hwloc_build_dir }}"
     state: directory
+    mode: "0755"
   when: hwloc_build
 
 - name: download hwloc source
@@ -62,14 +63,14 @@
     dest: "{{ hwloc_build_dir }}"
     extra_opts:
       - --strip-components=1
-  environment: "{{proxy_env if proxy_env is defined else {}}}"
+  environment: "{{ proxy_env if proxy_env is defined else {} }}"
   when: hwloc_build
 
 - name: uninstall old hwloc version
   command: make -j uninstall
   args:
     chdir: "{{ hwloc_build_dir }}"
-  ignore_errors: yes
+  failed_when: false
   when: hwloc_build
   tags:
     - uninstall
@@ -78,7 +79,7 @@
   command: make distclean
   args:
     chdir: "{{ hwloc_build_dir }}"
-  ignore_errors: yes
+  failed_when: false
   when: hwloc_build
 
 - name: configure hwloc

--- a/roles/slurm/tasks/login-compute-setup.yml
+++ b/roles/slurm/tasks/login-compute-setup.yml
@@ -2,6 +2,7 @@
 
 - name: Hide GPUs for regular user logins via sshd.service.
   shell: |
+    set -o pipefail
     deviceprop=$(systemctl show sshd.service -p DeviceAllow | grep -i nvidiactl)
 
     if [ -z "$deviceprop" ] ; then

--- a/roles/slurm/tasks/misc-node.yml
+++ b/roles/slurm/tasks/misc-node.yml
@@ -15,6 +15,7 @@
   template:
     src: "{{ slurm_conf_template }}"
     dest: "{{ slurm_config_dir }}/slurm.conf"
+    mode: "0644"
   tags:
   - config
 
@@ -27,4 +28,4 @@
   - slurmctld
   - slurmd
   - slurmdbd
-  ignore_errors: yes
+  failed_when: false

--- a/roles/slurm/tasks/munge.yml
+++ b/roles/slurm/tasks/munge.yml
@@ -22,4 +22,5 @@
     enabled: yes
     state: started
 
-- meta: flush_handlers
+- name: flush handlers to ensure munge gets restarted now
+  meta: flush_handlers

--- a/roles/slurm/tasks/pmix.yml
+++ b/roles/slurm/tasks/pmix.yml
@@ -50,7 +50,7 @@
     - libpmix-dev
     - libpmix5
   when: ansible_distribution == 'Ubuntu'
-  ignore_errors: yes
+  failed_when: false
 
 - name: remove pmix packages
   yum:
@@ -61,12 +61,13 @@
     - pmix-libs
     - pmix
   when: ansible_os_family == 'RedHat'
-  ignore_errors: yes
+  failed_when: false
 
 - name: make pmix build directory
   file:
     path: "{{ pmix_build_dir }}"
     state: directory
+    mode: "0755"
   when: pmix_build
 
 - name: download pmix source
@@ -76,14 +77,14 @@
     dest: "{{ pmix_build_dir }}"
     extra_opts:
       - --strip-components=1
-  environment: "{{proxy_env if proxy_env is defined else {}}}"
+  environment: "{{ proxy_env if proxy_env is defined else {} }}"
   when: pmix_build
 
 - name: uninstall old pmix version
   command: make -j uninstall
   args:
     chdir: "{{ pmix_build_dir }}"
-  ignore_errors: yes
+  failed_when: false
   when: pmix_build
   tags:
     - uninstall
@@ -92,7 +93,7 @@
   command: make distclean
   args:
     chdir: "{{ pmix_build_dir }}"
-  ignore_errors: yes
+  failed_when: false
   when: pmix_build
 
 - name: configure pmix

--- a/roles/slurm/tasks/service-files.yml
+++ b/roles/slurm/tasks/service-files.yml
@@ -4,18 +4,20 @@
     src: "{{ slurm_build_dir }}/etc/{{ item }}"
     dest: "/etc/systemd/system/{{ item }}"
     remote_src: yes
+    mode: "0644"
   with_items:
     - slurmctld.service
     - slurmdbd.service
   when: is_controller
-  ignore_errors: yes
+  failed_when: false
 
 - name: copy service files
   copy:
     src: "{{ slurm_build_dir }}/etc/{{ item }}"
     dest: "/etc/systemd/system/{{ item }}"
     remote_src: yes
+    mode: "0644"
   with_items:
     - slurmd.service
   when: is_compute
-  ignore_errors: yes
+  failed_when: false

--- a/roles/slurm/tasks/setup-role.yml
+++ b/roles/slurm/tasks/setup-role.yml
@@ -21,5 +21,5 @@
   yum:
     name: 
       - "{{ epel_package }}"
-    state: latest
+    state: present
   when: ansible_os_family == "RedHat"

--- a/roles/slurm/tasks/undrain.yml
+++ b/roles/slurm/tasks/undrain.yml
@@ -14,3 +14,4 @@
   tags:
     - never
     - undrain
+  changed_when: false

--- a/scripts/deepops/ansible-lint-roles.sh
+++ b/scripts/deepops/ansible-lint-roles.sh
@@ -12,6 +12,7 @@ fi
 
 # Use a var to set script failure so we check all roles
 CHECK_FAILED=0;
+failedRoles=();
 
 # Lint each role
 cd "${ROOT_DIR}/roles"
@@ -19,10 +20,17 @@ for r in $(find . -maxdepth 1 -mindepth 1 -type d | grep -v galaxy); do
 	echo "==============================================================="
 	echo "Linting ${r}"
 	cd "${r}"
-	if ! ansible-lint ; then
+	if ! ansible-lint --parseable-severity; then
 		CHECK_FAILED=1
+		failedRoles+=("${r}")
 	fi
 	cd "${ROOT_DIR}/roles"
 done
 
+# Print summary of results
+echo
+echo "==============================================================="
+echo "Failed roles:"
+echo "  ${failedRoles[*]}"
+echo "==============================================================="
 exit ${CHECK_FAILED}

--- a/scripts/deepops/ansible-lint-roles.sh
+++ b/scripts/deepops/ansible-lint-roles.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# ansible-lint-roles.sh
+# Runs ansible-lint against each of the subdirectories in roles/
+#
+# Roles can be excluded by setting the ANSIBLE_LINT_EXCLUDE variable to a
+# regex matching the roles to skip
+
 # Determine current directory and root directory
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 ROOT_DIR="${SCRIPT_DIR}/../.."

--- a/scripts/deepops/ansible-lint-roles.sh
+++ b/scripts/deepops/ansible-lint-roles.sh
@@ -35,5 +35,7 @@ echo
 echo "==============================================================="
 echo "Failed roles:"
 echo "  ${failedRoles[*]}"
+echo "Excluded role directories:"
+echo "  $(find . -maxdepth 1 -mindepth 1 -type d | grep -E "${ANSIBLE_LINT_EXCLUDE}|galaxy" | xargs)"
 echo "==============================================================="
 exit ${CHECK_FAILED}

--- a/scripts/deepops/ansible-lint-roles.sh
+++ b/scripts/deepops/ansible-lint-roles.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+# Determine current directory and root directory
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+ROOT_DIR="${SCRIPT_DIR}/../.."
+
+# Check for ansible-lint
+if ! which ansible-lint 2>&1 >/dev/null; then
+	echo "ansible-lint not found in PATH"
+	exit 1
+fi
+
+# Use a var to set script failure so we check all roles
+CHECK_FAILED=0;
+
+# Lint each role
+cd "${ROOT_DIR}/roles"
+for r in $(find . -maxdepth 1 -mindepth 1 -type d | grep -v galaxy); do
+	echo "==============================================================="
+	echo "Linting ${r}"
+	cd "${r}"
+	if ! ansible-lint ; then
+		CHECK_FAILED=1
+	fi
+	cd "${ROOT_DIR}/roles"
+done
+
+exit ${CHECK_FAILED}

--- a/scripts/deepops/ansible-lint-roles.sh
+++ b/scripts/deepops/ansible-lint-roles.sh
@@ -4,6 +4,9 @@
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 ROOT_DIR="${SCRIPT_DIR}/../.."
 
+# Allow optional passing of an exclude regex as an env var
+ANSIBLE_LINT_EXCLUDE="${ANSIBLE_LINT_EXCLUDE:-galaxy}"
+
 # Check for ansible-lint
 if ! which ansible-lint 2>&1 >/dev/null; then
 	echo "ansible-lint not found in PATH"
@@ -16,7 +19,7 @@ failedRoles=();
 
 # Lint each role
 cd "${ROOT_DIR}/roles"
-for r in $(find . -maxdepth 1 -mindepth 1 -type d | grep -v galaxy); do
+for r in $(find . -maxdepth 1 -mindepth 1 -type d | grep -v -E "${ANSIBLE_LINT_EXCLUDE}|galaxy"); do
 	echo "==============================================================="
 	echo "Linting ${r}"
 	cd "${r}"

--- a/scripts/deepops/ansible-lint-roles.sh
+++ b/scripts/deepops/ansible-lint-roles.sh
@@ -8,7 +8,7 @@ ROOT_DIR="${SCRIPT_DIR}/../.."
 ANSIBLE_LINT_EXCLUDE="${ANSIBLE_LINT_EXCLUDE:-galaxy}"
 
 # Check for ansible-lint
-if ! which ansible-lint 2>&1 >/dev/null; then
+if ! command -v ansible-lint >/dev/null 2>&1; then
 	echo "ansible-lint not found in PATH"
 	exit 1
 fi
@@ -18,16 +18,16 @@ CHECK_FAILED=0;
 failedRoles=();
 
 # Lint each role
-cd "${ROOT_DIR}/roles"
+cd "${ROOT_DIR}/roles" || exit 1
 for r in $(find . -maxdepth 1 -mindepth 1 -type d | grep -v -E "${ANSIBLE_LINT_EXCLUDE}|galaxy"); do
 	echo "==============================================================="
 	echo "Linting ${r}"
-	cd "${r}"
+	cd "${r}" || exit 1
 	if ! ansible-lint --parseable-severity; then
 		CHECK_FAILED=1
 		failedRoles+=("${r}")
 	fi
-	cd "${ROOT_DIR}/roles"
+	cd "${ROOT_DIR}/roles" || exit 1
 done
 
 # Print summary of results

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -14,6 +14,8 @@ ROOT_DIR="${SCRIPT_DIR}/.."
 # Configuration
 ANSIBLE_VERSION="${ANSIBLE_VERSION:-2.9.27}"     # Ansible version to install
 ANSIBLE_TOO_NEW="${ANSIBLE_TOO_NEW:-2.10.0}"    # Ansible version too new
+ANSIBLE_LINT_VERSION="${ANSIBLE_LINT_VERSION:-5.4.0}"
+ANSIBLE_LINT_TOO_NEW="${ANSIBLE_LINT_TOO_NEW:-6.0.0}"  # Dropped support for Ansible 2.9.x
 CONFIG_DIR="${CONFIG_DIR:-${ROOT_DIR}/config}"            # Default configuration directory location
 DEEPOPS_TAG="${1:-master}"                      # DeepOps branch to set up
 JINJA2_VERSION="${JINJA2_VERSION:-2.11.1}"      # Jinja2 required version
@@ -109,6 +111,7 @@ if command -v virtualenv &> /dev/null ; then
 
     as_user "${PIP} install -q --upgrade \
         ansible==${ANSIBLE_VERSION} \
+	ansible-lint==${ANSIBLE_LINT_VERSION} \
         Jinja2==${JINJA2_VERSION} \
         netaddr \
         ruamel.yaml \


### PR DESCRIPTION
## Summary

This PR makes the following changes:

- Adds `scripts/deepops/ansible-lint-roles.sh` which runs `ansible-lint` on each role in the `roles/` directory
- Adds a Github action in `.github/workflows/ansible-lint-roles.yml` to run this automatically on pushes and PRs
- Adds documentation on these scripts to `docs/deepops/testing.md`
- Cleans up linting issues in most existing roles so that the script can pass

(This turned out to be less difficult than I thought! Most roles had a small number of issues, or one minor issue repeated many times. A lot of fixes were solvable with a clever regex or three.)

Note: `ansible-lint-roles.sh` includes the option of specifying an environment variable `ANSIBLE_LINT_EXCLUDE`, that will be used as a regex to skip linting some roles. This is currently used in the Github action to skip linting `nvidia-dgx`, `nvidia-dgx-firmware`, and `nvidia-gpu-tests`. The first role is pending major changes in #1117. The other two are complex enough, and difficult enough to test, that they should get extra testing when making the changes needed for linting to pass.

## Test plan

- [x] All roles should pass `ansible-lint`, unless specifically excluded
- [x] All existing Ansible Molecule tests should pass
- [x] All existing end-to-end Jenkins tests should pass