### PR TITLE
Update Ansible to match Kubespray supported versions

### DIFF
--- a/.github/workflows/ansible-lint-roles.yml
+++ b/.github/workflows/ansible-lint-roles.yml
@@ -21,7 +21,7 @@ jobs:
       - name: install dependencies
         run: |
           python3 -m pip install --upgrade pip
-          python3 -m pip install ansible-lint==5.4.0 ansible==2.9.27
+          python3 -m pip install ansible-lint==5.4.0 ansible==4.8.0
 
       - name: run lint script
         env:

--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -37,7 +37,7 @@ jobs:
       - name: install dependencies
         run: |
           python3 -m pip install --upgrade pip
-          python3 -m pip install ansible==2.9.27
+          python3 -m pip install ansible==4.8.0
           python3 -m pip install molecule[docker] docker
       - name: run molecule test
         run: |

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -12,13 +12,13 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 ROOT_DIR="${SCRIPT_DIR}/.."
 
 # Configuration
-ANSIBLE_VERSION="${ANSIBLE_VERSION:-2.9.27}"     # Ansible version to install
-ANSIBLE_TOO_NEW="${ANSIBLE_TOO_NEW:-2.10.0}"    # Ansible version too new
+ANSIBLE_VERSION="${ANSIBLE_VERSION:-4.8.0}"     # Ansible version to install
+ANSIBLE_TOO_NEW="${ANSIBLE_TOO_NEW:-5.0.0}"    # Ansible version too new
 ANSIBLE_LINT_VERSION="${ANSIBLE_LINT_VERSION:-5.4.0}"
-ANSIBLE_LINT_TOO_NEW="${ANSIBLE_LINT_TOO_NEW:-6.0.0}"  # Dropped support for Ansible 2.9.x
 CONFIG_DIR="${CONFIG_DIR:-${ROOT_DIR}/config}"            # Default configuration directory location
 DEEPOPS_TAG="${1:-master}"                      # DeepOps branch to set up
-JINJA2_VERSION="${JINJA2_VERSION:-2.11.1}"      # Jinja2 required version
+JINJA2_VERSION="${JINJA2_VERSION:-2.11.3}"      # Jinja2 required version
+MARKUPSAFE_VERSION="${MARKUPSAFE_VERSION:-1.1.1}"  # MarkupSafe version
 PIP="${PIP:-pip3}"                              # Pip binary to use
 PYTHON_BIN="${PYTHON_BIN:-/usr/bin/python3}"    # Python3 path
 VENV_DIR="${VENV_DIR:-/opt/deepops/env}"        # Path to python virtual environment to create
@@ -117,7 +117,7 @@ if command -v virtualenv &> /dev/null ; then
         ruamel.yaml \
         PyMySQL \
         paramiko \
-        MarkupSafe==2.0.1
+        MarkupSafe==${MARKUPSAFE_VERSION} \
         selinux"
 else
     echo "ERROR: Unable to create Python virtual environment, 'virtualenv' command not found"


### PR DESCRIPTION
## Summary

We had locked Ansible to version 2.9.27 due to Kubespray staying on 2.9.x. Kubespray is now supporting later versions of Ansible, so let's update to match.

## Test plan

Passing CI tests.