### PR TITLE
Increase KillWait to 120 in slurm.conf

### DIFF
--- a/roles/slurm/templates/etc/slurm/slurm.conf
+++ b/roles/slurm/templates/etc/slurm/slurm.conf
@@ -88,7 +88,7 @@ SlurmctldTimeout=120
 SlurmdTimeout=300
 InactiveLimit=0
 MinJobAge=300
-KillWait=30
+KillWait=120
 Waittime=0
 
 # SCHEDULING


### PR DESCRIPTION
possible solution for #1317 i've opened
Update the KillWait parameter in slurm.conf from 30 to 120 seconds to allow for more graceful job termination. This change ensures that jobs have a longer period to complete their shutdown process.