### PR TITLE
Convert gres.conf syntax from CPUs to Cores

### DIFF
--- a/roles/slurm/templates/etc/slurm/gres.conf
+++ b/roles/slurm/templates/etc/slurm/gres.conf
@@ -1,5 +1,5 @@
 {% set cpu_topology = ansible_local["topology"]["cpu_topology"] -%}
 {% set gpu_topology = ansible_local["topology"]["gpu_topology"] -%}
 {% for affinity in gpu_topology %}
-Name=gpu File=/dev/nvidia{{ loop.index0 }} CPUs={{ affinity }}
+Name=gpu File=/dev/nvidia{{ loop.index0 }} Cores={{ affinity }}
 {% endfor %}


### PR DESCRIPTION
Addresses #1195 in cases where NVML is not used (see also #1157).

## Test plan

- [x] CI tests pass
- [x] Manual test and check of `gres.conf` syntax