### PR TITLE
Update to nvidia.nvidia_driver role v2.2.0

### DIFF
--- a/roles/requirements.yml
+++ b/roles/requirements.yml
@@ -27,7 +27,7 @@ roles:
   version: "v5.2.6"
 
 - src: nvidia.nvidia_driver
-  version: "v2.1.0"
+  version: "v2.2.0"
 
 - src: nvidia.nvidia_docker
   version: "v1.2.4"


### PR DESCRIPTION
Updates to use R510 driver by default.

## Test plan

* Passing Jenkins tests