### PR TITLE
Fix bugs preventing slurm reinstall or rebuild

### DIFF
--- a/roles/slurm/tasks/build.yml
+++ b/roles/slurm/tasks/build.yml
@@ -110,6 +110,13 @@
   when: slurm_build
   block:
 
+    # This service should be stopped before uninstalling slurm
+  - name: stop docker slurm exporter service to prevent subfolder creation
+    service:
+      name: "docker.slurm-exporter.service"
+      state: stopped
+    when: slurm_build and (ansible_distribution == 'Ubuntu') and ("{{ansible_hostname}}" not in groups['slurm-node'])
+
   - name: check that we have an old build dir
     stat:
       path: "{{ slurm_build_dir }}"
@@ -125,6 +132,11 @@
   - name: remove old build dir
     file:
       path: "{{ slurm_build_dir }}"
+      state: absent
+
+  - name: remove old lib dir
+    file:
+      path: "{{ slurm_install_prefix }}/lib/slurm"
       state: absent
 
 - name: make build directory

--- a/roles/slurm/tasks/build.yml
+++ b/roles/slurm/tasks/build.yml
@@ -106,16 +106,19 @@
   when: ansible_os_family == 'RedHat'
   failed_when: false
 
+- name: gather service facts
+  ansible.builtin.service_facts:
+
 - name: when building, try to uninstall first before downloading source
   when: slurm_build
   block:
-
     # This service should be stopped before uninstalling slurm
   - name: stop docker slurm exporter service to prevent subfolder creation
     service:
       name: "docker.slurm-exporter.service"
       state: stopped
-    when: slurm_build and (ansible_distribution == 'Ubuntu') and ("{{ansible_hostname}}" not in groups['slurm-node'])
+    when: (ansible_distribution == 'Ubuntu') and 
+      ("docker.slurm-exporter.service" in ansible_facts.services)
 
   - name: check that we have an old build dir
     stat:
@@ -229,3 +232,11 @@
     state: directory
     mode: 0755
     recurse: yes
+
+- name: start docker slurm exporter service again
+  service:
+    name: "docker.slurm-exporter.service"
+    state: restarted
+  when: (ansible_distribution == 'Ubuntu') and 
+      ("docker.slurm-exporter.service" in ansible_facts.services)
+


### PR DESCRIPTION
Bugs:

1. docker.slurm-exporter.service creates subdirectories
`/usr/loca/bin/{sinfo,sdiag,squeue}` when the excutables are absent
(due to uninstall process). When deepops tries to install the executables
again, they are put under the unwanted subdirectories (e.g.
/usr/local/bin/sinfo/sinfo instead of /usr/local/bin/sinfo)

2. Slurm 'make uninstall' doesn't remove files under `"{{ slurm_install_prefix
}}/lib/slurm"`. Therefore the directory needs to be removed. A safer solution
would be to run the correct 'make uninstall' command (at the correct location)
to uninstall the files. Without this handling, slurm commands fails to run because of
library version conflicts.