### PR TITLE
Fix linting errors in network operator role

### DIFF
--- a/roles/nvidia-network-operator/tasks/main.yaml
+++ b/roles/nvidia-network-operator/tasks/main.yaml
@@ -2,18 +2,20 @@
 # Deploy network operator related tasks on master node
 #
 
-- name: label the nodes
+- name: label the nodes  # noqa command-instead-of-shell
   shell: kubectl label --overwrite nodes {{ item }} node-role.kubernetes.io/worker=
-  with_items: "{{ groups['kube-node']}}"
+  with_items: "{{ groups['kube-node'] }}"
+  changed_when: false
 
 ## required as the DeepOps openshift role doesn't work
-- name: Install openshift
+- name: Install openshift  # noqa command-instead-of-shell
   shell: pip3 install openshift
+  changed_when: false
 
 - name: Add helm repo for network operator
   kubernetes.core.helm_repository:
     name: mellanox
-    repo_url: "{{nvidia_network_operator_url}}"
+    repo_url: "{{ nvidia_network_operator_url }}"
 
 - name: Deploy network operator helm chart
   kubernetes.core.helm:
@@ -34,8 +36,8 @@
   include_tasks: sriovibnetwork.yaml
   with_items: "{{ intf_resources }}"
 
-- name: Install latest Kubeflow MPI-Operator 
+- name: Install latest Kubeflow MPI-Operator
   k8s:
     state: present
-    definition: "{{ lookup('url', '{{mpi_raw_url}}/mpi-operator.yaml', split_lines=False) }}"
+    definition: "{{ lookup('url', '{{ mpi_raw_url }}/mpi-operator.yaml', split_lines=False) }}"
   run_once: true

--- a/roles/nvidia-network-operator/tasks/sriovibnetwork.yaml
+++ b/roles/nvidia-network-operator/tasks/sriovibnetwork.yaml
@@ -11,7 +11,7 @@
         {
           "type": "whereabouts",
           "datastore": "kubernetes",
-          "kubernetes": { 
+          "kubernetes": {
             "kubeconfig": "/etc/cni/net.d/whereabouts.d/whereabouts.kubeconfig"
            },
           "range": "{{ item.ip_addr }}",

--- a/roles/nvidia-network-operator/vars/main.yaml
+++ b/roles/nvidia-network-operator/vars/main.yaml
@@ -2,7 +2,7 @@
 #
 # variables for VFs, resource names,interface names and software versions.
 # pf_name is the physical interface with sriov enabled
-# res_name must match container's network resources in job file 
+# res_name must match container's network resources in job file
 # if_name must match k8s network annotation name
 #
 


### PR DESCRIPTION
A few lint errors cropped up in the network operator role. This PR just fixes those because I like seeing green tests. 😄 

This is mostly spacing fixes, with a couple of explicit instructions to the linter to ignore certain tests.

Test plan: verify the lint check passes in CI