### PR TITLE
Bump Kubeflow (1.7.0) and kustomize (5.1.0)

### DIFF
--- a/config.example/files/kubeflow/dex-config-map.yaml
+++ b/config.example/files/kubeflow/dex-config-map.yaml
@@ -37,6 +37,6 @@ data:
     staticClients:
     # https://github.com/dexidp/dex/pull/1664
     - idEnv: OIDC_CLIENT_ID
-      redirectURIs: ["/login/oidc"]
+      redirectURIs: ["/login/oidc", "/authservice/oidc/callback"]
       name: 'Dex Login Application'
       secretEnv: OIDC_CLIENT_SECRET

--- a/scripts/k8s/deploy_kubeflow.sh
+++ b/scripts/k8s/deploy_kubeflow.sh
@@ -136,9 +136,11 @@ function clone_repo() {
   cp -v "${KUBEFLOW_DEEPOPS_DEX_CONFIG}" "${KUBEFLOW_MANIFESTS_DEST}/common/dex/base/config-map.yaml"
   cp -v "${KUBEFLOW_DEEPOPS_USERNS_PARAMS}" "${KUBEFLOW_MANIFESTS_DEST}/common/user-namespace/base/params.env"
 
-
   # BUG: https://stackoverflow.com/questions/76502195/horizontalpodautoscaler-not-found-on-minikube-when-installing-kubeflow
   sed -i 's:autoscaling/v2beta2:autoscaling/v2:' "${KUBEFLOW_MANIFESTS_DEST}/common/knative/knative-serving/base/upstream/serving-core.yaml"
+
+  # XXX: Change the default Istio Ingress Gateway configuration to support NodePort for ease-of-use in on-prem
+  sed -i 's:ClusterIP:NodePort:g' "${KUBEFLOW_MANIFESTS_DEST}/common/istio-1-16/istio-install/base/patches/service.yaml"
 
   popd
   echo "Kubeflow manifests repo:"

--- a/scripts/k8s/deploy_kubeflow.sh
+++ b/scripts/k8s/deploy_kubeflow.sh
@@ -142,6 +142,13 @@ function clone_repo() {
   # XXX: Change the default Istio Ingress Gateway configuration to support NodePort for ease-of-use in on-prem
   sed -i 's:ClusterIP:NodePort:g' "${KUBEFLOW_MANIFESTS_DEST}/common/istio-1-16/istio-install/base/patches/service.yaml"
 
+  # XXX: Make the Kubeflow cluster allow insecure http instead of https
+  # Remove this for any production cluster and enable HTTPS suitable for the environment
+  # XXX: https://github.com/kubeflow/manifests#connect-to-your-kubeflow-cluster
+  sed -i 's:JWA_APP_SECURE_COOKIES=true:JWA_APP_SECURE_COOKIES=false:' "${KUBEFLOW_MANIFESTS_DEST}/apps/jupyter/jupyter-web-app/upstream/base/params.env"
+  sed -i 's:VWA_APP_SECURE_COOKIES=true:VWA_APP_SECURE_COOKIES=false:' "${KUBEFLOW_MANIFESTS_DEST}/apps/volumes-web-app/upstream/base/params.env"
+  sed -i 's:TWA_APP_SECURE_COOKIES=true:TWA_APP_SECURE_COOKIES=false:' "${KUBEFLOW_MANIFESTS_DEST}/apps/tensorboard/tensorboards-web-app/upstream/base/params.env"
+
   popd
   echo "Kubeflow manifests repo:"
   echo "- Cloned from: ${KUBEFLOW_MANIFESTS_URL}"

--- a/scripts/k8s/deploy_kubeflow.sh
+++ b/scripts/k8s/deploy_kubeflow.sh
@@ -18,7 +18,7 @@ export KUBEFLOW_DEPLOY_TIMEOUT="${KUBEFLOW_DEPLOY_TIMEOUT:-1200}"
 # Define Kubeflow manifests location
 export KUBEFLOW_MANIFESTS_DEST="${KUBEFLOW_MANIFESTS_DEST:-${CONFIG_DIR}/kubeflow-install/manifests}"
 export KUBEFLOW_MANIFESTS_URL="${KUBEFLOW_MANIFESTS_URL:-https://github.com/kubeflow/manifests}"
-export KUBEFLOW_MANIFESTS_VERSION="${KUBEFLOW_MANIFESTS_VERSION:-v1.6.1}"
+export KUBEFLOW_MANIFESTS_VERSION="${KUBEFLOW_MANIFESTS_VERSION:-v1.7.0}"
 
 # Define configuration we're injecting into the manifests location
 export KUBEFLOW_DEEPOPS_CONFIG_DIR="${KUBEFLOW_DEEPOPS_CONFIG_DIR:-${CONFIG_DIR}/files/kubeflow}"
@@ -26,7 +26,7 @@ export KUBEFLOW_DEEPOPS_DEX_CONFIG="${KUBEFLOW_DEEPOPS_DEX_CONFIG:-${KUBEFLOW_DE
 export KUBEFLOW_DEEPOPS_USERNS_PARAMS="${KUBEFLOW_DEEPOPS_USERNS_PARAMS:-${KUBEFLOW_DEEPOPS_CONFIG_DIR}/user-namespace-params.env}"
 
 # Define Kustomize location
-export KUSTOMIZE_URL="${KUSTOMIZE_URL:-https://github.com/kubernetes-sigs/kustomize/releases/download/v3.2.0/kustomize_3.2.0_linux_amd64}"
+export KUSTOMIZE_URL="${KUSTOMIZE_URL:-https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv5.1.0/kustomize_v5.1.0_linux_amd64.tar.gz}"
 export KUSTOMIZE="${KUSTOMIZE:-${CONFIG_DIR}/kustomize}"
 
 function help_me() {
@@ -147,7 +147,8 @@ function stand_up() {
   pushd .
   pushd "${KUBEFLOW_MANIFESTS_DEST}"
 
-  wget -O "${KUSTOMIZE}" "${KUSTOMIZE_URL}"
+  wget -O "${KUSTOMIZE}.tgz" "${KUSTOMIZE_URL}"
+  tar -xvf "${KUSTOMIZE}.tgz" -C "${CONFIG_DIR}"
   chmod +x "${KUSTOMIZE}"
 
   echo "Beginning Kubeflow deployment"

--- a/scripts/k8s/deploy_kubeflow.sh
+++ b/scripts/k8s/deploy_kubeflow.sh
@@ -136,6 +136,10 @@ function clone_repo() {
   cp -v "${KUBEFLOW_DEEPOPS_DEX_CONFIG}" "${KUBEFLOW_MANIFESTS_DEST}/common/dex/base/config-map.yaml"
   cp -v "${KUBEFLOW_DEEPOPS_USERNS_PARAMS}" "${KUBEFLOW_MANIFESTS_DEST}/common/user-namespace/base/params.env"
 
+
+  # BUG: https://stackoverflow.com/questions/76502195/horizontalpodautoscaler-not-found-on-minikube-when-installing-kubeflow
+  sed -i 's:autoscaling/v2beta2:autoscaling/v2:' "${KUBEFLOW_MANIFESTS_DEST}/common/knative/knative-serving/base/upstream/serving-core.yaml"
+
   popd
   echo "Kubeflow manifests repo:"
   echo "- Cloned from: ${KUBEFLOW_MANIFESTS_URL}"


### PR DESCRIPTION
Small bump in Kubeflow version, nothing to exciting.


* Bump Kustomize v3.2.0 -> v5.1.0
* Bump Kubeflow v.1.7.0 (Support K8s v1.24 and v1.25)

TODO:
[x] Bump versions
[] Fix K8s v1.26 support
[] Add HTTPS support
[x] Disable hard security requirement on HTTPS

Testing and docs:
[x] Verify Kubeflow install
[] Verify basic functionality of Kubeflow
[] Add additional automated testing
[] Update docs


This release works on the current DeepOps K8s version, but if we bump Kubespray to the latest as per my other open PR we will be jumping to K8s v1.26 which is not officially supported with this release of Kubeflow. In my testing it seemed to somewhat work just fine with the minor API patch included in this PR., but a few Pods were problematic. Will add some more debug to comments in case others want to jump in and get this working.