### PR TITLE
Update default Slurm version to 22.05.2

### DIFF
--- a/config.example/group_vars/slurm-cluster.yml
+++ b/config.example/group_vars/slurm-cluster.yml
@@ -3,7 +3,7 @@
 ################################################################################
 # Slurm job scheduler configuration
 # Playbook: slurm, slurm-cluster, slurm-perf, slurm-perf-cluster, slurm-validation
-slurm_version: "21.08.8-2"
+slurm_version: "22.05.2"
 slurm_install_prefix: /usr/local
 pmix_install_prefix: /opt/deepops/pmix
 hwloc_install_prefix: /opt/deepops/hwloc

--- a/roles/slurm/defaults/main.yml
+++ b/roles/slurm/defaults/main.yml
@@ -7,7 +7,7 @@ hwloc_build_dir: /opt/deepops/build/hwloc
 pmix_build_dir: /opt/deepops/build/pmix
 
 slurm_workflow_build: yes
-slurm_version: "21.08.8-2"
+slurm_version: "22.05.2"
 slurm_src_url: "https://download.schedmd.com/slurm/slurm-{{ slurm_version }}.tar.bz2"
 slurm_build_make_clean: no
 slurm_build_dir_cleanup: no

--- a/roles/slurm/templates/etc/slurm/cgroup.conf
+++ b/roles/slurm/templates/etc/slurm/cgroup.conf
@@ -1,5 +1,4 @@
 CgroupAutomount=yes
-CgroupReleaseAgentDir="/etc/slurm/cgroup"
 
 ConstrainCores=yes
 ConstrainDevices=yes


### PR DESCRIPTION
## Summary

- Update default Slurm version to 22.05.2. See the [release notes corresponding to this version](https://github.com/SchedMD/slurm/blob/slurm-22-05-2-1/RELEASE_NOTES) for the changes to Slurm.
- Remove `CgroupReleaseAgentDir` parameter from `cgroup.conf`, which now causes fatal errors. Per the Slurm release notes, this option was deprecated anyway.
    ```
     -- Fatal error if CgroupReleaseAgentDir is configured in cgroup.conf. The
        option has long been obsolete.
    ```

## Test plan

- [x] Successful test of Slurm role in the [molecule test](https://github.com/NVIDIA/deepops/tree/master/roles/slurm/molecule/default)
- [x] Successful Slurm cluster CI tests in [Jenkins](https://github.com/NVIDIA/deepops/tree/master/workloads/jenkins)