### PR TITLE
BUG:1284 - K8s Dashboard update

### DIFF
--- a/workloads/services/k8s/k8s-dashboard-admin.yml
+++ b/workloads/services/k8s/k8s-dashboard-admin.yml
@@ -5,6 +5,16 @@ metadata:
   name: admin-user
   namespace: kube-system
 ---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: admin-user-secret
+  annotations:
+    kubernetes.io/service-account.name: admin-user
+  namespace: kube-system
+type: kubernetes.io/service-account-token
+
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:


### PR DESCRIPTION
Fix based on https://github.com/NVIDIA/deepops/issues/1284.

Updates the K8s dashboard deployment to match the pattern in the newer K8s version.
