### PR TITLE
Use include_tasks instead of ansible.builtin.include

### DIFF
--- a/roles/nvidia_dcgm/tasks/main.yml
+++ b/roles/nvidia_dcgm/tasks/main.yml
@@ -6,15 +6,15 @@
 
 - name: DGX tasks
   when: dcgm_is_dgx
-  include: install-dgx.yml
+  include_tasks: install-dgx.yml
 
 - name: Ubuntu tasks
   when: (ansible_distribution == "Ubuntu") and not dcgm_is_dgx
-  include: install-ubuntu.yml
+  include_tasks: install-ubuntu.yml
 
 - name: Red Hat family tasks
   when: (ansible_os_family == "RedHat") and not dcgm_is_dgx
-  include: install-redhat.yml
+  include_tasks: install-redhat.yml
 
 # We don't test service start in Molecule, because the dcgm service will fail
 # if the CUDA driver isn't installed and working.

--- a/roles/slurm/tasks/compute.yml
+++ b/roles/slurm/tasks/compute.yml
@@ -94,7 +94,7 @@
     - epilog
 
 - name: include prolog/epilog
-  include: prolog_epilog.yml
+  include_tasks: prolog_epilog.yml
   when: slurm_enable_prolog_epilog
 
 - name: configure slurm.conf


### PR DESCRIPTION
Use include_tasks instead of ansible.builtin.include since this module has been removed in a major release after 2023-05-16.
[https://docs.ansible.com/ansible/latest/collections/ansible/builtin/include_module.html](info)