### PR TITLE
Bump GPU Operator version and related packages to 1.10.0

### DIFF
--- a/roles/nvidia-gpu-operator/defaults/main.yml
+++ b/roles/nvidia-gpu-operator/defaults/main.yml
@@ -12,7 +12,7 @@ gpu_operator_nvaie_helm_repo: "https://helm.ngc.nvidia.com/nvaie"
 gpu_operator_nvaie_chart_name: "nvaie/gpu-operator"
 
 # NVAIE GPU Operator may require different version, check NGC enterprise collection.
-gpu_operator_chart_version: "1.9.1"
+gpu_operator_chart_version: "1.10.0"
 
 k8s_gpu_mig_strategy: "mixed"
 
@@ -34,7 +34,7 @@ gpu_operator_grid_config_dir: "{{ deepops_dir }}/gpu_operator"
 
 # Defaults from https://github.com/NVIDIA/gpu-operator/blob/master/deployments/gpu-operator/values.yaml
 gpu_operator_driver_registry: "nvcr.io/nvidia"
-gpu_operator_driver_version: "470.82.01"
+gpu_operator_driver_version: "510.47.03"
 
 # This enables/disables NVAIE
 gpu_operator_nvaie_enable: false

--- a/roles/nvidia-k8s-gpu-device-plugin/defaults/main.yml
+++ b/roles/nvidia-k8s-gpu-device-plugin/defaults/main.yml
@@ -2,6 +2,6 @@
 k8s_gpu_plugin_helm_repo: "https://nvidia.github.io/k8s-device-plugin"
 k8s_gpu_plugin_chart_name: "nvdp/nvidia-device-plugin"
 k8s_gpu_plugin_release_name: "nvidia-device-plugin"
-k8s_gpu_plugin_chart_version: "0.10.0"
+k8s_gpu_plugin_chart_version: "0.11.0"
 k8s_gpu_plugin_init_error: "false"
 k8s_gpu_mig_strategy: "mixed"

--- a/roles/nvidia-k8s-gpu-feature-discovery/defaults/main.yml
+++ b/roles/nvidia-k8s-gpu-feature-discovery/defaults/main.yml
@@ -2,5 +2,5 @@
 k8s_gpu_feature_discovery_helm_repo: "https://nvidia.github.io/gpu-feature-discovery"
 k8s_gpu_feature_discovery_chart_name: "nvgfd/gpu-feature-discovery"
 k8s_gpu_feature_discovery_release_name: "gpu-feature-discovery"
-k8s_gpu_feature_discovery_chart_version: "0.4.1"
+k8s_gpu_feature_discovery_chart_version: "0.5.0"
 k8s_gpu_mig_strategy: "mixed"


### PR DESCRIPTION
* Bump GPU Operator 1.9.1 -> 1.10.0
* Bump GPU Feature Discovery 1.4.1->1.5.0
* Bump GPU Device Plugin 0.10.0->0.11.0