### PR TITLE
Specify runtime_path partition size

### DIFF
--- a/config.example/group_vars/slurm-cluster.yml
+++ b/config.example/group_vars/slurm-cluster.yml
@@ -179,6 +179,12 @@ slurm_install_enroot: true
 slurm_install_pyxis: true
 slurm_pyxis_version: 0.11.1
 
+# /run is default partition of pyxis runtime_path
+resize_run_partition: false
+
+# /run tmpfs size. ubuntu default is 10%
+pyxis_run_tmpfs_size: 50%
+
 ################################################################################
 # Node Health Check                                                            #
 ################################################################################

--- a/roles/pyxis/defaults/main.yml
+++ b/roles/pyxis/defaults/main.yml
@@ -12,3 +12,9 @@ pyxis_ubuntu_deps:
 
 pyxis_el_deps:
 - "util-linux"
+
+# /run is default partition of pyxis runtime_path
+resize_run_partition: false
+
+# /run tmpfs size. ubuntu default is 10% of physical memory
+pyxis_run_tmpfs_size: 50%

--- a/roles/pyxis/tasks/main.yml
+++ b/roles/pyxis/tasks/main.yml
@@ -31,3 +31,15 @@
   include_tasks: pyxis.yml
   when: slurm_install_pyxis
   tags: pyxis
+
+# Resize /run temporary file system, which is used to import docker image.
+#  - Default pyxis runtime_path is: /run/pyxis
+# If image is bigger than the file system, the importing will be failed
+- name: resize /run partition
+  mount:
+    name: /run
+    src: tmpfs
+    opts: size={{ pyxis_run_tmpfs_size }}
+    fstype: tmpfs
+    state: mounted
+  when: resize_run_partition


### PR DESCRIPTION
Problem:
 - In the case a docker image is bigger than `/run` partition size then slurm job fails: no space left on device
 - Cf.) nvcr.io/nvidia/pytorch is about 14GB, aws g4dn.2xlarge instance `/run` is about 3GB
 - https://github.com/NVIDIA/pyxis/issues/53

Cause:
 - Pyxis uses `runtime_path` to store squashfs file temporarily
 - The default location of `runtime_path` is `/run/pyxis`.
 - `/run` size might be up to distribution, however ubuntu is 10% of physical memory

Suggestion:
 - Add `resize_run_partition` option to specify `/run` partition size 

I know we can change `runtime_path` to other location, but I believe it is meaningful to use `tmpfs` residing in memory faster than other filesystems if compute nodes have sufficient memory.