### PR TITLE
fix: replace yaml.load with yaml.safe_load to prevent deserialization…

### DIFF
--- a/scripts/k8s/update_kubeflow_config.py
+++ b/scripts/k8s/update_kubeflow_config.py
@@ -63,8 +63,8 @@ def get_images(url='https://api.ngc.nvidia.com/v2/repos', number_tags=5):
 
 def update_yaml(images, yaml_file):
     with open(yaml_file, 'r') as fname:
-        config = yaml.load(fname.read(), Loader=yaml.FullLoader)
-    ui_config = yaml.load(config['data']['spawner_ui_config.yaml'], Loader=yaml.FullLoader)
+        config = yaml.safe_load(fname.read())
+    ui_config = yaml.safe_load(config['data']['spawner_ui_config.yaml'])
 
     # XXX: the yaml file doesn't read in properly due to the line 'spawner_ui_config.yaml: |'. So we pull it out and put it back later.
     config['data']['spawner_ui_config.yaml'] = ui_config

--- a/workloads/examples/k8s/kubeflow-pipeline-deploy/triton_ops.py
+++ b/workloads/examples/k8s/kubeflow-pipeline-deploy/triton_ops.py
@@ -100,6 +100,6 @@ class TritonService(dsl.ResourceOp):
 
     super(TritonService, self).__init__(
       name=name,
-      k8s_resource=yaml.load(__TRITON_SERVICE_MANIFEST___),
+      k8s_resource=yaml.safe_load(__TRITON_SERVICE_MANIFEST___),
       action='create'
 )


### PR DESCRIPTION
Fixes insecure YAML deserialization vulnerability. yaml.load() with FullLoader (or no Loader) allows Python object construction tags (!!python/object/new:...) enabling arbitrary code execution.

Affected files:
- scripts/k8s/update_kubeflow_config.py (2 sinks: outer + inner yaml.load)
- workloads/examples/k8s/kubeflow-pipeline-deploy/triton_ops.py (1 sink: no Loader)

Fix: replace all instances with yaml.safe_load() which disables Python-specific type constructors entirely.