### PR TITLE
Fix multi-node K8s deployment script

### DIFF
--- a/scripts/k8s/deploy_monitoring.sh
+++ b/scripts/k8s/deploy_monitoring.sh
@@ -276,8 +276,8 @@ install_dependencies
 setup_prom_monitoring
 
 # Install DCGM-Exporter and setup custom metrics, if needed
-# # GPU Device Plugin is installed into kube-system, GPU Operator installs it into gpu-operator-resources
-plugin_namespace=$( kubectl get pods -A -l app.kubernetes.io/instance=nvidia-device-plugin  --no-headers   --no-headers -o custom-columns=NAMESPACE:.metadata.namespace)
+# # GPU Device Plugin is installed into kube-system, GPU Operator installs it into gpu-operator-resources, use uniq for HA K8s clusters
+plugin_namespace=$( kubectl get pods -A -l app.kubernetes.io/instance=nvidia-device-plugin  --no-headers   --no-headers -o custom-columns=NAMESPACE:.metadata.namespace | uniq)
 if [ "${plugin_namespace}" == "kube-system" ] ; then
     # No GPU Operator DCGM-Exporter Stack
     setup_gpu_monitoring

--- a/workloads/jenkins/scripts/test-monitoring.sh
+++ b/workloads/jenkins/scripts/test-monitoring.sh
@@ -33,6 +33,7 @@ if [ "${pass}" != "true" ]; then
   curl -s --raw -L "${alertmanager_url}"
   exit 1
 fi
+pass=""
 set -e # The loop is done, and we got debug if it failed, re-enable fail on error
 
 # Validate DCGM metrics are in Prometheus
@@ -52,6 +53,7 @@ if [ "${pass}" != "true" ]; then
   curl -L "${prometheus_url}/api/v1/label/__name__/values" # Print output for debug
   exit 1
 fi
+pass=""
 set -e # The loop is done, and we got debug if it failed, re-enable fail on error
 
 
@@ -96,6 +98,7 @@ if [ "${pass}" != "true" ]; then
   curl -s --raw -L "${alertmanager_url}"
   exit 1
 fi
+pass=""
 set -e # The loop is done, and we got debug if it failed, re-enable fail on error
 
 # Validate DCGM metrics are in Prometheus
@@ -115,6 +118,7 @@ if [ "${pass}" != "true" ]; then
   curl -L "${prometheus_url}/api/v1/label/__name__/values" # Print output for debug
   exit 1
 fi
+pass=""
 set -e # The loop is done, and we got debug if it failed, re-enable fail on error
 
 # Get some debug for Pods that did/didn't come up and verify DCGM metrics


### PR DESCRIPTION
In the recent upgrade to support GPU Operator end-to-end I introduced a bug in the HA K8s deployments. This resulted in DCGM-exporter not being deployed.

This PR simply fixes that script bug and also causes the test-monitoring.sh script to fail a bit faster when an error does occur.
