### PR TITLE
Update deepops to support kubernetes v1.32.0

### DIFF
--- a/playbooks/container/docker-login.yml
+++ b/playbooks/container/docker-login.yml
@@ -1,6 +1,7 @@
 ---
 # Ensure Docker is installed and configured
-- include: docker.yml
+- name: Install docker
+  import_playbook: docker.yml
 
 # Log into Docker registries
 - hosts: "{{ hostlist | default('all') }}"

--- a/playbooks/container/docker-rootless.yml
+++ b/playbooks/container/docker-rootless.yml
@@ -1,11 +1,14 @@
 ---
-- include: ../nvidia-software/nvidia-driver.yml
+- name: Install NVIDIA driver on GPU servers
+  import_playbook: ../nvidia-software/nvidia-driver.yml
 
-- include: nvidia-docker.yml
+- name: Install NVIDIA container runtime on GPU servers
+  import_playbook: nvidia-docker.yml
   vars:
     nvidia_docker_skip_docker_reload: true
 
-- include: ../slurm-cluster/lmod.yml
+- name: Install Lmod
+  import_playbook: ../slurm-cluster/lmod.yml
 
 - hosts: all
   become: yes

--- a/playbooks/container/docker.yml
+++ b/playbooks/container/docker.yml
@@ -11,7 +11,7 @@
     - ../../submodules/kubespray/roles/kubernetes/preinstall/defaults/main.yml
   tasks:
     - name: include kubespray task to set facts required for docker role
-      include: ../../submodules/kubespray/roles/kubernetes/preinstall/tasks/0020-set_facts.yml
+      import_playbook: ../../submodules/kubespray/roles/kubernetes/preinstall/tasks/0020-set_facts.yml
       when: docker_install | default('yes')
     - name: remove docker overrides, specifically to deal with conflicting options from DGX OS
       file:

--- a/playbooks/container/nginx-docker-registry-cache-client.yml
+++ b/playbooks/container/nginx-docker-registry-cache-client.yml
@@ -1,5 +1,6 @@
 ---
-- include: docker.yml
+- name: Install docker
+  import_playbook: docker.yml
 
 - hosts: "{{ hostlist | default('all') }}"
   become: yes

--- a/playbooks/container/nginx-docker-registry-cache-server.yml
+++ b/playbooks/container/nginx-docker-registry-cache-server.yml
@@ -1,5 +1,6 @@
 ---
-- include: docker.yml
+- name: Install docker
+  import_playbook: docker.yml
 
 - hosts: "{{ hostlist | default('all') }}"
   become: yes

--- a/playbooks/container/standalone-container-registry.yml
+++ b/playbooks/container/standalone-container-registry.yml
@@ -1,5 +1,6 @@
 ---
-- include: docker.yml
+- name: Install docker
+  import_playbook: docker.yml
 
 - hosts: "{{ hostlist | default('all') }}"
   become: true

--- a/playbooks/k8s-cluster.yml
+++ b/playbooks/k8s-cluster.yml
@@ -21,8 +21,8 @@
         - container_manager is defined
         - container_manager == "docker"
 
-# Install python required for Ansible
-- include: bootstrap/bootstrap-python.yml
+- name: Install python required for Ansible
+  import_playbook: bootstrap/bootstrap-python.yml
   tags:
     - bootstrap
 
@@ -42,32 +42,33 @@
   tags:
     - local
 
-# Set up passwordless sudo and SSH keys if needed
-- include: bootstrap/bootstrap-ssh.yml
+- name: Set up SSH keys if needed
+  import_playbook: bootstrap/bootstrap-ssh.yml
   tags:
     - bootstrap
-- include: bootstrap/bootstrap-sudo.yml
+- name: Set up passwordless sudo if needed
+  import_playbook: bootstrap/bootstrap-sudo.yml
   tags:
     - bootstrap
 
-# Disable cloud-init
-- include: generic/disable-cloud-init.yml
+- name: Disable cloud-init
+  import_playbook: generic/disable-cloud-init.yml
   when: deepops_disable_cloud_init|default(true)
 
-# Configure Chrony (NTP) sync
-- include: generic/chrony-client.yml
+- name: Configure Chrony (NTP) sync
+  import_playbook: generic/chrony-client.yml
   when: chrony_install|default(true)
 
-# Install the OpenShift API libraries required by the GPU plugin
-- include: bootstrap/bootstrap-openshift.yml
+- name: Install the OpenShift API libraries required by the GPU plugin
+  import_playbook: bootstrap/bootstrap-openshift.yml
   tags:
     - bootstrap
 
-# Configure hostnames, /etc/hosts
-- include: generic/hosts.yml
+- name: Configure hostnames, /etc/hosts
+  import_playbook: generic/hosts.yml
 
-# Set up a local cluster container registry
-- include: container/standalone-container-registry.yml hostlist=kube-master
+- name: Set up a local cluster container registry
+  import_playbook: container/standalone-container-registry.yml hostlist=kube-master
   when: kube_enable_container_registry|default(false)
 
 # Install 'sshpass' program for: https://github.com/ansible/ansible/issues/56629
@@ -109,7 +110,8 @@
 
 # Install Kubernetes
 # for configuration, see: config/group_vars/k8s-cluster.yml
-- include: ../submodules/kubespray/cluster.yml
+- name: Install Kubernetes
+  import_playbook: ../submodules/kubespray/cluster.yml
   tags:
     - k8s
   vars:
@@ -163,8 +165,8 @@
   tags:
     - local
 
-# Install NVIDIA driver on GPU servers
-- include: nvidia-software/nvidia-driver.yml
+- name: Install NVIDIA driver on GPU servers
+  import_playbook: nvidia-software/nvidia-driver.yml
   vars:
     hostlist: "k8s-cluster"
   tags:
@@ -172,8 +174,8 @@
   when: deepops_gpu_operator_enabled|default(true) | bool == false or
         gpu_operator_preinstalled_nvidia_software|default(true)
 
-# Install NVIDIA container runtime on GPU servers
-- include: container/nvidia-docker.yml
+- name: Install NVIDIA container runtime on GPU servers
+  import_playbook: container/nvidia-docker.yml
   vars:
     hostlist: "k8s-cluster"
   tags:
@@ -271,33 +273,36 @@
       delegate_to: localhost
       failed_when: false # Taint will not be present if kube-master also under kube-node
 
-# Install k8s GPU feature discovery
-- include: k8s-cluster/nvidia-k8s-gpu-feature-discovery.yml
+- name: Install k8s GPU feature discovery
+  import_playbook: k8s-cluster/nvidia-k8s-gpu-feature-discovery.yml
   tags:
     - nvidia
   when: deepops_gpu_operator_enabled|default(true) | bool == false
 
-# Install k8s GPU device plugin
-- include: k8s-cluster/nvidia-k8s-gpu-device-plugin.yml
+- name: Install k8s GPU device plugin
+  import_playbook: k8s-cluster/nvidia-k8s-gpu-device-plugin.yml
   tags:
     - nvidia
   when: deepops_gpu_operator_enabled|default(true) | bool == false
 
-# Install NVIDIA GPU Operator
-- include: k8s-cluster/nvidia-gpu-operator.yml
+- name: Install NVIDIA GPU Operator
+  import_playbook: k8s-cluster/nvidia-gpu-operator.yml
   tags:
     - nvidia
   when: deepops_gpu_operator_enabled|default(true) | bool == true
 
-# Setup a volume for NFS, install nfs_utils, and install NFS Helm chart
-- include: k8s-cluster/nfs-client-provisioner.yml
+- name: Setup a volume for NFS, install nfs_utils, and install NFS Helm chart
+  import_playbook: k8s-cluster/nfs-client-provisioner.yml
   when: k8s_nfs_client_provisioner | default('false')
 
-- include: generic/rsyslog-server.yml
+- name: Setup rsyslog server
+  import_playbook: generic/rsyslog-server.yml
   vars:
     hostlist: "{{ rsyslog_server_hostname | default('kube-master[0]') }}"
   when: kube_enable_rsyslog_server|default(true)
-- include: generic/rsyslog-client.yml
+
+- name: Setup rsyslog client
+  import_playbook: generic/rsyslog-client.yml
   vars:
     hostlist: "{{ rsyslog_client_group | default('k8s-cluster') }}"
   when: kube_enable_rsyslog_client|default(true)

--- a/playbooks/k8s-cluster.yml
+++ b/playbooks/k8s-cluster.yml
@@ -106,6 +106,7 @@
       when:
         - container_manager is defined and container_manager != "docker"
         - ansible_distribution == "Ubuntu"
+      ignore_errors: yes
   environment: "{{proxy_env if proxy_env is defined else {}}}"
 
 # Install Kubernetes

--- a/playbooks/k8s-cluster/nvidia-gpu-operator.yml
+++ b/playbooks/k8s-cluster/nvidia-gpu-operator.yml
@@ -1,6 +1,6 @@
 ---
-# Ensure OpenShift packages are installed
-- include: ../bootstrap/bootstrap-openshift.yml
+- name: Ensure OpenShift packages are installed
+  import_playbook: ../bootstrap/bootstrap-openshift.yml
 
 # GPU operator
 - hosts: kube-master[0]

--- a/playbooks/ngc-ready-server.yml
+++ b/playbooks/ngc-ready-server.yml
@@ -1,14 +1,25 @@
 ---
 
-- include: bootstrap/bootstrap-python.yml
-- include: bootstrap/bootstrap-ssh.yml
-- include: bootstrap/bootstrap-sudo.yml
+- name: Install python
+  import_playbook: bootstrap/bootstrap-python.yml
 
-- include: container/docker.yml
-- include: nvidia-software/nvidia-driver.yml
-- include: container/nvidia-docker.yml
+- name: Set up SSH keys if needed
+  import_playbook: bootstrap/bootstrap-ssh.yml
 
-- include: nvidia-software/nvidia-dcgm.yml
+- name: Set up passwordless sudo if needed
+  import_playbook: bootstrap/bootstrap-sudo.yml
+
+- name: Install docker
+  import_playbook: container/docker.yml
+
+- name: Install NVIDIA driver
+  import_playbook: nvidia-software/nvidia-driver.yml
+
+- name: Install NVIDIA container runtime
+  import_playbook: container/nvidia-docker.yml
+
+- name: Install NVIDIA DCGM
+  import_playbook: nvidia-software/nvidia-dcgm.yml
   when: install_dcgm|default(false)
 
 - hosts: all

--- a/playbooks/slurm-cluster.yml
+++ b/playbooks/slurm-cluster.yml
@@ -1,146 +1,163 @@
 ---
 # Slurm Cluster Playbook
 
-# Install python required for Ansible
-- include: bootstrap/bootstrap-python.yml
+- name: Install python required for Ansible
+  import_playbook: bootstrap/bootstrap-python.yml
 
-# Set up passwordless sudo and SSH keys if needed
-- include: bootstrap/bootstrap-ssh.yml
-- include: bootstrap/bootstrap-sudo.yml
+- name: Set up SSH keys if needed
+  import_playbook: bootstrap/bootstrap-ssh.yml
 
-# Disable cloud-init
-- include: generic/disable-cloud-init.yml
+- name: Set up passwordless sudo if needed
+  import_playbook: bootstrap/bootstrap-sudo.yml
+
+- name: Disable cloud-init
+  import_playbook: generic/disable-cloud-init.yml
   when: deepops_disable_cloud_init
 
-# Configure hostnames, /etc/hosts
-- include: generic/hosts.yml
+- name: Configure hostnames, /etc/hosts
+  import_playbook: generic/hosts.yml
   when: "{{ slurm_configure_etc_hosts | default(true) }}"
   tags:
   - set-etc-hosts
 
-# Configure Chrony (NTP) sync
-- include: generic/chrony-client.yml
+- name: Configure Chrony (NTP) sync
+  import_playbook: generic/chrony-client.yml
   when: chrony_install|default(true)
 
-# Set up a local cluster container registry
-- include: container/standalone-container-registry.yml hostlist=slurm-master
+- name: Set up a local cluster container registry
+  import_playbook: container/standalone-container-registry.yml hostlist=slurm-master
   when: slurm_enable_container_registry|default(true)
 
-# Set up NGINX-based container caching
-- include: container/nginx-docker-registry-cache-server.yml
+- name: Set up NGINX-based container caching | Install docker registry cache server
+  import_playbook: container/nginx-docker-registry-cache-server.yml
   vars:
     hostlist: "{{ nginx_docker_cache_hostgroup | default('slurm-cache') }}"
   when: slurm_enable_nginx_docker_cache | default(false)
-- include: container/nginx-docker-registry-cache-client.yml
+
+- name: Set up NGINX-based container caching | Install docker registry cache client
+  import_playbook: container/nginx-docker-registry-cache-client.yml
   vars:
     hostlist: "{{ nginx_docker_cache_clients | default('slurm-node') }}"
   when: slurm_enable_nginx_docker_cache | default(false)
 
-# Install NVIDIA driver
-- include: nvidia-software/nvidia-driver.yml
+- name: Install NVIDIA driver
+  import_playbook: nvidia-software/nvidia-driver.yml
   when: slurm_cluster_install_nvidia_driver|default(true)
 
 # Install NVIDIA CUDA Toolkit
 #   Note: the CUDA playbook also installs the driver, so we pass the
 #   appropriate flag to this playbook as well.
-- include: nvidia-software/nvidia-cuda.yml
+- name: Install NVIDIA CUDA Toolkit
+  import_playbook: nvidia-software/nvidia-cuda.yml
   vars:
      cuda_playbook_install_driver: "{{ slurm_cluster_install_nvidia_driver }}"
   when: slurm_cluster_install_cuda|default(true)
 
-# Install software
-- include: generic/software.yml
+- name: Install software
+  import_playbook: generic/software.yml
 
-# Set up NFS filesystem
-- include: generic/nfs-server.yml
+- name: Set up NFS filesystem | Install nfs-server
+  import_playbook: generic/nfs-server.yml
   vars:
     hostlist: "{{ nfs_server_group | default('slurm-nfs[0]') }}"
   when: slurm_enable_nfs_server
-- include: generic/nfs-client.yml
+
+- name: Set up NFS filesystem | Install nfs-client
+  import_playbook: generic/nfs-client.yml
   vars:
     hostlist: "{{ nfs_client_group | default('slurm-nfs-client') }}"
   when: slurm_enable_nfs_client_nodes
 
-# Install DCGM
-- include: nvidia-software/nvidia-dcgm.yml hostlist=slurm-node
+- name: Install DCGM
+  import_playbook: nvidia-software/nvidia-dcgm.yml hostlist=slurm-node
   when: install_dcgm|default(false)
 
-# Install Node Health Check
-- include: slurm-cluster/nhc.yml hostlist=slurm-node
+- name: Install Node Health Check
+  import_playbook: slurm-cluster/nhc.yml hostlist=slurm-node
   when: slurm_install_nhc|default(false)
 
-# Install Slurm
-- include: slurm-cluster/slurm.yml
+- name: Install Slurm
+  import_playbook: slurm-cluster/slurm.yml
 
-# Install OpenMPI
-- include: slurm-cluster/openmpi.yml
+- name: Install OpenMPI
+  import_playbook: slurm-cluster/openmpi.yml
   when: slurm_cluster_install_openmpi|default(true)
 
-# Install Lmod
-- include: slurm-cluster/lmod.yml
+- name: Install Lmod
+  import_playbook: slurm-cluster/lmod.yml
   when: slurm_install_lmod
 
-# Install the NVIDIA HPC SDK
-- include: nvidia-software/nvidia-hpc-sdk.yml
+- name: Install the NVIDIA HPC SDK
+  import_playbook: nvidia-software/nvidia-hpc-sdk.yml
   vars:
     hostlist: "{{ sm_install_host | default('slurm-login[0]')}}"
   when: slurm_install_hpcsdk
 
-# Install monitoring services
-- include: slurm-cluster/prometheus.yml
+- name: Install monitoring services | Install prometheus
+  import_playbook: slurm-cluster/prometheus.yml
   vars:
     hostlist: "{{ slurm_monitoring_group | default('slurm-metric') }}"
   when: slurm_enable_monitoring
-- include: slurm-cluster/grafana.yml
+
+- name: Install monitoring services | Install grafana
+  import_playbook: slurm-cluster/grafana.yml
   vars:
     hostlist: "{{ slurm_monitoring_group | default('slurm-metric') }}"
   when: slurm_enable_monitoring
-- include: slurm-cluster/alertmanager.yml
+
+- name: Install monitoring services | Install alert manager
+  import_playbook: slurm-cluster/alertmanager.yml
   vars:
     hostlist: "{{ slurm_monitoring_group | default('slurm-metric') }}"
   when: slurm_enable_monitoring
   
-# Install monitoring exporters
-- include: slurm-cluster/prometheus-slurm-exporter.yml
+- name: Install monitoring exporters | Install prometheus slurm exporter
+  import_playbook: slurm-cluster/prometheus-slurm-exporter.yml
   vars:
     hostlist: "{{ slurm_monitoring_group | default('slurm-metric') }}"
   when: slurm_enable_monitoring
-- include: slurm-cluster/prometheus-node-exporter.yml
-  when: slurm_enable_monitoring
-- include: slurm-cluster/nvidia-dcgm-exporter.yml
+
+- name: Install monitoring exporters | Install prometheus node exporter
+  import_playbook: slurm-cluster/prometheus-node-exporter.yml
   when: slurm_enable_monitoring
 
-# Set up rsyslog forwarding from compute nodes to head node
-- include: generic/rsyslog-server.yml
+- name: Install monitoring exporters | Install nvidia dcgm exporter
+  import_playbook: slurm-cluster/nvidia-dcgm-exporter.yml
+  when: slurm_enable_monitoring
+
+- name: Set up rsyslog forwarding from compute nodes to head node | Install rsyslog server
+  import_playbook: generic/rsyslog-server.yml
   vars:
     hostlist: "{{ rsyslog_server_hostname | default('slurm-master[0]') }}"
   when: slurm_enable_rsyslog_server|default(true)
-- include: generic/rsyslog-client.yml
+
+- name: Set up rsyslog forwarding from compute nodes to head node | Install rsyslog client
+  import_playbook: generic/rsyslog-client.yml
   vars:
     hostlist: "{{ rsyslog_client_group | default('slurm-node') }}"
   when: slurm_enable_rsyslog_client|default(true)
 
-# Install Singularity
-- include: container/singularity.yml
+- name: Install Singularity
+  import_playbook: container/singularity.yml
   when: slurm_cluster_install_singularity|default(true)
 
-# Install Open OnDemand
-- include: slurm-cluster/open-ondemand.yml
+- name: Install Open OnDemand
+  import_playbook: slurm-cluster/open-ondemand.yml
   when: install_open_ondemand
 
-# Set Permissions to adjust GPU Clocks speeds
-- include: utilities/gpu-clocks.yml
+- name: Set Permissions to adjust GPU Clocks speeds
+  import_playbook: utilities/gpu-clocks.yml
   when: allow_user_set_gpu_clocks
 
-# Install Enroot and Pyxis
-- include: container/pyxis.yml
+- name: Install Enroot and Pyxis
+  import_playbook: container/pyxis.yml
   when:
     - slurm_install_enroot
     - slurm_install_pyxis
   tags:
     - pyxis
 
-# Ensure that nv_peer_mem is loaded
-- include: nvidia-software/nvidia-peer-memory.yml
+- name: Ensure that nv_peer_mem is loaded
+  import_playbook: nvidia-software/nvidia-peer-memory.yml
   tags:
     - nvidia-peer-memory

--- a/playbooks/slurm-cluster/alertmanager.yml
+++ b/playbooks/slurm-cluster/alertmanager.yml
@@ -1,5 +1,6 @@
 ---
-- include: ../container/docker.yml
+- name: Install docker
+  import_playbook: ../container/docker.yml
 
 - hosts: "{{ hostlist | default('all') }}"
   become: yes

--- a/playbooks/slurm-cluster/grafana.yml
+++ b/playbooks/slurm-cluster/grafana.yml
@@ -1,5 +1,6 @@
 ---
-- include: ../container/docker.yml
+- name: Install docker
+  import_playbook: ../container/docker.yml
 
 - hosts: "{{ hostlist | default('all') }}"
   become: yes

--- a/playbooks/slurm-cluster/nvidia-dcgm-exporter.yml
+++ b/playbooks/slurm-cluster/nvidia-dcgm-exporter.yml
@@ -1,7 +1,12 @@
 ---
-- include: ../container/docker.yml
-- include: ../nvidia-software/nvidia-driver.yml
-- include: ../container/nvidia-docker.yml
+- name: Install docker
+  import_playbook: ../container/docker.yml
+
+- name: Install NVIDIA driver
+  import_playbook: ../nvidia-software/nvidia-driver.yml
+
+- name: Install NVIDIA container runtime
+  import_playbook: ../container/nvidia-docker.yml
 
 - hosts:  "{{ hostlist | default('all') }}"
   become: yes

--- a/playbooks/slurm-cluster/prometheus-node-exporter.yml
+++ b/playbooks/slurm-cluster/prometheus-node-exporter.yml
@@ -1,5 +1,6 @@
 ---
-- include: ../container/docker.yml
+- name: Install docker
+  import_playbook: ../container/docker.yml
 
 - hosts: "{{ hostlist | default('all') }}"
   become: yes

--- a/playbooks/slurm-cluster/prometheus-slurm-exporter.yml
+++ b/playbooks/slurm-cluster/prometheus-slurm-exporter.yml
@@ -1,5 +1,6 @@
 ---
-- include: ../container/docker.yml
+- name: Install docker
+  import_playbook: ../container/docker.yml
 
 - hosts: "{{ hostlist | default('all') }}"
   become: yes

--- a/playbooks/slurm-cluster/prometheus.yml
+++ b/playbooks/slurm-cluster/prometheus.yml
@@ -1,5 +1,6 @@
 ---
-- include: ../container/docker.yml
+- name: Install docker
+  import_playbook: ../container/docker.yml
 
 - hosts: "{{ hostlist | default('all') }}"
   become: yes

--- a/roles/nfs/tasks/main.yml
+++ b/roles/nfs/tasks/main.yml
@@ -39,11 +39,14 @@
   tags:
     - nfs
 
-- include: server.yml
+- name: setup server
+  include_tasks: server.yml
   when: nfs_is_server
 
-- include: firewall.yml
+- name: setup firewall
+  include_tasks: firewall.yml
   when: nfs_is_server
 
-- include: client.yml
+- name: setup client
+  include_tasks: client.yml
   when: nfs_is_client

--- a/roles/nginx-docker-registry-cache/tasks/client.yml
+++ b/roles/nginx-docker-registry-cache/tasks/client.yml
@@ -1,6 +1,8 @@
 ---
-- include: client-ubuntu.yml
+- name: Set up Ubuntu client
+  include_tasks: client-ubuntu.yml
   when: ansible_distribution == 'Ubuntu'
 
-- include: client-el.yml
+- name: Set up RHEL client
+  include_tasks: client-el.yml
   when: ansible_os_family == 'RedHat'

--- a/roles/nvidia-dgx-firmware/tasks/main.yml
+++ b/roles/nvidia-dgx-firmware/tasks/main.yml
@@ -19,7 +19,7 @@
 
 - block:
   # Run some pre-flight diagnostics pre-firmware update in case things go wrong
-  - include: run-diagnostics.yml
+  - include_tasks: run-diagnostics.yml
     vars:
       run_diagnostics_type: '-pre-check'
     when:
@@ -27,7 +27,7 @@
       - load_firmware or update_firmware
 
   # Verify the local container exists, then copy it over if necessary and verify it is loaded into Docker
-  - include: load-image.yml
+  - include_tasks: load-image.yml
     when: load_firmware
 
   # Shut down services and unload drivers
@@ -47,20 +47,20 @@
     when: update_firmware
 
   # Update the FW and reboot if necessary
-  - include: update-firmware.yml
+  - include_tasks: update-firmware.yml
     when: update_firmware
 
   # Run post-flight diagnostics
-  - include: run-diagnostics.yml
+  - include_tasks: run-diagnostics.yml
     vars:
       run_diagnostics_type: '-post-check'
     when: run_diagnostics
 
   always:
-  - include: transfer-logs.yml # In case of failure, this will pull whatever logs were captured; in case of success it will pull the later logs and some pre-flight checks may be overwritten
+  - include_tasks: transfer-logs.yml # In case of failure, this will pull whatever logs were captured; in case of success it will pull the later logs and some pre-flight checks may be overwritten
 
-# Clean up the loaded images and copied files
-- include: clean.yml
+- name: Clean up the loaded images and copied files
+  include_tasks: clean.yml
   when: clean_fw
 
 # Some FW component upgrades require cleanly shutting down the DGX and doing a full powercycle (typically SBIOS or BMC)

--- a/roles/nvidia-dgx-firmware/tasks/run-diagnostics.yml
+++ b/roles/nvidia-dgx-firmware/tasks/run-diagnostics.yml
@@ -3,9 +3,14 @@
   debug:
     msg: "Starting now"
 
-- include: check-firmware.yml
+- name: Check firmware
+  include_tasks: check-firmware.yml
   ignore_errors: true
-- include: get-health.yml
+
+- name: Get health
+  include_tasks: get-health.yml
   ignore_errors: true
-- include: get-ib.yml
+
+- name: Get IB
+  include_tasks: get-ib.yml
   ignore_errors: true

--- a/roles/nvidia-dgx-firmware/tasks/transfer-logs.yml
+++ b/roles/nvidia-dgx-firmware/tasks/transfer-logs.yml
@@ -1,5 +1,6 @@
 ---
-- include: get-time.yml
+- name: Get current time
+  include_tasks: get-time.yml
 
 # nvsm does not allow you to specify a dump location, so we search /tmp for the last dump
 - name: Get name of the latest dumpfile from nvsm

--- a/roles/nvidia-dgx-firmware/tasks/update-firmware.yml
+++ b/roles/nvidia-dgx-firmware/tasks/update-firmware.yml
@@ -3,7 +3,8 @@
   debug:
     msg: "Starting now"
 
-- include: check-firmware.yml
+- name: Check firmware
+  include_tasks: check-firmware.yml
 
 - block:
   - name: Check if force update requested
@@ -62,6 +63,7 @@
   debug:
     msg: Host is online
 
-- include: verify-firmware.yml
+- name: Verify firmware
+  include_tasks: verify-firmware.yml
   when:
     - firmware_needs_upgrade | default(false)

--- a/roles/nvidia-dgx-firmware/tasks/verify-firmware.yml
+++ b/roles/nvidia-dgx-firmware/tasks/verify-firmware.yml
@@ -15,7 +15,7 @@
 
 - name: Ensure firmware was updated and everything is up-to-date. Skip if force update was used.
   block:
-    - include: check-firmware.yml
+    - include_tasks: check-firmware.yml
     - name: "Ensure all fw versions are up-to-date after the update - skip if force update was used or specific target fw was updated"
       debug:
         msg: ""

--- a/roles/nvidia-gpu-operator/tasks/main.yml
+++ b/roles/nvidia-gpu-operator/tasks/main.yml
@@ -5,9 +5,11 @@
     gpu_operator_enable_toolkit: true
   when: gpu_operator_preinstalled_nvidia_software
 
-- include: k8s.yml
+- name: deploy nvidia gpu operator to kubernetes
+  include_tasks: k8s.yml
   when: not gpu_operator_nvaie_enable
 
-- include: nvaie.yml
+- name: deploy nvidia gpu operator to nvidia ai enterprise
+  include_tasks: nvaie.yml
   when: gpu_operator_nvaie_enable
 

--- a/roles/ood-wrapper/tasks/main.yml
+++ b/roles/ood-wrapper/tasks/main.yml
@@ -10,11 +10,14 @@
       skip: true
   tags: vars
 
-- include: server.yml
+- name: Setup Open OnDemand server
+  include_tasks: server.yml
   when: ood_is_server
 
-- include: client.yml
+- name: Setup Open OnDemand client
+  include_tasks: client.yml
   when: ood_is_client
 
-- include: linuxhost-adapter.yml
+- name: Setup linuxhost adapter
+  include_tasks: linuxhost-adapter.yml
   when: ood_is_server and ood_install_linuxhost_adapter

--- a/roles/singularity_wrapper/requirements.yml
+++ b/roles/singularity_wrapper/requirements.yml
@@ -1,3 +1,4 @@
 ---
 roles:
-- include: roles.yml
+- name: Setup singularity roles
+  include_tasks: roles.yml

--- a/roles/slurm/tasks/build.yml
+++ b/roles/slurm/tasks/build.yml
@@ -3,7 +3,8 @@
 # Install dependencies
 ###########################################
 
-- include: setup-role.yml
+- name: Setup role
+  include_tasks: setup-role.yml
 
 - name: configure alternative library path
   template:
@@ -16,13 +17,16 @@
   command: ldconfig
   when: updated_slurm_ld.changed # noqa no-handler
 
-- include: munge.yml
+- name: Setup munge
+  include_tasks: munge.yml
 
-- include: hwloc.yml
+- name: Setup hwlock
+  include_tasks: hwloc.yml
   tags: hwloc
   when: slurm_include_hwloc
 
-- include: pmix.yml
+- name: Setup pmix
+  include_tasks: pmix.yml
   tags: pmix
   when: slurm_include_pmix
 

--- a/roles/slurm/tasks/main.yml
+++ b/roles/slurm/tasks/main.yml
@@ -4,34 +4,45 @@
     name: nvidia_cuda
   when: slurm_autodetect_nvml|default(false)
 
-- include: setup-role.yml
+- name: Setup role
+  include_tasks: setup-role.yml
 
-- include: build.yml
+- name: Setup build
+  include_tasks: build.yml
   tags: build
   when: slurm_workflow_build
 
-- include: service-files.yml
+- name: Setup slurm systemd services
+  include_tasks: service-files.yml
 
-- include: setup-user.yml
+- name: Setup slurm user environment
+  include_tasks: setup-user.yml
 
-- include: controller.yml
+- name: Setup slurm controller
+  include_tasks: controller.yml
   when: is_controller
 
-- include: compute.yml
+- name: Setup slurm on compute nodes
+  include_tasks: compute.yml
   when: is_compute
 
-- include: misc-node.yml
+- name: Setup slurm on other nodes
+  include_tasks: misc-node.yml
   when: (not is_compute) and (not is_controller)
 
-- include: shmfix.yml
+- name: Apply shm fix
+  include_tasks: shmfix.yml
   when: is_compute and slurm_fix_shm
 
-- include: logging.yml
+- name: Setup logging
+  include_tasks: logging.yml
   tags:
   - rsyslog
   - logging
 
-- include: undrain.yml
+- name: Setup undrain
+  include_tasks: undrain.yml
   when: is_compute
 
-- include: build-cleanup.yml
+- name: Cleanup
+  include_tasks: build-cleanup.yml

--- a/scripts/k8s/install_helm.sh
+++ b/scripts/k8s/install_helm.sh
@@ -4,7 +4,7 @@ set -x
 
 # Source common libraries and env variables
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-ROOT_DIR="${SCRIPT_DIR}/.."
+ROOT_DIR="${SCRIPT_DIR}/../.."
 source ${ROOT_DIR}/scripts/common.sh
 
 HELM_INSTALL_DIR=/usr/local/bin

--- a/scripts/k8s/install_helm.sh
+++ b/scripts/k8s/install_helm.sh
@@ -4,7 +4,7 @@ set -x
 
 # Source common libraries and env variables
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-ROOT_DIR="${SCRIPT_DIR}/../.."
+ROOT_DIR="${SCRIPT_DIR}/.."
 source ${ROOT_DIR}/scripts/common.sh
 
 HELM_INSTALL_DIR=/usr/local/bin
@@ -46,7 +46,7 @@ if [ "${HELM_MINIMUM_VERSION}" != "${helm_min_installed}" ]; then
     chmod +x /var/tmp/get_helm.sh
     #sed -i 's/sudo//g' /var/tmp/get_helm.sh
     mkdir -p ${HELM_INSTALL_DIR}
-    HELM_INSTALL_DIR=${HELM_INSTALL_DIR} DESIRED_VERSION=v3.7.1 /var/tmp/get_helm.sh # Should match: config/group_vars/k8s-cluster.yml:helm_version:
+    HELM_INSTALL_DIR=${HELM_INSTALL_DIR} DESIRED_VERSION=v3.17.1 /var/tmp/get_helm.sh # Should match: config/group_vars/k8s-cluster.yml:helm_version:
 fi
 
 # Display the helm version for better debug

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -12,14 +12,14 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 ROOT_DIR="${SCRIPT_DIR}/.."
 
 # Configuration
-ANSIBLE_VERSION="${ANSIBLE_VERSION:-4.8.0}"     # Ansible version to install
-ANSIBLE_TOO_NEW="${ANSIBLE_TOO_NEW:-5.0.0}"    # Ansible version too new
+ANSIBLE_VERSION="${ANSIBLE_VERSION:-9.13.0}"     # Ansible version to install
+ANSIBLE_TOO_NEW="${ANSIBLE_TOO_NEW:-10.0.1}"    # Ansible version too new
 ANSIBLE_LINT_VERSION="${ANSIBLE_LINT_VERSION:-5.4.0}"
 CONFIG_DIR="${CONFIG_DIR:-${ROOT_DIR}/config}"            # Default configuration directory location
 DEEPOPS_TAG="${1:-master}"                      # DeepOps branch to set up
-JINJA2_VERSION="${JINJA2_VERSION:-2.11.3}"      # Jinja2 required version
+JINJA2_VERSION="${JINJA2_VERSION:-3.1.5}"      # Jinja2 required version
 JMESPATH_VERSION="${JMESPATH_VERSION:-0.10.0}"    # jmespath pegged version, actual version probably not that crucial
-MARKUPSAFE_VERSION="${MARKUPSAFE_VERSION:-1.1.1}"  # MarkupSafe version
+MARKUPSAFE_VERSION="${MARKUPSAFE_VERSION:-3.0.2}"  # MarkupSafe version
 PIP="${PIP:-pip3}"                              # Pip binary to use
 PYTHON_BIN="${PYTHON_BIN:-/usr/bin/python3}"    # Python3 path
 VENV_DIR="${VENV_DIR:-/opt/deepops/env}"        # Path to python virtual environment to create


### PR DESCRIPTION
Hi!

Please, consider this PR if you find it worth for running up-to-date Kubernetes clusters.

PR includes: 
- upgrade required ansible version to 9.13 (ansible-core 2.16.14)
- refactor playbooks and change "import" and "include" statements to "import_tasks", "include_tasks"
- minor bug fixes

Best,
   Alex Frolov