### PR TITLE
Kubeflow v1.6.1 Upgrade & drop failing docker runtime tests

### DIFF
--- a/scripts/k8s/deploy_kubeflow.sh
+++ b/scripts/k8s/deploy_kubeflow.sh
@@ -18,7 +18,7 @@ export KUBEFLOW_DEPLOY_TIMEOUT="${KUBEFLOW_DEPLOY_TIMEOUT:-1200}"
 # Define Kubeflow manifests location
 export KUBEFLOW_MANIFESTS_DEST="${KUBEFLOW_MANIFESTS_DEST:-${CONFIG_DIR}/kubeflow-install/manifests}"
 export KUBEFLOW_MANIFESTS_URL="${KUBEFLOW_MANIFESTS_URL:-https://github.com/kubeflow/manifests}"
-export KUBEFLOW_MANIFESTS_VERSION="${KUBEFLOW_MANIFESTS_VERSION:-v1.4.1}"
+export KUBEFLOW_MANIFESTS_VERSION="${KUBEFLOW_MANIFESTS_VERSION:-v1.6.1}"
 
 # Define configuration we're injecting into the manifests location
 export KUBEFLOW_DEEPOPS_CONFIG_DIR="${KUBEFLOW_DEEPOPS_CONFIG_DIR:-${CONFIG_DIR}/files/kubeflow}"

--- a/workloads/jenkins/Jenkinsfile-nightly
+++ b/workloads/jenkins/Jenkinsfile-nightly
@@ -43,117 +43,6 @@ pipeline {
             bash -x ./workloads/jenkins/scripts/vagrant-startup.sh
           '''
 
-          echo "Cluster Up - MGMT Nodes - device plugin + docker"
-          sh '''
-            export DEEPOPS_K8S_OPERATOR=false
-            export DEEPOPS_K8S_CONTAINER_MANAGER=docker
-            bash -x ./workloads/jenkins/scripts/test-cluster-up.sh
-          '''
-
-          echo "Get K8S Cluster Status"
-          sh '''
-            bash -x ./workloads/jenkins/scripts/get-k8s-debug.sh
-          '''
-
-          echo "Verify we can run a GPU job"
-          sh '''
-            timeout 500 bash -x ./workloads/jenkins/scripts/run-gpu-job.sh
-          '''
-
-          echo "Verify ingress config"
-          sh '''
-             bash -x ./workloads/jenkins/scripts/verify-ingress-config.sh
-          '''
-
-          echo "Verify local docker registry"
-          sh '''
-             bash -x ./workloads/jenkins/scripts/test-local-registry.sh
-          '''
-
-          echo "Test running a Deep Learning Example"
-          sh '''
-            timeout 1200 bash -x ./workloads/jenkins/scripts/test-dle-deployment.sh
-          '''
-
-          echo "Verify rsyslog forwarding is working for the k8s cluster"
-          sh '''
-             bash -x ./workloads/jenkins/scripts/test-rsyslog-k8s.sh
-          '''
-
-          echo "Test Kubeflow installation"
-          sh '''
-             # TODO: timeout 4000 bash -x ./workloads/jenkins/scripts/test-kubeflow.sh
-          '''
-
-          echo "Test Monitoring installation"
-          sh '''
-             timeout 1200 bash -x ./workloads/jenkins/scripts/test-monitoring.sh
-          '''
-
-          echo "Test Dashboard installation"
-          sh '''
-             timeout 180 bash -x ./workloads/jenkins/scripts/test-dashboard.sh
-          '''
-
-          echo "Test Kubeflow pipeline"
-          sh '''
-             # TODO: timeout 1500 bash -x ./workloads/jenkins/scripts/test-kubeflow-pipeline.sh
-          '''
-
-          echo "Start new virtual environment"
-          sh '''
-            bash -x ./workloads/jenkins/scripts/vagrant-startup.sh
-          '''
-
-          echo "Cluster Up - MGMT Nodes gpu operator + docker"
-          sh '''
-            export DEEPOPS_K8S_OPERATOR=true
-            export DEEPOPS_K8S_CONTAINER_MANAGER=docker
-            bash -x ./workloads/jenkins/scripts/test-cluster-up.sh
-          '''
-
-          echo "Get K8S Cluster Status"
-          sh '''
-            export DEEPOPS_K8S_OPERATOR=true
-            bash -x ./workloads/jenkins/scripts/get-k8s-debug.sh
-          '''
-
-          echo "Verify we can run a GPU job"
-          sh '''
-            export DEEPOPS_K8S_OPERATOR=true
-            timeout 500 bash -x ./workloads/jenkins/scripts/run-gpu-job.sh
-          '''
-
-          echo "Verify ingress config"
-          sh '''
-             bash -x ./workloads/jenkins/scripts/verify-ingress-config.sh
-          '''
-
-          echo "Verify local docker registry"
-          sh '''
-             bash -x ./workloads/jenkins/scripts/test-local-registry.sh
-          '''
-
-          echo "Verify rsyslog forwarding is working for the k8s cluster"
-          sh '''
-             bash -x ./workloads/jenkins/scripts/test-rsyslog-k8s.sh
-          '''
-
-          echo "Test Monitoring installation"
-          sh '''
-             timeout 1200 bash -x ./workloads/jenkins/scripts/test-monitoring.sh
-          '''
-
-          echo "Test Dashboard installation"
-          sh '''
-             timeout 180 bash -x ./workloads/jenkins/scripts/test-dashboard.sh
-          '''
-
-          echo "Start new virtual environment"
-          sh '''
-            bash -x ./workloads/jenkins/scripts/vagrant-startup.sh
-          '''
-
           echo "Cluster Up - MGMT Nodes gpu operator + containerd"
           sh '''
             export DEEPOPS_K8S_OPERATOR=true
@@ -213,10 +102,10 @@ pipeline {
             bash -x ./workloads/jenkins/scripts/vagrant-startup.sh
           '''
 
-          echo "Cluster Up - MGMT Nodes gpu operator + docker + drivers"
+          echo "Cluster Up - MGMT Nodes gpu operator + containerd + drivers"
           sh '''
             export DEEPOPS_K8S_OPERATOR_EXISTING_SOFTWARE=true
-            export DEEPOPS_K8S_CONTAINER_MANAGER=docker
+            export DEEPOPS_K8S_CONTAINER_MANAGER=containerd
             bash -x ./workloads/jenkins/scripts/test-cluster-up.sh
           '''
 


### PR DESCRIPTION
* Tweaked some of the tests to pass. Now that we are at K8s v1.24 containerd testing is all that is needed, as docker support is dropped in K8s-proper.
* Bumped Kubeflow version to v1.6.1

