### PR TITLE
Fix typo and version for installing docker and kubespray

### DIFF
--- a/playbooks/container/docker.yml
+++ b/playbooks/container/docker.yml
@@ -7,7 +7,7 @@
   vars_files:
     # include kubespray-defaults here so that we can set the facts using the
     # kubespray 0020-set_facts.yml tasks
-    - ../../submodules/kubespray/roles/kubespray-defaults/defaults/main.yaml
+    - ../../submodules/kubespray/roles/kubespray-defaults/defaults/main.yml
     - ../../submodules/kubespray/roles/kubernetes/preinstall/defaults/main.yml
   tasks:
     - name: include kubespray task to set facts required for docker role

--- a/roles/requirements.yml
+++ b/roles/requirements.yml
@@ -8,7 +8,7 @@ collections:
   version: 7.2.0
 
 - name: community.docker
-  version: 3.4.8
+  version: 3.10.2
 
 roles:
 


### PR DESCRIPTION
1. I am facing below error in kubespray part during installation.

	```
	fatal: [node1]: FAILED! =>
	msg: I-
	The task includes an option with an undefined variable. The error was. "dns domain! is undefined, "dns domain! is undefined

	The error appears to be in '/home/jaeho/deepops/submodules/kubespray/roles/kubernetes/preinstall/tasks/0020-set_facts.yml': line 59, column 3, but may be elsewhere in the file depending on the exact syntax problem.

	The offending line appears to be:
	- name: Set default dns if remove_default_searchdomains is false
	^ here
	```

	After checking, I found that there was an extension typo in loading the variable file for 'dns_domain' of submodule kubespray.
	https://github.com/NVIDIA/deepops/blob/master/playbooks/container/docker.yml#L10
	Modified from main.yaml to main.yml. 

2. Updated the required version of community.docker to 3.10.2 following commit.
	https://github.com/NVIDIA/deepops/pull/1327#issue-2968502734