### PR TITLE
Update ansible.cfg

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -19,6 +19,9 @@ forks = 25
 force_valid_group_names = ignore
 ansible_python_interpreter = /usr/bin/python3
 
+[galaxy]
+server = https://old-galaxy.ansible.com/
+
 [ssh_connection]
 pipelining = True
 ssh_args = -o ControlMaster=auto -o ControlPersist=5m -o ConnectionAttempts=100 -o UserKnownHostsFile=/dev/null


### PR DESCRIPTION
Following the deepOps guide and running ./scripts/setup.sh results in the following: 

[WARNING]: Skipping Galaxy server https://galaxy.ansible.com/api/. Got an unexpected error when getting available versions of collection
ERROR! Unexpected Exception, this is probably a bug: '/api/v3/plugin/ansible/content/published/collections/index/community/general/versions/'

This issue is related to the recent update of galaxy as informed at https://forum.ansible.com/t/new-ansible-galaxy/1155 

The suggested change fixes the issue