### PR TITLE
release: 26.05 notes and README tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The DeepOps project encapsulates best practices in the deployment of GPU server 
 - An existing cluster that needs a resource manager / batch scheduler, where DeepOps is used to install Slurm or Kubernetes
 - A single machine where no scheduler is desired, only NVIDIA drivers, Docker, and the NVIDIA Container Runtime
 
-Latest release: [DeepOps 23.08 Release](https://github.com/NVIDIA/deepops/releases/tag/23.08)
+Latest release: [DeepOps 26.05 Release](https://github.com/NVIDIA/deepops/releases/tag/26.05)
 
 It is recommended to use the latest release branch for stable code (linked above). All development takes place on the master branch, which is generally [functional](docs/deepops/testing.md) but may change significantly between releases.
 


### PR DESCRIPTION
# DeepOps 26.05 Release Notes

DeepOps 26.05 is the first DeepOps release since 23.08. It refreshes the Kubernetes, Slurm, GPU, monitoring, provisioning, and supporting dependency stack while preserving the existing DeepOps release model of tagging `master`.

## General

- Updated software component pins and documentation for the 26.05 release.
- Updated Ansible role dependencies for current ansible-core compatibility.
- Updated documentation references for current Kubespray inventory group names.
- Continued to keep release artifacts public-facing and free of environment-specific infrastructure details.

## Kubernetes

- Updated Kubespray to v2.31.0.
- Updated Kubernetes inventory group references from legacy `kube-master` / `kube-node` names to current Kubespray group names.
- Fixed the NFS client provisioner playbook include path for current Ansible variable typing.
- Updated Helm installation handling so the installer runs with Bash and leaves the installed binary executable.
- Updated ingress and monitoring chart pins.

## GPU Stack

- Updated GPU Operator to v26.3.1.
- Updated the default GPU Operator driver version to 580.126.20.
- Added Ubuntu open-kernel-module package selection through `nvidia_driver_ubuntu_use_open_kernel_modules`.
- Updated NVIDIA device plugin and GPU feature discovery chart versions to 0.19.1.
- Updated NVIDIA Network Operator to 26.1.1 and adjusted the role for the current chart behavior.
- Updated MIG Manager package URLs.

## Slurm

- Updated Slurm to 25.11.6.
- Improved Slurm controller idempotency for repeated `sacctmgr` account and user creation.
- Ran login/compute GPU visibility setup with Bash so `pipefail` handling works consistently.

## MAAS

- Updated the MAAS role dependency to the maintained upstream role revision used by this release.
- Updated MAAS examples for MAAS 3.5.
- Added `maas_python_reqs` defaults so pip packages do not shadow the packaged MAAS CLI.

## Monitoring And Supporting Components

- Updated Prometheus, Alertmanager, Grafana, node exporter, cache, Spack, Helm chart, and container image defaults.
- Updated NetApp Trident documentation references.

## Upgrading

- Re-run `./scripts/setup.sh` after updating to this release.
- Compare your existing `config/` directory against `config.example/` and carry forward new or changed variables.
- Kubernetes upgrades from much older DeepOps releases may need staged upgrades through compatible intermediate Kubespray and network-plugin versions. Direct upgrades from 23.08-era Kubernetes deployments can stop in Kubespray prechecks when the deployed Calico version is older than the current minimum. Use staged upgrades or redeploy for older clusters instead of assuming a direct jump will work.
- For Slurm, consult SchedMD upgrade guidance before upgrading existing accounting and controller state across major releases.
- For GPU Operator and Network Operator upgrades, consult upstream release notes for CRD and chart behavior changes before upgrading existing clusters.

## Validation

- Public CI passed for the 26.05 version-bump PR.
- Release validation covered role linting, selected playbook syntax checks, fresh Slurm deployment, fresh Kubernetes/GPU Operator deployment, MAAS provisioning, and upgrade-path behavior from 23.08-era Kubernetes.

## Changes

- #1344 - chore(release): bump component versions for 26.05
