### PR TITLE
Fix GPG key import for a large set of DeepOps roles

### DIFF
--- a/roles/lmod/defaults/main.yml
+++ b/roles/lmod/defaults/main.yml
@@ -6,4 +6,4 @@ sm_module_path: "{{ sm_module_root }}/all"
 sm_software_path: "{{ sm_prefix }}/software"
 
 epel_package: "https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm"
-epel_key_url: "https://getfedora.org/static/fedora.gpg"
+epel_key_url: "https://download.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-{{ ansible_distribution_major_version }}"

--- a/roles/nvidia-dgx/defaults/main.yml
+++ b/roles/nvidia-dgx/defaults/main.yml
@@ -1,7 +1,7 @@
 nvidia_dgx_rhel_baseurl: "https://international.download.nvidia.com/dgx/repos/{{ dgx_repo_dir }}/"
 nvidia_dgx_rhel_gpgkey: "https://international.download.nvidia.com/dgx/repos/RPM-GPG-KEY-dgx-cosmos-support"
 epel_package: "https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm"
-epel_key_url: "https://getfedora.org/static/fedora.gpg"
+epel_key_url: "https://download.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-{{ ansible_distribution_major_version }}"
 
 nvidia_dgx_ubuntu_baseurl: "http://international.download.nvidia.com/dgx/repos"
 nvidia_dgx_ubuntu_gpgkey: "https://international.download.nvidia.com/dgx/repos/bionic/pool/multiverse/d/dgx-repo-keys/dgx-repo-keys_2.0_amd64.deb"

--- a/roles/nvidia_cuda/defaults/main.yml
+++ b/roles/nvidia_cuda/defaults/main.yml
@@ -19,7 +19,7 @@ cuda_toolkit_add_profile_script: yes
 
 # RedHat family
 epel_package: "https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm"
-epel_key_url: "https://getfedora.org/static/fedora.gpg"
+epel_key_url: "https://download.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-{{ ansible_distribution_major_version }}"
 nvidia_driver_rhel_cuda_repo_baseurl: "https://developer.download.nvidia.com/compute/cuda/repos/{{ _rhel_repo_dir }}/"
 nvidia_driver_rhel_cuda_repo_gpgkey: "https://developer.download.nvidia.com/compute/cuda/repos/{{ _rhel_repo_dir }}/D42D0685.pub"
 

--- a/roles/nvidia_dcgm/defaults/main.yml
+++ b/roles/nvidia_dcgm/defaults/main.yml
@@ -3,7 +3,7 @@ dcgm_pkg_name: "datacenter-gpu-manager"
 
 # RedHat family
 epel_package: "https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm"
-epel_key_url: "https://getfedora.org/static/fedora.gpg"
+epel_key_url: "https://download.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-{{ ansible_distribution_major_version }}"
 nvidia_driver_rhel_cuda_repo_baseurl: "https://developer.download.nvidia.com/compute/cuda/repos/{{ _rhel_repo_dir }}/"
 nvidia_driver_rhel_cuda_repo_gpgkey: "https://developer.download.nvidia.com/compute/cuda/repos/{{ _rhel_repo_dir }}/D42D0685.pub"
 

--- a/roles/openshift/defaults/main.yml
+++ b/roles/openshift/defaults/main.yml
@@ -1,4 +1,4 @@
 deepops_dir: /opt/deepops
 deepops_venv: '{{ deepops_dir }}/venv'
 epel_package: "https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm"
-epel_key_url: "https://getfedora.org/static/fedora.gpg"
+epel_key_url: "https://download.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-{{ ansible_distribution_major_version }}"

--- a/roles/slurm/defaults/main.yml
+++ b/roles/slurm/defaults/main.yml
@@ -1,5 +1,5 @@
 epel_package: "https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm"
-epel_key_url: "https://getfedora.org/static/fedora.gpg"
+epel_key_url: "https://download.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-{{ ansible_distribution_major_version }}"
 
 deepops_dir: /opt/deepops
 slurm_build_dir: /opt/deepops/build/slurm

--- a/roles/standalone-container-registry/defaults/main.yml
+++ b/roles/standalone-container-registry/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 epel_package: "https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm"
-epel_key_url: "https://getfedora.org/static/fedora.gpg"
+epel_key_url: "https://download.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-{{ ansible_distribution_major_version }}"
 
 standalone_container_registry_image: "registry:2.7"
 standalone_container_registry_port: "5000"


### PR DESCRIPTION
## Summary

Previously, many DeepOps roles were importing the full Fedora GPG keychain from `https://getfedora.org/static/fedora.gpg`. At some point in the past several days, this started failing with errors that look like this:

```
2022-06-16T16:15:03.7136338Z fatal: [dcgm-centos-7]: FAILED! => {"changed": false, "msg": "Not a public key: https://getfedora.org/static/fedora.gpg"}
```

Unfortunately, it's difficult to tell what may have changed with the upstream URL.

Because we're just interested in EPEL anyway, this PR changes the URL import to the EPEL-specific key for the distro in question, i.e. `https://download.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-{{ ansible_distribution_major_version }}`.

## Test plan

All Molecule tests should pass following this change. (Jenkins CI is still broken 😢 for other reasons around a Helm chart.)