### PR TITLE
Misc fixes for Jenkins CI

### DIFF
--- a/config.example/group_vars/k8s-cluster.yml
+++ b/config.example/group_vars/k8s-cluster.yml
@@ -69,6 +69,15 @@ docker_insecure_registries: "{{ groups['kube-master']|map('regex_replace', '^(.*
 crio_insecure_registries: "{{ groups['kube-master']|map('regex_replace', '^(.*)$', '\\1:5000')|list + ['registry.local:31500']}}"
 docker_registry_mirrors: "{{ groups['kube-master'] | map('regex_replace', '^(.*)$', 'http://\\1:5000') | list }}"
 
+# TODO: Add support in containerd for automatically setting up registry
+# mirrors, not just the k8s-local registry
+containerd_insecure_registries:
+  "registry.local:31500": "http://registry.local:31500"
+
+# Work-around for https://github.com/kubernetes-sigs/kubespray/issues/8529
+nerdctl_extra_flags: " --insecure-registry"
+image_command_tool: "crictl"
+
 ################################################################################
 # Logging with rsyslog                                                         #
 ################################################################################

--- a/roles/k8s-internal-container-registry/defaults/main.yml
+++ b/roles/k8s-internal-container-registry/defaults/main.yml
@@ -1,8 +1,8 @@
 ---
 helm_cmd: "/usr/local/bin/helm"
 
-container_registry_chart_location: "https://charts.helm.sh/stable"
-container_registry_repo_name: "stable"
+container_registry_chart_location: "https://helm.twun.io"
+container_registry_repo_name: "twuni"
 container_registry_chart_name: "{{ container_registry_repo_name }}/docker-registry"
 container_registry_installed_name: "docker-registry"
 
@@ -10,7 +10,7 @@ container_registry_values_template: "values.yaml"
 container_registry_values_path: "/tmp/container-registry.yaml"
 
 container_registry_namespace: "deepops-docker"
-container_registry_version: 1.9.4
+container_registry_version: "2.1.0"
 container_registry_hostname: registry.local
 container_registry_ingress_enabled: false
 container_registry_ingress_size: 4096m

--- a/roles/k8s-internal-container-registry/templates/values.yaml
+++ b/roles/k8s-internal-container-registry/templates/values.yaml
@@ -13,8 +13,8 @@ ingress:
   enabled: "{{ container_registry_ingress_enabled }}"
   hosts:
   - "{{ container_registry_hostname }}"
+  className: "nginx"
   annotations:
-    kubernetes.io/ingress.class: "nginx"
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
     nginx.ingress.kubernetes.io/rewrite-target: /
     nginx.ingress.kubernetes.io/proxy-body-size: "{{ container_registry_ingress_size }}"

--- a/scripts/k8s/deploy_monitoring.sh
+++ b/scripts/k8s/deploy_monitoring.sh
@@ -24,7 +24,7 @@ if [ ! -d "${DEEPOPS_CONFIG_DIR}" ]; then
 fi
 
 HELM_CHARTS_REPO_PROMETHEUS="${HELM_CHARTS_REPO_PROMETHEUS:-https://prometheus-community.github.io/helm-charts}"
-HELM_PROMETHEUS_CHART_VERSION="${HELM_PROMETHEUS_CHART_VERSION:-15.2.0}"
+HELM_PROMETHEUS_CHART_VERSION="${HELM_PROMETHEUS_CHART_VERSION:-34.5.0}"
 ingress_name="ingress-nginx"
 
 PROMETHEUS_YAML_CONFIG="${PROMETHEUS_YAML_CONFIG:-${DEEPOPS_CONFIG_DIR}/helm/monitoring.yml}"
@@ -152,6 +152,7 @@ function setup_prom_monitoring() {
             --set alertmanager.ingress.hosts[0]="alertmanager-${ingress_ip_string}" \
             --set prometheus.ingress.hosts[0]="prometheus-${ingress_ip_string}" \
             --set grafana.ingress.hosts[0]="grafana-${ingress_ip_string}" \
+	    --timeout 1200s \
             ${helm_prom_oper_args} \
             ${helm_kube_prom_args}
     fi

--- a/workloads/jenkins/Jenkinsfile
+++ b/workloads/jenkins/Jenkinsfile
@@ -122,11 +122,6 @@ pipeline {
           sh '''
             timeout 60 bash -x ./workloads/jenkins/scripts/test-slurm-gpu.sh
           '''
-
-          echo "Test DCGM metrics"
-          sh '''
-            timeout 500 bash -x ./workloads/jenkins/scripts/test-dcgm-metrics.sh slurm-node
-          '''
         }
       }
     }

--- a/workloads/jenkins/scripts/files/nginx-from-local-registry.yml
+++ b/workloads/jenkins/scripts/files/nginx-from-local-registry.yml
@@ -5,6 +5,6 @@ metadata:
 spec:
   containers:
   - name: nginx
-    image: registry.local:31500/nginx
+    image: registry.local:31500/nginx:1.21
   hostNetwork: true
   dnsPolicy: Default

--- a/workloads/jenkins/scripts/remote-script-for-registry-test.sh
+++ b/workloads/jenkins/scripts/remote-script-for-registry-test.sh
@@ -3,10 +3,10 @@
 set -ex
 
 # Pull nginx container locally
-sudo docker pull nginx:latest
+sudo ctr images pull --all-platforms docker.io/library/nginx:1.21
 
 # Tag docker container for local cluster registry
-sudo docker tag nginx registry.local:31500/nginx
+sudo ctr images tag docker.io/library/nginx:1.21 registry.local:31500/nginx:1.21
 
 # Push to the local registry
-sudo docker push registry.local:31500/nginx 
+sudo ctr images push --plain-http registry.local:31500/nginx:1.21

--- a/workloads/jenkins/scripts/test-monitoring.sh
+++ b/workloads/jenkins/scripts/test-monitoring.sh
@@ -123,7 +123,15 @@ set -e # The loop is done, and we got debug if it failed, re-enable fail on erro
 
 # Get some debug for Pods that did/didn't come up and verify DCGM metrics
 kubectl get all -n monitoring
-bash -x ./workloads/jenkins/scripts/test-dcgm-metrics.sh slurm-node # We use slurm-node here because it is GPU only, kube-node includes the mgmt plane
+
+# Check for dcgm-exporter pods that are not running
+if kubectl get pods -n gpu-operator-resources -l app=nvidia-dcgm-exporter | grep nvidia-dcgm-exporter | grep -v Running; then
+  echo "Some nvidia-dcgm-exporter pods are not in state Running"
+  exit 1
+fi
+
+# Commented out test-dcgm-metrics test, as with gpu-operator we no longer expose port 9400 directly on the nodes
+#bash -x ./workloads/jenkins/scripts/test-dcgm-metrics.sh slurm-node # We use slurm-node here because it is GPU only, kube-node includes the mgmt plane
 
 # Delete Monitoring
 ./scripts/k8s/deploy_monitoring.sh -d


### PR DESCRIPTION
## Summary

Following the merge of #1043 to update our Kubespray version and migrate to containerd, we're seeing some failures in Jenkins CI.

This PR is intended to let me work through these failures until we get a successful build. 😄 

Changes include:

- https://github.com/NVIDIA/deepops/commit/a7c89bfe6de16367e8af5ea5a321aeeb9bba671b: Update to maintained version of docker-registry chart
- https://github.com/NVIDIA/deepops/pull/1141/commits/e271f74c0700b1eb0581137ac30a7a23e9ba0300: Fixes for local registry test in Kubernetes with use of containerd
- https://github.com/NVIDIA/deepops/pull/1141/commits/5e7c681c2b8910e8a5133b10d3abee300539dcdd: Fixes to monitoring tests to update stack to one that works with later Kubernetes, and account for use of GPU operator

## Test plan

All CI tests should pass