### PR TITLE
Fix non-GPU Operator installs by allowing installation into default namespace

### DIFF
--- a/roles/nvidia-k8s-gpu-device-plugin/tasks/main.yml
+++ b/roles/nvidia-k8s-gpu-device-plugin/tasks/main.yml
@@ -13,5 +13,5 @@
   changed_when: false
 
 - name: install nvidia k8s gpu device plugin
-  command: /usr/local/bin/helm upgrade --install "{{ k8s_gpu_plugin_release_name }}" "{{ k8s_gpu_plugin_chart_name }}" --version "{{ k8s_gpu_plugin_chart_version }}" --set "migStrategy={{ k8s_gpu_mig_strategy }}" --set "failOnInitError={{ k8s_gpu_plugin_init_error }}" --set affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].key="nvidia\.com\/gpu\.count",affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].operator="Exists" --wait
+  command: /usr/local/bin/helm upgrade --install "{{ k8s_gpu_plugin_release_name }}" "{{ k8s_gpu_plugin_chart_name }}" --version "{{ k8s_gpu_plugin_chart_version }}" --set "migStrategy={{ k8s_gpu_mig_strategy }}" --set "failOnInitError={{ k8s_gpu_plugin_init_error }}" --set affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].key="nvidia\.com\/gpu\.count",affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].operator="Exists" --set allowDefaultNamespace=true --wait
   changed_when: false

--- a/roles/nvidia-k8s-gpu-feature-discovery/tasks/main.yml
+++ b/roles/nvidia-k8s-gpu-feature-discovery/tasks/main.yml
@@ -13,5 +13,5 @@
   changed_when: false
 
 - name: install nvidia k8s gpu feature discovery
-  command: /usr/local/bin/helm upgrade --install "{{ k8s_gpu_feature_discovery_release_name }}" "{{ k8s_gpu_feature_discovery_chart_name }}" --version "{{ k8s_gpu_feature_discovery_chart_version }}" --set "migStrategy={{ k8s_gpu_mig_strategy }}" --wait
+  command: /usr/local/bin/helm upgrade --install "{{ k8s_gpu_feature_discovery_release_name }}" "{{ k8s_gpu_feature_discovery_chart_name }}" --version "{{ k8s_gpu_feature_discovery_chart_version }}" --set allowDefaultNamespace=true --set "migStrategy={{ k8s_gpu_mig_strategy }}" --wait
   changed_when: false


### PR DESCRIPTION
In the latest updates to the device plugin and GFD they introduced a new flag that causes the installation to fail if you install it into the default namespace.

By default we install these into default, as the more recommended and supported path is installing the full GPU Operator into the gpu operator namespace.

Rather than changing the behavior of this existing code and moving around where things are installed, I am fixing this legacy non-GPU Operator code path by setting "allowDefaultNamespace" to true. This will allow users to disable the full GPU Operator and only get the device plugin and GFD, which is the less supported path and not recommended.