### PR TITLE
Bump GPU Operator to v22.9.1

### DIFF
--- a/roles/lmod/defaults/main.yml
+++ b/roles/lmod/defaults/main.yml
@@ -6,4 +6,4 @@ sm_module_path: "{{ sm_module_root }}/all"
 sm_software_path: "{{ sm_prefix }}/software"
 
 epel_package: "https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm"
-epel_key_url: "https://download.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-{{ ansible_distribution_major_version }}"
+epel_key_url: "https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-{{ ansible_distribution_major_version }}"

--- a/roles/nvidia-dgx/defaults/main.yml
+++ b/roles/nvidia-dgx/defaults/main.yml
@@ -1,7 +1,7 @@
 nvidia_dgx_rhel_baseurl: "https://international.download.nvidia.com/dgx/repos/{{ dgx_repo_dir }}/"
 nvidia_dgx_rhel_gpgkey: "https://international.download.nvidia.com/dgx/repos/RPM-GPG-KEY-dgx-cosmos-support"
 epel_package: "https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm"
-epel_key_url: "https://download.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-{{ ansible_distribution_major_version }}"
+epel_key_url: "https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-{{ ansible_distribution_major_version }}"
 
 nvidia_dgx_ubuntu_baseurl: "http://international.download.nvidia.com/dgx/repos"
 nvidia_dgx_ubuntu_gpgkey: "https://international.download.nvidia.com/dgx/repos/bionic/pool/multiverse/d/dgx-repo-keys/dgx-repo-keys_2.0_amd64.deb"

--- a/roles/nvidia-gpu-operator/defaults/main.yml
+++ b/roles/nvidia-gpu-operator/defaults/main.yml
@@ -5,14 +5,14 @@
 #  for additional details around buidling/pushing/using driver containers and setting gpu_operator_driver_version to the correct value
 
 # Vars needed to install operator
-gpu_operator_helm_repo: "https://nvidia.github.io/gpu-operator"
+gpu_operator_helm_repo: "https://helm.ngc.nvidia.com/nvidia"
 gpu_operator_chart_name: "nvidia/gpu-operator"
 gpu_operator_release_name: "nvidia-gpu-operator"
 gpu_operator_nvaie_helm_repo: "https://helm.ngc.nvidia.com/nvaie"
 gpu_operator_nvaie_chart_name: "nvaie/gpu-operator"
 
 # NVAIE GPU Operator may require different version, check NGC enterprise collection.
-gpu_operator_chart_version: "22.9.1"
+gpu_operator_chart_version: "v22.9.2"
 
 k8s_gpu_mig_strategy: "mixed"
 
@@ -33,7 +33,7 @@ gpu_operator_grid_config_dir: "{{ deepops_dir }}/gpu_operator"
 # Defaults from https://github.com/NVIDIA/gpu-operator/blob/master/deployments/gpu-operator/values.yaml
 gpu_operator_default_runtime: "containerd"
 gpu_operator_driver_registry: "nvcr.io/nvidia"
-gpu_operator_driver_version: "525.60.13"
+gpu_operator_driver_version: "525.85.12"
 
 # This enables/disables NVAIE
 gpu_operator_nvaie_enable: false

--- a/roles/nvidia-gpu-operator/defaults/main.yml
+++ b/roles/nvidia-gpu-operator/defaults/main.yml
@@ -12,7 +12,7 @@ gpu_operator_nvaie_helm_repo: "https://helm.ngc.nvidia.com/nvaie"
 gpu_operator_nvaie_chart_name: "nvaie/gpu-operator"
 
 # NVAIE GPU Operator may require different version, check NGC enterprise collection.
-gpu_operator_chart_version: "1.11.1"
+gpu_operator_chart_version: "22.9.1"
 
 k8s_gpu_mig_strategy: "mixed"
 
@@ -23,9 +23,7 @@ gpu_operator_enable_dcgm: false
 gpu_operator_enable_migmanager: true
 
 # Set to true for DGX and other systems with pre-installed drivers
-# In an upcoming GPU Operator release, components can be enabled/disabled per-node
-# In the current version, the cluster is expected to be more homogeneous
-# TODO: Remove this flag and make detection dynamic per-node in this new release
+# TODO: Remove this flag and take advantage of new per-node GPU Operator config to make this behavior dynamic
 gpu_operator_preinstalled_nvidia_software: true
 
 # Configuration customization
@@ -35,7 +33,7 @@ gpu_operator_grid_config_dir: "{{ deepops_dir }}/gpu_operator"
 # Defaults from https://github.com/NVIDIA/gpu-operator/blob/master/deployments/gpu-operator/values.yaml
 gpu_operator_default_runtime: "containerd"
 gpu_operator_driver_registry: "nvcr.io/nvidia"
-gpu_operator_driver_version: "515.48.07"
+gpu_operator_driver_version: "525.60.13"
 
 # This enables/disables NVAIE
 gpu_operator_nvaie_enable: false

--- a/roles/nvidia-k8s-gpu-device-plugin/defaults/main.yml
+++ b/roles/nvidia-k8s-gpu-device-plugin/defaults/main.yml
@@ -2,6 +2,6 @@
 k8s_gpu_plugin_helm_repo: "https://nvidia.github.io/k8s-device-plugin"
 k8s_gpu_plugin_chart_name: "nvdp/nvidia-device-plugin"
 k8s_gpu_plugin_release_name: "nvidia-device-plugin"
-k8s_gpu_plugin_chart_version: "0.12.2"
+k8s_gpu_plugin_chart_version: "0.13.0"
 k8s_gpu_plugin_init_error: "false"
 k8s_gpu_mig_strategy: "mixed"

--- a/roles/nvidia-k8s-gpu-feature-discovery/defaults/main.yml
+++ b/roles/nvidia-k8s-gpu-feature-discovery/defaults/main.yml
@@ -2,5 +2,5 @@
 k8s_gpu_feature_discovery_helm_repo: "https://nvidia.github.io/gpu-feature-discovery"
 k8s_gpu_feature_discovery_chart_name: "nvgfd/gpu-feature-discovery"
 k8s_gpu_feature_discovery_release_name: "gpu-feature-discovery"
-k8s_gpu_feature_discovery_chart_version: "0.6.1"
+k8s_gpu_feature_discovery_chart_version: "0.7.0"
 k8s_gpu_mig_strategy: "mixed"

--- a/roles/nvidia_cuda/defaults/main.yml
+++ b/roles/nvidia_cuda/defaults/main.yml
@@ -19,7 +19,7 @@ cuda_toolkit_add_profile_script: yes
 
 # RedHat family
 epel_package: "https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm"
-epel_key_url: "https://download.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-{{ ansible_distribution_major_version }}"
+epel_key_url: "https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-{{ ansible_distribution_major_version }}"
 nvidia_driver_rhel_cuda_repo_baseurl: "https://developer.download.nvidia.com/compute/cuda/repos/{{ _rhel_repo_dir }}/"
 nvidia_driver_rhel_cuda_repo_gpgkey: "https://developer.download.nvidia.com/compute/cuda/repos/{{ _rhel_repo_dir }}/D42D0685.pub"
 

--- a/roles/nvidia_dcgm/defaults/main.yml
+++ b/roles/nvidia_dcgm/defaults/main.yml
@@ -3,7 +3,7 @@ dcgm_pkg_name: "datacenter-gpu-manager"
 
 # RedHat family
 epel_package: "https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm"
-epel_key_url: "https://download.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-{{ ansible_distribution_major_version }}"
+epel_key_url: "https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-{{ ansible_distribution_major_version }}"
 nvidia_driver_rhel_cuda_repo_baseurl: "https://developer.download.nvidia.com/compute/cuda/repos/{{ _rhel_repo_dir }}/"
 nvidia_driver_rhel_cuda_repo_gpgkey: "https://developer.download.nvidia.com/compute/cuda/repos/{{ _rhel_repo_dir }}/D42D0685.pub"
 

--- a/roles/openshift/defaults/main.yml
+++ b/roles/openshift/defaults/main.yml
@@ -1,4 +1,4 @@
 deepops_dir: /opt/deepops
 deepops_venv: '{{ deepops_dir }}/venv'
 epel_package: "https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm"
-epel_key_url: "https://download.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-{{ ansible_distribution_major_version }}"
+epel_key_url: "https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-{{ ansible_distribution_major_version }}"

--- a/roles/slurm/defaults/main.yml
+++ b/roles/slurm/defaults/main.yml
@@ -1,5 +1,5 @@
 epel_package: "https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm"
-epel_key_url: "https://download.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-{{ ansible_distribution_major_version }}"
+epel_key_url: "https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-{{ ansible_distribution_major_version }}"
 
 deepops_dir: /opt/deepops
 slurm_build_dir: /opt/deepops/build/slurm

--- a/roles/standalone-container-registry/defaults/main.yml
+++ b/roles/standalone-container-registry/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 epel_package: "https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm"
-epel_key_url: "https://download.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-{{ ansible_distribution_major_version }}"
+epel_key_url: "https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-{{ ansible_distribution_major_version }}"
 
 standalone_container_registry_image: "registry:2.8"
 standalone_container_registry_port: "5000"


### PR DESCRIPTION
Bumped to the latest GPU Operator and supporting tools.

Even though the supported path forward is to only use the GPU Operator, I am continuing to maintain and test the paths using Device Plugin without the operator.

GPU Operator -> v22.9.2 (NGC hosted)
Device Plugin -> v0.13.0
GFD ->  v0.7.0

Also pushed some changed in here to address the SSL issues introduced by recent updates to the fedoraproject website.

**Testing:**
The existing test already cover GFD+device plugin and GPU Operator installs. It looks like this release added a few additional features and upgrade paths that could eventually be included in our testing harness, but I have not done so for this PR.

**Upgrade steps:**
For existing clusters an upgrade can be done by:
* Tainting all GPU nodes as NoSchedule and evacuating all running GPU workloads or waiting  for them to complete
* ` helm delete -n gpu-operator-resources nvidia-gpu-operator`
* `kubectl delete crd clusterpolicies.nvidia.com`
* `ansible-playbook playbooks/k8s-cluster/nvidia-gpu-operator.yml`
* Untaint the nodes
See the official docs for a long list of upgrade steps: https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/getting-started.html#upgrade