### PR TITLE
Update role nvidia.nvidia_driver to v2.1.0

### DIFF
--- a/roles/requirements.yml
+++ b/roles/requirements.yml
@@ -27,7 +27,7 @@ roles:
   version: "v5.2.6"
 
 - src: nvidia.nvidia_driver
-  version: "v2.0.2"
+  version: "v2.1.0"
 
 - src: nvidia.nvidia_docker
   version: "v1.2.4"


### PR DESCRIPTION
See [release notes for v2.1.0](https://github.com/NVIDIA/ansible-role-nvidia-driver/releases/tag/v2.1.0)

- Update metadata to include support for EL8
- Make optional the addition of yum/apt repos
- Explicitly blacklist nouveau when installing from CUDA repos
- Explicitly add support for CentOS/RHEL8 to README
- Align default driver branch across all installs and update to r470
- Add Molecule CI test for nvidia driver role