### PR TITLE
Fix Ansible Galaxy dependencies to address Molecule test failures

### DIFF
--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -37,7 +37,8 @@ jobs:
       - name: install dependencies
         run: |
           python3 -m pip install --upgrade pip
-          python3 -m pip install molecule[docker] docker ansible
+          python3 -m pip install ansible==2.9.27
+          python3 -m pip install molecule[docker] docker
       - name: run molecule test
         run: |
           cd "${{ github.repository }}/roles"

--- a/roles/requirements.yml
+++ b/roles/requirements.yml
@@ -7,6 +7,9 @@ collections:
 - name: community.general
   version: 4.7.0
 
+- name: community.docker
+  version: 2.3.0
+
 roles:
 
 - src: dev-sec.ssh-hardening

--- a/roles/requirements.yml
+++ b/roles/requirements.yml
@@ -5,7 +5,7 @@ collections:
   version: 1.1.1
 
 - name: community.general
-  version: 3.0.0
+  version: 4.7.0
 
 roles:
 


### PR DESCRIPTION
## Summary

* Update `community.general` to 4.7.0
* Pin Ansible to 2.9.27 in Molecule tests
* Add explicit dependency on `community.docker`

## Context

[Starting about a week ago](https://github.com/NVIDIA/deepops/actions/runs/2103470398), our Molecule tests started failing due to issues installing the `community.general` collection from Ansible Galaxy:

```
Downloading https://galaxy.ansible.com/download/community-general-3.0.0.tar.gz to /home/runner/.ansible/tmp/ansible-local-2080w4oiblig/tmp44egidyw/community-general-3.0.0-hz736f[97](https://github.com/NVIDIA/deepops/runs/5853868950?check_suite_focus=true#step:5:97)
Installing 'community.general:3.0.0' to '/home/runner/.ansible/collections/ansible_collections/community/general'
ERROR! Unable to extract 'tests/integration/targets/django_manage/files/base_test/1045-single-app-project/single_app_project/core/' from collection
```

It *seems* like something changed upstream which may be causing this, despite our version pinning.

It's not clear to me why this would be going on... but in any case, our version of `community.general` is pretty old anyway. We're on 3.0.0, and the most recent version is 4.7.0. This collection [still maintains compatibility with Ansible 2.9](https://github.com/ansible-collections/community.general/blob/caedcc3075c013a358c70db5c9860536abcf00e1/README.md?plain=1#L20) so we should be good to upgrade.

The remaining changes (pinning our Ansible version and making our `community.docker` dependency explicit) are rolled in to try and help keep these tests more stable.

## Test plan

All of linting, Molecule tests, and Jenkins tests should pass.