### PR TITLE
Add virtual/vagrant support for Ubuntu 22.04 in order to test via Jenkins

### DIFF
--- a/virtual/Vagrantfile-ubuntu22.04
+++ b/virtual/Vagrantfile-ubuntu22.04
@@ -1,0 +1,48 @@
+VAGRANTFILE_API_VERSION = "2"
+BOX_IMAGE = "generic/ubuntu2204"
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+  config.ssh.insert_key = false
+  config.ssh.private_key_path = ["~/.ssh/id_rsa", "~/.vagrant.d/insecure_private_key"]
+  config.vm.provision "file", source: "~/.ssh/id_rsa.pub", destination: "~/.ssh/authorized_keys"
+
+  config.vm.define "virtual-mgmt01" do |mgmt|
+    mgmt.vm.provider "libvirt" do |v|
+      v.memory = 4096
+      v.cpus = 4
+    end
+    mgmt.vm.box = BOX_IMAGE
+    mgmt.vm.network :private_network, ip: "10.0.0.2"
+  end
+
+  config.vm.define "virtual-login01" do |login|
+    login.vm.provider "libvirt" do |v|
+      v.memory = 6144
+      v.cpus = 4
+    end
+    login.vm.box = BOX_IMAGE
+    login.vm.network :private_network, ip: "10.0.0.5"
+  end
+
+  config.vm.define "virtual-gpu01" do |gpu|
+    gpu.vm.provider "libvirt" do |v|
+      v.memory = 16384
+      v.cpus = 2
+      v.machine_type = "q35"
+      v.cpu_mode = "host-passthrough"
+      # comment in for pci passthrough (and change bus according
+      # to local hw setup - `lspci -nnk | grep NVIDIA`)
+      # BUS-GPU01 is a magic string used by automation, this should be removed
+      #BUS-GPU01 v.pci :bus => '0x08', :slot => '0x00', :function => '0x0'
+    end
+    gpu.vm.box = BOX_IMAGE
+    gpu.vm.network :private_network, ip: "10.0.0.6"
+  end
+
+  config.vm.provision "shell", inline: <<-SHELL
+    sed -i -e 's/4\.2\.2\.1/8.8.8.8/g' -e 's/4\.2\.2\.2/8.8.4.4/g' /etc/netplan/01-netcfg.yaml
+    netplan apply
+
+    apt-get update
+  SHELL
+end

--- a/virtual/Vagrantfile-ubuntu22.04-full
+++ b/virtual/Vagrantfile-ubuntu22.04-full
@@ -1,0 +1,79 @@
+VAGRANTFILE_API_VERSION = "2"
+BOX_IMAGE = "generic/ubuntu2204"
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+  config.ssh.insert_key = false
+  config.ssh.private_key_path = ["~/.ssh/id_rsa", "~/.vagrant.d/insecure_private_key"]
+  config.vm.provision "file", source: "~/.ssh/id_rsa.pub", destination: "~/.ssh/authorized_keys"
+
+  config.vm.define "virtual-mgmt01" do |mgmt|
+    mgmt.vm.provider "libvirt" do |v|
+      v.memory = 4096
+      v.cpus = 2
+    end
+    mgmt.vm.box = BOX_IMAGE
+    mgmt.vm.network :private_network, ip: "10.0.0.2"
+  end
+
+  config.vm.define "virtual-mgmt02" do |mgmt|
+    mgmt.vm.provider "libvirt" do |v|
+      v.memory = 4096
+      v.cpus = 2
+    end
+    mgmt.vm.box = BOX_IMAGE
+    mgmt.vm.network :private_network, ip: "10.0.0.3"
+  end
+
+  config.vm.define "virtual-mgmt03" do |mgmt|
+    mgmt.vm.provider "libvirt" do |v|
+      v.memory = 4096
+      v.cpus = 2
+    end
+    mgmt.vm.box = BOX_IMAGE
+    mgmt.vm.network :private_network, ip: "10.0.0.4"
+  end
+
+  config.vm.define "virtual-login01" do |login|
+    login.vm.provider "libvirt" do |v|
+      v.memory = 6144
+      v.cpus = 4
+    end
+    login.vm.box = BOX_IMAGE
+    login.vm.network :private_network, ip: "10.0.0.5"
+  end
+
+  config.vm.define "virtual-gpu01" do |gpu|
+    gpu.vm.provider "libvirt" do |v|
+      v.memory = 16384
+      v.cpus = 4
+      v.machine_type = "q35"
+      v.cpu_mode = "host-passthrough"
+      # comment in for pci passthrough (and change bus according
+      # to local hw setup - `lspci -nnk | grep NVIDIA`)
+      # BUS-GPU01 is a magic string used by automation, this should be removed
+      #BUS-GPU01 v.pci :bus => '0x08', :slot => '0x00', :function => '0x0'
+    end 
+    gpu.vm.box = BOX_IMAGE
+    gpu.vm.network :private_network, ip: "10.0.0.6"
+  end
+
+  config.vm.define "virtual-gpu02" do |gpu|
+    gpu.vm.provider "libvirt" do |v|
+      v.memory = 16384
+      v.cpus = 4
+      v.machine_type = "q35"
+      v.cpu_mode = "host-passthrough"
+      # comment in for pci passthrough (and change bus according
+      # to local hw setup - `lspci -nnk | grep NVIDIA`)
+      # BUS-GPU02 is a magic string used by automation, this should be removed
+      #BUS-GPU02 v.pci :bus => '0x08', :slot => '0x00', :function => '0x0'
+    end
+    gpu.vm.box = BOX_IMAGE
+    gpu.vm.network :private_network, ip: "10.0.0.7"
+  end
+
+  config.vm.provision "shell", inline: <<-SHELL
+	sed -i -e 's/4\.2\.2\.1/8.8.8.8/g' -e 's/4\.2\.2\.2/8.8.4.4/g' /etc/netplan/01-netcfg.yaml
+	netplan apply
+  SHELL
+end

--- a/virtual/Vagrantfile-ubuntu22.04-large-slurm
+++ b/virtual/Vagrantfile-ubuntu22.04-large-slurm
@@ -1,0 +1,115 @@
+VAGRANTFILE_API_VERSION = "2"
+BOX_IMAGE = "generic/ubuntu2204"
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+  config.ssh.insert_key = false
+  config.ssh.private_key_path = ["~/.ssh/id_rsa", "~/.vagrant.d/insecure_private_key"]
+  config.vm.provision "file", source: "~/.ssh/id_rsa.pub", destination: "~/.ssh/authorized_keys"
+
+  config.vm.define "virtual-wm01" do |mgmt|
+    mgmt.vm.provider "libvirt" do |v|
+      v.memory = 2048
+      v.cpus = 2
+    end
+    mgmt.vm.box = BOX_IMAGE
+    mgmt.vm.network :private_network, ip: "10.0.0.2"
+  end
+
+  config.vm.define "virtual-wm02" do |mgmt|
+    mgmt.vm.provider "libvirt" do |v|
+      v.memory = 2048
+      v.cpus = 2
+    end
+    mgmt.vm.box = BOX_IMAGE
+    mgmt.vm.network :private_network, ip: "10.0.0.3"
+  end
+
+  config.vm.define "virtual-login01" do |login|
+    login.vm.provider "libvirt" do |v|
+      v.memory = 6144
+      v.cpus = 2
+    end
+    login.vm.box = BOX_IMAGE
+    login.vm.network :private_network, ip: "10.0.0.4"
+  end
+
+  config.vm.define "virtual-login02" do |login|
+    login.vm.provider "libvirt" do |v|
+      v.memory = 6144
+      v.cpus = 2
+    end
+    login.vm.box = BOX_IMAGE
+    login.vm.network :private_network, ip: "10.0.0.5"
+  end
+
+  config.vm.define "virtual-cache01" do |cache|
+    cache.vm.provider "libvirt" do |v|
+      v.memory = 6144
+      v.cpus = 2
+    end
+    cache.vm.box = BOX_IMAGE
+    cache.vm.network :private_network, ip: "10.0.0.6"
+  end
+
+  config.vm.define "virtual-cache02" do |cache|
+    cache.vm.provider "libvirt" do |v|
+      v.memory = 6144
+      v.cpus = 2
+    end
+    cache.vm.box = BOX_IMAGE
+    cache.vm.network :private_network, ip: "10.0.0.7"
+  end
+
+  config.vm.define "virtual-metric01" do |metric|
+    metric.vm.provider "libvirt" do |v|
+      v.memory = 6144
+      v.cpus = 2
+    end
+    metric.vm.box = BOX_IMAGE
+    metric.vm.network :private_network, ip: "10.0.0.8"
+  end
+
+  config.vm.define "virtual-gpu01" do |gpu|
+    config.vm.provider "libvirt" do |v|
+      v.memory = 16384
+      v.cpus = 2
+      v.machine_type = "q35"
+      v.cpu_mode = "host-passthrough"
+      # comment in for pci passthrough (and change bus according
+      # to local hw setup - `lspci -nnk | grep NVIDIA`)
+      # BUS-GPU01 is a magic string used by automation, this should be removed
+      #BUS-GPU01 v.pci :bus => '0x08', :slot => '0x00', :function => '0x0'
+    end 
+    gpu.vm.box = BOX_IMAGE
+    gpu.vm.network :private_network, ip: "10.0.0.9"
+  end
+
+  config.vm.define "virtual-gpu02" do |gpu|
+    config.vm.provider "libvirt" do |v|
+      v.memory = 16384
+      v.cpus = 2
+      v.machine_type = "q35"
+      v.cpu_mode = "host-passthrough"
+      # comment in for pci passthrough (and change bus according
+      # to local hw setup - `lspci -nnk | grep NVIDIA`)
+      # BUS-GPU02 is a magic string used by automation, this should be removed
+      #BUS-GPU02 v.pci :bus => '0x08', :slot => '0x00', :function => '0x0'
+    end
+    gpu.vm.box = BOX_IMAGE
+    gpu.vm.network :private_network, ip: "10.0.0.10"
+  end
+
+  config.vm.define "virtual-nfs01" do |mgmt|
+    mgmt.vm.provider "libvirt" do |v|
+      v.memory = 2048
+      v.cpus = 2
+    end
+    mgmt.vm.box = BOX_IMAGE
+    mgmt.vm.network :private_network, ip: "10.0.0.11"
+  end
+
+  config.vm.provision "shell", inline: <<-SHELL
+	sed -i -e 's/4\.2\.2\.1/8.8.8.8/g' -e 's/4\.2\.2\.2/8.8.4.4/g' /etc/netplan/01-netcfg.yaml
+	netplan apply
+  SHELL
+end


### PR DESCRIPTION
Initial PR that adds Vagrant support for testing of Ubuntu 22.04 in Jenkins DeepOps.

This PR does not add official support for Ubuntu 22.04, it is purely an initial PR to add testing capabilities to the DeepOps test harness for new OSes.