### PR TITLE
Revert "Update ansible.cfg"

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -19,9 +19,6 @@ forks = 25
 force_valid_group_names = ignore
 ansible_python_interpreter = /usr/bin/python3
 
-[galaxy]
-server = https://old-galaxy.ansible.com/
-
 [ssh_connection]
 pipelining = True
 ssh_args = -o ControlMaster=auto -o ControlPersist=5m -o ConnectionAttempts=100 -o UserKnownHostsFile=/dev/null


### PR DESCRIPTION
This reverts commit 6186cf17726f51dede6d8c277f0184c16d21752c.

The commit is workaround of the issue [1312](https://github.com/NVIDIA/deepops/issues/1312)
Since the version of ansible is updated and the new ansible galaxy does not cause failure of collection installation anymore, I think we don't need this commit anymore.
This revert commit is also relevant to another [issue#1314](https://github.com/NVIDIA/deepops/issues/1314) because the new galaxy can provide docker version higher than 3.10.2.
