### PR TITLE
Check for SELinux disabled in Ansible tasks

### DIFF
--- a/roles/nvidia-dgx/tasks/configure-raid.yml
+++ b/roles/nvidia-dgx/tasks/configure-raid.yml
@@ -14,5 +14,7 @@
 
 - name: Restore SELinux label on RAID array
   command: restorecon /raid
-  when: ansible_os_family == 'RedHat'
+  when:
+  - ansible_os_family == 'RedHat'
+  - (ansible_selinux is defined) and (ansible_selinux.status != "disabled")
   notify: restart cachefilesd

--- a/roles/slurm/tasks/controller.yml
+++ b/roles/slurm/tasks/controller.yml
@@ -39,11 +39,15 @@
     target: '/lib64(/.*)?'
     setype: mysqld_db_t
     state: present
-  when: ansible_os_family == "RedHat"
+  when: 
+  - ansible_os_family == "RedHat"
+  - (ansible_selinux is defined) and (ansible_selinux.status != "disabled")
 
 - name: Apply new SELinux file context to filesystem
   command: restorecon -irv /lib64
-  when: ansible_os_family == "RedHat"
+  when: 
+  - ansible_os_family == "RedHat"
+  - (ansible_selinux is defined) and (ansible_selinux.status != "disabled")
 
 - name: start mariadb
   systemd:


### PR DESCRIPTION
## Summary

In tasks that interact with SELinux, add a check so we skip the task if SELinux is fully disabled (rather than just in permissive mode). Closes #1159.

## Test plan

### Before

Turned up a virtual Slurm cluster with two CentOS controller nodes, so that we hit the following task:

```
- name: Allow mysql to read libaio.so.1
  sefcontext:
    target: '/lib64(/.*)?'
    setype: mysqld_db_t
    state: present
```

One controller node was configured with SELinux in permissive mode, the second with SELinux disabled.

On the node with SELinux in permissive mode, the task executes successfully, but on the node with SELinux disabled, it fails with the error:

```
fatal: [virtual-mgmt01]: FAILED! => {"changed": false, "msg": "SELinux is disabled on this host."}
```

### After

After making these changes, the relevant tasks execute successfully.

### Other tests

All existing CI tests should pass.
