### PR TITLE
Conform to standard gpu operator namespacing

### DIFF
--- a/config.example/helm/monitoring-no-persist.yml
+++ b/config.example/helm/monitoring-no-persist.yml
@@ -20,7 +20,7 @@ prometheus:
       - role: endpoints
         namespaces:
           names:
-          - gpu-operator-resources
+          - gpu-operator
           - monitoring
       relabel_configs:
       - source_labels: [__meta_kubernetes_pod_node_name]

--- a/config.example/helm/monitoring.yml
+++ b/config.example/helm/monitoring.yml
@@ -23,7 +23,7 @@ prometheus:
       - role: endpoints
         namespaces:
           names:
-          - gpu-operator-resources
+          - gpu-operator
           - monitoring
       relabel_configs:
       - source_labels: [__meta_kubernetes_pod_node_name]

--- a/roles/nvidia-gpu-operator/defaults/main.yml
+++ b/roles/nvidia-gpu-operator/defaults/main.yml
@@ -29,7 +29,7 @@ gpu_operator_enable_migmanager: true
 gpu_operator_preinstalled_nvidia_software: true
 
 # Configuration customization
-gpu_operator_namespace: "gpu-operator-resources"
+gpu_operator_namespace: "gpu-operator"
 gpu_operator_grid_config_dir: "{{ deepops_dir }}/gpu_operator"
 
 # Defaults from https://github.com/NVIDIA/gpu-operator/blob/master/deployments/gpu-operator/values.yaml

--- a/scripts/k8s/debug.sh
+++ b/scripts/k8s/debug.sh
@@ -44,23 +44,23 @@ kubectl get svc -A > ${logdir}/get-svc.log
 
 # Kubectl / GPU Operator (Generic for any Kubernetes cluster)
 kubectl get pvc -A > ${logdir}/get-pvc.log
-for pod in $(kubectl get pods -n gpu-operator-resources  | grep nvidia-device-plugin | awk '{print $1}'); do
-  kubectl -n gpu-operator-resources  logs ${pod} > ${logdir}/get-plugin-logs-${pod}.log
+for pod in $(kubectl get pods -n gpu-operator  | grep nvidia-device-plugin | awk '{print $1}'); do
+  kubectl -n gpu-operator  logs ${pod} > ${logdir}/get-plugin-logs-${pod}.log
 done
-for pod in $(kubectl get pods -n gpu-operator-resources  | grep gpu-feature-discovery | awk '{print $1}'); do
-  kubectl -n gpu-operator-resources  logs ${pod} > ${logdir}/get-plugin-logs-${pod}.log
+for pod in $(kubectl get pods -n gpu-operator  | grep gpu-feature-discovery | awk '{print $1}'); do
+  kubectl -n gpu-operator  logs ${pod} > ${logdir}/get-plugin-logs-${pod}.log
 done
-for pod in $(kubectl get pods -n gpu-operator-resources  | grep nvidia-operator-validator | awk '{print $1}'); do
-  kubectl -n gpu-operator-resources  logs ${pod} > ${logdir}/get-plugin-logs-${pod}.log
+for pod in $(kubectl get pods -n gpu-operator  | grep nvidia-operator-validator | awk '{print $1}'); do
+  kubectl -n gpu-operator  logs ${pod} > ${logdir}/get-plugin-logs-${pod}.log
 done
-for pod in $(kubectl get pods -n gpu-operator-resources  | grep driver | awk '{print $1}'); do
-  kubectl -n gpu-operator-resources  logs ${pod} > ${logdir}/get-plugin-logs-${pod}.log
+for pod in $(kubectl get pods -n gpu-operator  | grep driver | awk '{print $1}'); do
+  kubectl -n gpu-operator  logs ${pod} > ${logdir}/get-plugin-logs-${pod}.log
 done
-for pod in $(kubectl get pods -n gpu-operator-resources  | grep mig | awk '{print $1}'); do
-  kubectl -n gpu-operator-resources  logs ${pod} > ${logdir}/get-plugin-logs-${pod}.log
+for pod in $(kubectl get pods -n gpu-operator  | grep mig | awk '{print $1}'); do
+  kubectl -n gpu-operator  logs ${pod} > ${logdir}/get-plugin-logs-${pod}.log
 done
-kubectl describe pods -n gpu-operator-resources > ${logdir}/describe-gpu-operator-resources-pods.log
-kubectl describe configmap -n gpu-operator-resources default-mig-parted-config > ${logdir}/default-mig-parted-config.log
+kubectl describe pods -n gpu-operator > ${logdir}/describe-gpu-operator-pods.log
+kubectl describe configmap -n gpu-operator default-mig-parted-config > ${logdir}/default-mig-parted-config.log
 
 
 # Helm

--- a/scripts/k8s/deploy_monitoring.sh
+++ b/scripts/k8s/deploy_monitoring.sh
@@ -31,7 +31,7 @@ PROMETHEUS_YAML_CONFIG="${PROMETHEUS_YAML_CONFIG:-${DEEPOPS_CONFIG_DIR}/helm/mon
 PROMETHEUS_YAML_NO_PERSIST_CONFIG="${PROMETHEUS_YAML_NO_PERSIST_CONFIG:-${DEEPOPS_CONFIG_DIR}/helm/monitoring-no-persist.yml}"
 DCGM_CONFIG_CSV="${DCGM_CONFIG_CSV:-${DEEPOPS_CONFIG_DIR}/files/k8s-cluster/dcgm-custom-metrics.csv}"
 
-GPU_OPERATOR_NAMESPACE="${GPU_OPERATOR_NAMESPACE:-gpu-operator-resources}"
+GPU_OPERATOR_NAMESPACE="${GPU_OPERATOR_NAMESPACE:-gpu-operator}"
 
 function help_me() {
     echo "This script installs the DCGM exporter, Prometheus, Grafana, and configures a GPU Grafana dashboard."
@@ -277,7 +277,7 @@ install_dependencies
 setup_prom_monitoring
 
 # Install DCGM-Exporter and setup custom metrics, if needed
-# # GPU Device Plugin is installed into kube-system, GPU Operator installs it into gpu-operator-resources, use uniq for HA K8s clusters
+# # GPU Device Plugin is installed into kube-system, GPU Operator installs it into gpu-operator, use uniq for HA K8s clusters
 plugin_namespace=$( kubectl get pods -A -l app.kubernetes.io/instance=nvidia-device-plugin  --no-headers   --no-headers -o custom-columns=NAMESPACE:.metadata.namespace | uniq)
 if [ "${plugin_namespace}" == "kube-system" ] ; then
     # No GPU Operator DCGM-Exporter Stack

--- a/workloads/jenkins/scripts/get-k8s-debug.sh
+++ b/workloads/jenkins/scripts/get-k8s-debug.sh
@@ -26,10 +26,10 @@ kubectl get daemonsets -A
 
 # Get some logs from the GPU operator Pods
 if [ ${DEEPOPS_K8S_OPERATOR} ]; then
-  kubectl -n gpu-operator-resources logs -l app=gpu-feature-discovery
-  kubectl -n gpu-operator-resources logs -l app=nvidia-driver-daemonset
-  kubectl -n gpu-operator-resources logs -l app=dcgm-exporter-daemonset
-  kubectl -n gpu-operator-resources logs -l app=nvidia-container-toolkit-daemonset
+  kubectl -n gpu-operator logs -l app=gpu-feature-discovery
+  kubectl -n gpu-operator logs -l app=nvidia-driver-daemonset
+  kubectl -n gpu-operator logs -l app=dcgm-exporter-daemonset
+  kubectl -n gpu-operator logs -l app=nvidia-container-toolkit-daemonset
 fi
 
 # Get helm status (requires helm install)

--- a/workloads/jenkins/scripts/run-gpu-job.sh
+++ b/workloads/jenkins/scripts/run-gpu-job.sh
@@ -12,8 +12,8 @@ kubectl get nodes
 kubectl describe nodes
 
 # Wait for GPU operator to finish
-if kubectl get pods -n gpu-operator-resources | grep nvidia-operator-validator ; then
-    kubectl wait --for=condition=ready --timeout=600s pod -n gpu-operator-resources -l app=nvidia-operator-validator
+if kubectl get pods -n gpu-operator | grep nvidia-operator-validator ; then
+    kubectl wait --for=condition=ready --timeout=600s pod -n gpu-operator -l app=nvidia-operator-validator
 fi
 
 # Verify GPU Feature Discovery was installed and one or more nodes were labeled, run queries and remove new lines/white space/non-gpu node output

--- a/workloads/jenkins/scripts/test-monitoring.sh
+++ b/workloads/jenkins/scripts/test-monitoring.sh
@@ -125,13 +125,13 @@ set -e # The loop is done, and we got debug if it failed, re-enable fail on erro
 kubectl get all -n monitoring
 
 # Check for dcgm-exporter pods that are not running
-if kubectl get pods -n gpu-operator-resources -l app=nvidia-dcgm-exporter | grep nvidia-dcgm-exporter | grep -v Running; then
+if kubectl get pods -n gpu-operator -l app=nvidia-dcgm-exporter | grep nvidia-dcgm-exporter | grep -v Running; then
   echo "Some nvidia-dcgm-exporter pods are not in state Running"
   exit 1
 fi
 
 # When deploying the GPU Operator, DCGM is not made available via port 9400 and is instead a K8s service
-if [ "$(kubectl get pods -n gpu-operator-resources -l app=nvidia-dcgm-exporter  -o name)" == "" ]; then
+if [ "$(kubectl get pods -n gpu-operator -l app=nvidia-dcgm-exporter  -o name)" == "" ]; then
   bash -x ./workloads/jenkins/scripts/test-dcgm-metrics.sh slurm-node # We use slurm-node here because it is GPU only, kube-node includes the mgmt plane
 else
   kubectl get svc -A # TODO: Look into if there is a trivial way we can verify DCGM metrics, not high priority because we check Prometheus above


### PR DESCRIPTION
When the GPU Operator was originally launched it installed into "default" and as a best-practice we installed it into "gpu-operator-resources" namespace. They now install everything into "gpu-operator" and cleaned up some bugs that prevented this cleaner install.

This PR conforms to their naming standard and upates a few of our installation scripts and tests.

I'm hoping this will make alignment with official documentation and additional addon installs such as kube-prometheus-stack easier to follow going forward.