### PR TITLE
Fix GPU Operator runtime configuration

### DIFF
--- a/roles/nvidia-gpu-operator/tasks/k8s.yml
+++ b/roles/nvidia-gpu-operator/tasks/k8s.yml
@@ -16,5 +16,5 @@
   changed_when: false
 
 - name: install nvidia gpu operator
-  command: /usr/local/bin/helm upgrade --install "{{ gpu_operator_release_name }}" "{{ gpu_operator_chart_name }}" --version "{{ gpu_operator_chart_version }}" --create-namespace --namespace {{ gpu_operator_namespace }} --set driver.version="{{ gpu_operator_driver_version }}" --set mig.strategy="{{ k8s_gpu_mig_strategy |lower }}" --set driver.enabled="{{ gpu_operator_enable_driver |lower }}" --set toolkit.enabled="{{ gpu_operator_enable_toolkit |lower }}" --set dcgm.enabled="{{ gpu_operator_enable_dcgm |lower }}" --set migManager.enabled="{{ gpu_operator_enable_migmanager |lower }}" --set operator.defaultRuntime="{{ gpu_operator_default_runtime }}" --wait
+  command: /usr/local/bin/helm upgrade --install "{{ gpu_operator_release_name }}" "{{ gpu_operator_chart_name }}" --version "{{ gpu_operator_chart_version }}" --create-namespace --namespace {{ gpu_operator_namespace }} --set driver.version="{{ gpu_operator_driver_version }}" --set mig.strategy="{{ k8s_gpu_mig_strategy |lower }}" --set driver.enabled="{{ gpu_operator_enable_driver |lower }}" --set toolkit.enabled="{{ gpu_operator_enable_toolkit |lower }}" --set dcgm.enabled="{{ gpu_operator_enable_dcgm |lower }}" --set migManager.enabled="{{ gpu_operator_enable_migmanager |lower }}" --wait
   changed_when: false

--- a/roles/nvidia-gpu-operator/tasks/k8s.yml
+++ b/roles/nvidia-gpu-operator/tasks/k8s.yml
@@ -16,5 +16,5 @@
   changed_when: false
 
 - name: install nvidia gpu operator
-  command: /usr/local/bin/helm upgrade --install "{{ gpu_operator_release_name }}" "{{ gpu_operator_chart_name }}" --version "{{ gpu_operator_chart_version }}" --create-namespace --namespace {{ gpu_operator_namespace }} --set driver.version="{{ gpu_operator_driver_version }}" --set mig.strategy="{{ k8s_gpu_mig_strategy |lower }}" --set driver.enabled="{{ gpu_operator_enable_driver |lower }}" --set toolkit.enabled="{{ gpu_operator_enable_toolkit |lower }}" --set dcgm.enabled="{{ gpu_operator_enable_dcgm |lower }}" --set migManager.enabled="{{ gpu_operator_enable_migmanager |lower }}" --wait
+  command: /usr/local/bin/helm upgrade --install "{{ gpu_operator_release_name }}" "{{ gpu_operator_chart_name }}" --version "{{ gpu_operator_chart_version }}" --create-namespace --namespace {{ gpu_operator_namespace }} --set driver.version="{{ gpu_operator_driver_version }}" --set mig.strategy="{{ k8s_gpu_mig_strategy |lower }}" --set driver.enabled="{{ gpu_operator_enable_driver |lower }}" --set toolkit.enabled="{{ gpu_operator_enable_toolkit |lower }}" --set dcgm.enabled="{{ gpu_operator_enable_dcgm |lower }}" --set migManager.enabled="{{ gpu_operator_enable_migmanager |lower }}" --set operator.defaultRuntime="{{ gpu_operator_default_runtime }}" --wait
   changed_when: false

--- a/roles/nvidia-gpu-operator/tasks/main.yml
+++ b/roles/nvidia-gpu-operator/tasks/main.yml
@@ -2,7 +2,7 @@
 - name: Set GPU Operator flags for systems with preinstalled NVIDIA software (DGX, etc).
   set_fact:
     gpu_operator_enable_driver: false
-    gpu_operator_enable_toolkit: false
+    gpu_operator_enable_toolkit: true
   when: gpu_operator_preinstalled_nvidia_software
 
 - include: k8s.yml


### PR DESCRIPTION
Fixes the previous commit where we now default to containerd, the defaults needed to be changed to allow configuring the runtime to use the nvidia toolkit.