### PR TITLE
fix: kubectl download hardening from Copilot review

### DIFF
--- a/playbooks/k8s-cluster.yml
+++ b/playbooks/k8s-cluster.yml
@@ -209,10 +209,19 @@
       run_once: true
       when: local_uname.stdout == remote_uname.stdout
 
+    - name: ensure fetched kubectl is executable
+      file:
+        path: "{{ artifacts_dir }}/kubectl"
+        mode: '0755'
+      delegate_to: localhost
+      run_once: true
+      when: local_uname.stdout == remote_uname.stdout
+
     - name: get kubectl version for cross-platform download
       command: /usr/local/bin/kubectl version --client -o json
       register: kubectl_ver_json
       run_once: true
+      changed_when: false
       when: local_uname.stdout != remote_uname.stdout
 
     - name: download kubectl for ansible host platform
@@ -225,6 +234,8 @@
         dest: "{{ artifacts_dir }}/kubectl"
         mode: '0755'
         force: yes
+        checksum: "sha256:https://dl.k8s.io/release/{{ kubectl_ver }}/bin/{{ kubectl_os }}/{{ kubectl_arch }}/kubectl.sha256"
+      environment: "{{ proxy_env if proxy_env is defined else {} }}"
       delegate_to: localhost
       run_once: true
       when: local_uname.stdout != remote_uname.stdout


### PR DESCRIPTION
## Summary
Follow-up to PR #1339 addressing Copilot review feedback:
- Set executable mode on fetched kubectl binary (`fetch` doesn't preserve permissions)
- Add `changed_when: false` to `kubectl version` command for idempotent runs
- Add SHA256 checksum verification for cross-platform kubectl download (supply-chain safety)
- Respect `proxy_env` for `get_url` in proxy environments

## Test plan
- [ ] `--tags local` run is idempotent (no spurious "changed" on kubectl version)
- [ ] Cross-platform download verifies checksum
- [ ] Fetched kubectl has executable permissions
- [ ] Works behind HTTP proxy (if applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)