### PR TITLE
git.io is being deprecated, fix shortlinks

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -4,8 +4,8 @@
 #   This script installs required dependencies on a system so it can run Ansible
 #   and initializes the DeepOps directory
 #
-# Can be run standalone with: curl -sL git.io/deepops | bash
-#                         or: curl -sL git.io/deepops | bash -s -- 19.07
+# Can be run standalone with: curl -sL bit.ly/nvdeepops | bash
+#                         or: curl -sL bit.ly/nvdeepops | bash -s -- 19.07
 
 # Determine current directory and root directory
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"

--- a/src/containers/pxe/docker-compose.yml
+++ b/src/containers/pxe/docker-compose.yml
@@ -24,5 +24,5 @@ services:
     "http://archive.ubuntu.com/ubuntu/dists/bionic-updates/main/installer-amd64/current/images/netboot/ubuntu-installer/amd64/linux",
   "http://archive.ubuntu.com/ubuntu/dists/bionic-updates/main/installer-amd64/current/images/netboot/ubuntu-installer/amd64/initrd.gz",
               "--cmdline",
-"auto=true priority=critical preseed/url=http://git.io/deepseed",
+              "auto=true priority=critical preseed/url=https://bit.ly/nvdeepseed",
               "--dhcp-no-bind"]


### PR DESCRIPTION
Github is deprecating git.io on April 29, 2022:
https://github.blog/changelog/2022-04-25-git-io-deprecation/

Change our shortlinks not to use this url shortener