### PR TITLE
Add Ubuntu 24.04 NVIDIA Container Toolkit path

### DIFF
--- a/docs/airgap/mirror-apt-repos.md
+++ b/docs/airgap/mirror-apt-repos.md
@@ -15,7 +15,7 @@ Set up offline repositoriy mirrors for Aptitude
     - [NVIDIA CUDA repository](#nvidia-cuda-repository)
       - [APT Configuration](#apt-configuration-1)
       - [GPG Key Validation](#gpg-key-validation-1)
-    - [nvidia-docker](#nvidia-docker)
+    - [NVIDIA Container Toolkit](#nvidia-container-toolkit)
       - [APT Configuration](#apt-configuration-2)
       - [GPG Key Validation](#gpg-key-validation-2)
     - [Additional DEB packages](#additional-deb-packages)
@@ -57,7 +57,7 @@ deb http://archive.ubuntu.com/ubuntu/ <release-name>-updates main multiverse uni
 ```
 
 where `<release-name>` is the name of the Ubuntu release you want to mirror.
-This is `bionic` for Ubuntu 18.04, and `focal` for Ubuntu 20.04.
+This is `bionic` for Ubuntu 18.04, `focal` for Ubuntu 20.04, `jammy` for Ubuntu 22.04, and `noble` for Ubuntu 24.04.
 
 ### Docker repository
 
@@ -74,7 +74,7 @@ https://download.docker.com/linux/ubuntu/gpg
 ```
 
 where `<release-name>` is the name of the Ubuntu release you want to mirror.
-This is `bionic` for Ubuntu 18.04, and `focal` for Ubuntu 20.04.
+This is `bionic` for Ubuntu 18.04, `focal` for Ubuntu 20.04, `jammy` for Ubuntu 22.04, and `noble` for Ubuntu 24.04.
 
 ### NVIDIA CUDA repository
 
@@ -92,6 +92,18 @@ deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804
 deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004
 ```
 
+**Ubuntu 22.04**
+
+```bash
+deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64 /
+```
+
+**Ubuntu 24.04**
+
+```bash
+deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/x86_64 /
+```
+
 #### GPG Key Validation
 
 **Ubuntu 18.04**
@@ -106,30 +118,30 @@ https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/7fa2a
 https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/7fa2af80.pub
 ```
 
-### nvidia-docker
+**Ubuntu 22.04**
+
+```bash
+https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/3bf863cc.pub
+```
+
+**Ubuntu 24.04**
+
+```bash
+https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/x86_64/3bf863cc.pub
+```
+
+### NVIDIA Container Toolkit
 
 #### APT Configuration
 
-**Ubuntu 18.04**
-
 ```bash
-deb https://nvidia.github.io/libnvidia-container/stable/ubuntu18.04/$(ARCH) /
-deb https://nvidia.github.io/nvidia-container-runtime/stable/ubuntu18.04/$(ARCH) /
-deb https://nvidia.github.io/nvidia-docker/ubuntu18.04/$(ARCH)
-```
-
-**Ubuntu 20.04**
-
-```bash
-deb https://nvidia.github.io/libnvidia-container/stable/ubuntu18.04/$(ARCH) /
-deb https://nvidia.github.io/nvidia-container-runtime/stable/ubuntu18.04/$(ARCH) /
-deb https://nvidia.github.io/nvidia-docker/ubuntu18.04/$(ARCH)
+deb https://nvidia.github.io/libnvidia-container/stable/deb/$(ARCH) /
 ```
 
 #### GPG Key Validation
 
 ```bash
-https://nvidia.github.io/nvidia-docker/gpgkey
+https://nvidia.github.io/libnvidia-container/gpgkey
 ```
 
 ### Additional DEB packages
@@ -161,7 +173,7 @@ After installing `apt-mirror`, edit the `/etc/apt/mirror.list` file make the fol
 - Set the `base_path` to the desired download path for your mirror (here, `/var/repos`)
 - Add a list of APT configuration lines for each repo you wish to mirror
 
-For example, if we just want to mirror the Docker and NVIDIA Docker repositories, this configuration would work:
+For example, if we just want to mirror the Docker and NVIDIA Container Toolkit repositories, this configuration would work:
 
 ```
 ############# config ##################
@@ -172,11 +184,11 @@ set _tilde 0
 #
 ############# end config ##############
 
-deb https://download.docker.com/linux/ubuntu bionic stable
-deb https://nvidia.github.io/nvidia-docker/ubuntu20.04/amd64 /
+deb https://download.docker.com/linux/ubuntu noble stable
+deb https://nvidia.github.io/libnvidia-container/stable/deb/amd64 /
 ```
 
-The full mirror.list file for Deepops:
+The full mirror.list file for DeepOps:
 
 ```
 ############# config ##################
@@ -195,29 +207,27 @@ set _tilde 0
 #
 ############# end config ##############
 
-deb http://archive.ubuntu.com/ubuntu focal main restricted universe multiverse
-deb http://archive.ubuntu.com/ubuntu focal-security main restricted universe multiverse
-deb http://archive.ubuntu.com/ubuntu focal-updates main restricted universe multiverse
-deb http://archive.ubuntu.com/ubuntu focal-proposed main restricted universe multiverse
-deb http://archive.ubuntu.com/ubuntu focal-backports main restricted universe multiverse
-deb http://ppa.launchpad.net/maas/2.9/ubuntu focal main
-deb http://archive.canonical.com/ubuntu focal partner
+deb http://archive.ubuntu.com/ubuntu noble main restricted universe multiverse
+deb http://archive.ubuntu.com/ubuntu noble-security main restricted universe multiverse
+deb http://archive.ubuntu.com/ubuntu noble-updates main restricted universe multiverse
+deb http://archive.ubuntu.com/ubuntu noble-proposed main restricted universe multiverse
+deb http://archive.ubuntu.com/ubuntu noble-backports main restricted universe multiverse
+deb http://ppa.launchpad.net/maas/3.5/ubuntu noble main
+deb http://archive.canonical.com/ubuntu noble partner
 
-deb-src http://archive.ubuntu.com/ubuntu focal main restricted universe multiverse
-deb-src http://archive.ubuntu.com/ubuntu focal-security main restricted universe multiverse
-deb-src http://archive.ubuntu.com/ubuntu focal-updates main restricted universe multiverse
-deb-src http://archive.ubuntu.com/ubuntu focal-proposed main restricted universe multiverse
-deb-src http://archive.ubuntu.com/ubuntu focal-backports main restricted universe multiverse
+deb-src http://archive.ubuntu.com/ubuntu noble main restricted universe multiverse
+deb-src http://archive.ubuntu.com/ubuntu noble-security main restricted universe multiverse
+deb-src http://archive.ubuntu.com/ubuntu noble-updates main restricted universe multiverse
+deb-src http://archive.ubuntu.com/ubuntu noble-proposed main restricted universe multiverse
+deb-src http://archive.ubuntu.com/ubuntu noble-backports main restricted universe multiverse
 
-deb https://download.docker.com/linux/ubuntu focal stable
-deb https://nvidia.github.io/nvidia-docker/ubuntu20.04/amd64 /
-deb https://nvidia.github.io/libnvidia-container/stable/ubuntu20.04/amd64 /
-deb https://nvidia.github.io/nvidia-container-runtime/stable/ubuntu20.04/amd64 /
+deb https://download.docker.com/linux/ubuntu noble stable
+deb https://nvidia.github.io/libnvidia-container/stable/deb/amd64 /
 
-deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64 /
+deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/x86_64 /
 
-deb http://repo.download.nvidia.com/baseos/ubuntu/focal/x86_64/ focal common dgx
-deb http://repo.download.nvidia.com/baseos/ubuntu/focal/x86_64/ focal-updates common dgx
+deb http://repo.download.nvidia.com/baseos/ubuntu/noble/x86_64/ noble common dgx
+deb http://repo.download.nvidia.com/baseos/ubuntu/noble/x86_64/ noble-updates common dgx
 
 clean http://archive.ubuntu.com/ubuntu
 clean https://download.docker.com
@@ -266,10 +276,10 @@ sudo mkdir /var/www/html/repos
 
 Then, from the extracted mirror directory,
 copy the directories for each repository into the web root.
-For example, assuming the extracted mirror directory is `/var/repos` and the repository is `nvidia-docker`:
+For example, assuming the extracted mirror directory is `/var/repos` and the repository is `libnvidia-container`:
 
 ```bash
-sudo cp -r /var/repos/mirror/nvidia.github.com/nvidia-docker/ /var/www/html/repos/nvidia-docker/
+sudo cp -r /var/repos/mirror/nvidia.github.io/libnvidia-container/ /var/www/html/repos/libnvidia-container/
 ```
 
 At this point, the downloaded package repositories should be available on your offline network via the package server.
@@ -278,29 +288,27 @@ You can then add these downloaded repos to the `/etc/apt/sources.list` configura
  Line added to `/etc/apt/sources.list`:
 
 ```
-deb http://repo-server/ubuntu focal main restricted universe multiverse
-deb http://repo-server/ubuntu focal-updates main restricted universe multiverse
-deb http://repo-server/ubuntu focal-backports main restricted universe multiverse
-deb http://repo-server/ubuntu focal-security main restricted universe multiverse
+deb http://repo-server/ubuntu noble main restricted universe multiverse
+deb http://repo-server/ubuntu noble-updates main restricted universe multiverse
+deb http://repo-server/ubuntu noble-backports main restricted universe multiverse
+deb http://repo-server/ubuntu noble-security main restricted universe multiverse
 ```
 
 Lines added to `/etc/apt/sources.list.d/dgx.list`:
 
 ```
-deb http://repo-server/baseos/ubuntu/focal/x86_64/ focal common dgx
-deb http://repo-server/baseos/ubuntu/focal/x86_64/ focal-updates common dgx
+deb http://repo-server/baseos/ubuntu/noble/x86_64/ noble common dgx
+deb http://repo-server/baseos/ubuntu/noble/x86_64/ noble-updates common dgx
 ```
 
 Lines added to `/etc/apt/sources.list.d/cuda-compute-repo.list`:
 
 ```
-deb http://repo-server/cuda/repos/ubuntu2004/x86_64/ /
+deb http://repo-server/cuda/repos/ubuntu2404/x86_64/ /
 ```
 
-Lines add to `/etc/apt/sources.list.d/nvidia-docker.list`:
+Lines add to `/etc/apt/sources.list.d/nvidia-container-toolkit.list`:
 
 ```
-deb  [trusted=yes] http://repo-server/libnvidia-container/stable/ubuntu20.04/amd64 /
-deb  [trusted=yes] http://repo-server/nvidia-container-runtime/stable/ubuntu20.04/amd64 /
-deb  [trusted=yes] http://repo-server/nvidia-docker/ubuntu20.04/amd64 /
+deb  [trusted=yes] http://repo-server/libnvidia-container/stable/deb/amd64 /
 ```

--- a/docs/airgap/ngc-ready.md
+++ b/docs/airgap/ngc-ready.md
@@ -24,7 +24,7 @@ The following Apt repositories will need to be mirrored in the offline environme
 
 - Ubuntu distribution repositories
 - Docker CE repository
-- nvidia-docker repositories
+- NVIDIA container runtime repositories
 
 For instructions on mirroring these repositories, see the [doc on Apt mirrors](./mirror-apt-repos.md).
 
@@ -49,7 +49,7 @@ The following RPM repositories will need to be mirrored in the offline environme
 
 - Enterprise Linux distribution repositories (RHEL or CentOS, depending on your distro)
 - Docker CE repository
-- nvidia-docker repositories
+- NVIDIA container runtime repositories
 
 For instructions on mirroring these repositories, see the [doc on RPM mirrors](./mirror-rpm-repos.md).
 
@@ -123,7 +123,7 @@ In all cases, you should edit the URLs appropriately to ensure they can download
 
 ### Configure DeepOps to use your mirrors for non-distribution package repositories
 
-The NGC-Ready playbook depends on the Docker CE and nvidia-docker package repositories.
+The NGC-Ready playbook depends on the Docker CE and NVIDIA container runtime package repositories.
 DeepOps sets up these repositories automatically during the installation.
 
 To configure alternate URLs for these repositories, set the following variables in your DeepOps configuration:

--- a/docs/deepops/testing.md
+++ b/docs/deepops/testing.md
@@ -51,6 +51,8 @@ A short description of the nightly testing is outlined below. The full suit of t
 | --------------------------------------------------- | ----------------------------------------- | ------------------------------------------------------ | ----------------------------------------------------------------------- | ------------------------------------ |
 | Ubuntu 18.04                                        | x                                         | x                                                      | x                                                                       |                                      |
 | Ubuntu 20.04                                        |                                           | x                                                      | x                                                                       |                                      |
+| Ubuntu 22.04                                        |                                           |                                                        |                                                                         | setup.sh and Molecule GitHub Actions |
+| Ubuntu 24.04                                        |                                           |                                                        |                                                                         | setup.sh and Molecule GitHub Actions |
 | CentOS 7                                            |                                           | x                                                      | x                                                                       |                                      |
 | CentOS                                              |                                           |                                                        | x                                                                       |                                      |
 | DGX OS                                              |                                           |                                                        |                                                                         | Syntax-checked only; full validation requires DGX hardware |
@@ -118,7 +120,8 @@ molecule init scenario -r <your-role> --driver-name docker
 ```
 
 4. In the file `molecule/default/molecule.yml`, define the list of platforms to be tested.
-   DeepOps currently supports operating systems based on Ubuntu 18.04, Ubuntu 20.04, EL7, and EL8.
+   DeepOps currently supports operating systems based on Ubuntu 18.04, Ubuntu 20.04, Ubuntu 22.04, Ubuntu 24.04, EL7, and EL8.
+   The DGX software stack role also supports Red Hat Enterprise Linux / Rocky Linux 8 and 9 for DGX platform software installation.
    To test these stacks, the following `platforms` stanza can be used.
 
 ```yaml
@@ -128,6 +131,12 @@ platforms:
     pre_build_image: true
   - name: ubuntu-2004
     image: geerlingguy/docker-ubuntu2004-ansible
+    pre_build_image: true
+  - name: ubuntu-2204
+    image: geerlingguy/docker-ubuntu2204-ansible
+    pre_build_image: true
+  - name: ubuntu-2404
+    image: geerlingguy/docker-ubuntu2404-ansible
     pre_build_image: true
   - name: centos-7
     image: geerlingguy/docker-centos7-ansible

--- a/docs/ngc-ready/README.md
+++ b/docs/ngc-ready/README.md
@@ -15,6 +15,8 @@ These instructions assume the following:
 - You have a NGC-Ready server. To determine if your server is NGC-Ready, please review the list of validated servers at the NGC-Ready Server documentation page - https://docs.nvidia.com/certification-programs/ngc-ready-systems/index.html
 - Your NGC-Ready Server has a compatible Linux distribution installed:
   - Ubuntu Server 20.04 LTS
+  - Ubuntu Server 22.04 LTS
+  - Ubuntu Server 24.04 LTS
   - CentOS 7
 
 ## Setup

--- a/docs/slurm-cluster/slurm-single-node.md
+++ b/docs/slurm-cluster/slurm-single-node.md
@@ -15,7 +15,7 @@ Single Node Slurm Deployment Guide
 
 ## Introduction
 
-The general requirements and procedure for Slurm setup via deepops is documented in the [README.md](README.md) for the slurm-cluster. The instructions below outline the steps to deviate from the general setup to enable single node DeepOps Slurm setup. The machine on which Slurm is being deployed should be up to date in a stable state with GPU drivers already installed and functional. The supported Operating Systems are Ubuntu (version 18 and 20), CentOS and RHEL (version 7 and 8 albeit version 8 is preferred).
+The general requirements and procedure for Slurm setup via deepops is documented in the [README.md](README.md) for the slurm-cluster. The instructions below outline the steps to deviate from the general setup to enable single node DeepOps Slurm setup. The machine on which Slurm is being deployed should be up to date in a stable state with GPU drivers already installed and functional. The supported operating systems are Ubuntu 18.04, 20.04, 22.04, and 24.04; CentOS 7 and 8; and RHEL 7 and 8, with RHEL 8 preferred among the RHEL paths.
 
 ## Deployment Procedure
 

--- a/playbooks/container/nvidia-docker.yml
+++ b/playbooks/container/nvidia-docker.yml
@@ -16,10 +16,19 @@
         state: absent
       when: docker_install | default('yes')
 
+    - name: install NVIDIA Container Toolkit on Ubuntu 24.04 and newer
+      include_role:
+        name: nvidia_container_toolkit
+      when:
+        - ansible_local['gpus']['count'] and ansible_distribution == "Ubuntu"
+        - ansible_distribution_version is version('24.04', '>=')
+        - docker_install | default('yes')
+
     - name: install nvidia-docker
       include_role:
         name: nvidia.nvidia_docker
       when:
         - ansible_local['gpus']['count'] and (ansible_distribution == "Ubuntu" or ansible_os_family == "RedHat")
+        - not (ansible_distribution == "Ubuntu" and ansible_distribution_version is version('24.04', '>='))
         - docker_install | default('yes')
   environment: "{{ proxy_env if proxy_env is defined else {} }}"

--- a/roles/nvidia_container_toolkit/defaults/main.yml
+++ b/roles/nvidia_container_toolkit/defaults/main.yml
@@ -1,0 +1,10 @@
+---
+nvidia_container_toolkit_repo_base_url: "https://nvidia.github.io/libnvidia-container"
+nvidia_container_toolkit_repo_gpg_url: "{{ nvidia_container_toolkit_repo_base_url }}/gpgkey"
+nvidia_container_toolkit_keyring_ascii_path: "/usr/share/keyrings/nvidia-container-toolkit-keyring.asc"
+nvidia_container_toolkit_keyring_path: "/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg"
+nvidia_container_toolkit_apt_source_path: "/etc/apt/sources.list.d/nvidia-container-toolkit.list"
+nvidia_container_toolkit_package: "nvidia-container-toolkit"
+nvidia_container_toolkit_configure_docker: true
+nvidia_container_toolkit_set_as_default_runtime: true
+nvidia_container_toolkit_restart_docker: true

--- a/roles/nvidia_container_toolkit/handlers/main.yml
+++ b/roles/nvidia_container_toolkit/handlers/main.yml
@@ -1,0 +1,6 @@
+---
+- name: restart docker
+  ansible.builtin.service:
+    name: docker
+    state: restarted
+  when: nvidia_container_toolkit_restart_docker | bool

--- a/roles/nvidia_container_toolkit/tasks/main.yml
+++ b/roles/nvidia_container_toolkit/tasks/main.yml
@@ -1,0 +1,114 @@
+---
+- name: Ubuntu | verify supported distribution
+  ansible.builtin.assert:
+    that:
+      - ansible_distribution == "Ubuntu"
+    fail_msg: "The nvidia_container_toolkit role currently supports Ubuntu only."
+
+- name: Ubuntu | set package architecture
+  ansible.builtin.set_fact:
+    nvidia_container_toolkit_deb_arch: "{{ _nvidia_container_toolkit_arch_map.get(ansible_architecture, ansible_architecture) }}"
+  vars:
+    _nvidia_container_toolkit_arch_map:
+      aarch64: arm64
+      arm64: arm64
+      x86_64: amd64
+
+- name: Ubuntu | install repository prerequisites
+  ansible.builtin.apt:
+    name:
+      - ca-certificates
+      - gnupg
+    state: present
+    update_cache: true
+  when: nvidia_container_toolkit_repo_base_url | length > 0
+
+- name: Ubuntu | ensure keyring directory exists
+  ansible.builtin.file:
+    path: "{{ nvidia_container_toolkit_keyring_path | dirname }}"
+    state: directory
+    owner: root
+    group: root
+    mode: "0755"
+
+- name: Ubuntu | check NVIDIA Container Toolkit keyring
+  ansible.builtin.stat:
+    path: "{{ nvidia_container_toolkit_keyring_path }}"
+  register: nvidia_container_toolkit_keyring
+
+- name: Ubuntu | download NVIDIA Container Toolkit GPG key
+  ansible.builtin.get_url:
+    url: "{{ nvidia_container_toolkit_repo_gpg_url }}"
+    dest: "{{ nvidia_container_toolkit_keyring_ascii_path }}"
+    owner: root
+    group: root
+    mode: "0644"
+  register: nvidia_container_toolkit_key
+  environment: "{{ proxy_env if proxy_env is defined else {} }}"
+
+- name: Ubuntu | install NVIDIA Container Toolkit GPG keyring
+  ansible.builtin.command:
+    cmd: "gpg --dearmor --yes -o {{ nvidia_container_toolkit_keyring_path }} {{ nvidia_container_toolkit_keyring_ascii_path }}"
+  when: nvidia_container_toolkit_key.changed or not nvidia_container_toolkit_keyring.stat.exists
+  register: nvidia_container_toolkit_keyring_install
+  changed_when: true
+
+- name: Ubuntu | set NVIDIA Container Toolkit GPG keyring permissions
+  ansible.builtin.file:
+    path: "{{ nvidia_container_toolkit_keyring_path }}"
+    owner: root
+    group: root
+    mode: "0644"
+
+- name: Ubuntu | configure NVIDIA Container Toolkit APT repository
+  ansible.builtin.copy:
+    content: |
+      deb [signed-by={{ nvidia_container_toolkit_keyring_path }}] {{ nvidia_container_toolkit_repo_base_url }}/stable/deb/{{ nvidia_container_toolkit_deb_arch }} /
+    dest: "{{ nvidia_container_toolkit_apt_source_path }}"
+    owner: root
+    group: root
+    mode: "0644"
+  register: nvidia_container_toolkit_apt_source
+
+- name: Ubuntu | install NVIDIA Container Toolkit
+  ansible.builtin.apt:
+    name: "{{ nvidia_container_toolkit_package }}"
+    state: present
+    update_cache: "{{ nvidia_container_toolkit_apt_source.changed or nvidia_container_toolkit_keyring_install.changed | default(false) }}"
+  environment: "{{ proxy_env if proxy_env is defined else {} }}"
+
+- name: Docker | ensure Docker configuration directory exists
+  ansible.builtin.file:
+    path: /etc/docker
+    state: directory
+    owner: root
+    group: root
+    mode: "0755"
+  when: nvidia_container_toolkit_configure_docker | bool
+
+- name: Docker | check NVIDIA runtime configuration
+  ansible.builtin.command:
+    cmd: >-
+      python3 -c 'import json, pathlib, sys;
+      p = pathlib.Path("/etc/docker/daemon.json");
+      required_default = {{ nvidia_container_toolkit_set_as_default_runtime | bool | ternary("True", "False") }};
+      data = {};
+      text = p.read_text().strip() if p.exists() else "";
+      data = json.loads(text) if text else {};
+      runtime = data.get("runtimes", {}).get("nvidia", {});
+      ok = runtime.get("path") in ("nvidia-container-runtime", "/usr/bin/nvidia-container-runtime");
+      ok = ok and (not required_default or data.get("default-runtime") == "nvidia");
+      sys.exit(0 if ok else 1)'
+  register: nvidia_container_toolkit_docker_runtime
+  failed_when: false
+  changed_when: false
+  when: nvidia_container_toolkit_configure_docker | bool
+
+- name: Docker | configure NVIDIA runtime
+  ansible.builtin.command:
+    cmd: "nvidia-ctk runtime configure --runtime=docker{{ ' --set-as-default' if nvidia_container_toolkit_set_as_default_runtime | bool else '' }}"
+  when:
+    - nvidia_container_toolkit_configure_docker | bool
+    - nvidia_container_toolkit_docker_runtime.rc != 0
+  changed_when: true
+  notify: restart docker


### PR DESCRIPTION
## Summary
- add an Ubuntu 24.04+ container-runtime path that installs NVIDIA Container Toolkit from the current libnvidia-container APT repository and configures Docker with `nvidia-ctk`
- keep the legacy `nvidia.nvidia_docker` role path for Ubuntu 22.04 and older plus Red Hat family hosts
- refresh Ubuntu 24.04/Noble testing and airgap package mirror docs

Related to #1333.

## Validation
- `ansible-playbook --syntax-check playbooks/container/nvidia-docker.yml`
- `./scripts/deepops/ansible-lint-roles.sh`
- `make public-sanitize RELEASE=26.07 WORKTREE=<worktree>`
- live Ubuntu 24.04.4 GPU server validation:
  - Docker playbook completed: `ok=40 changed=10 failed=0`
  - NVIDIA driver playbook completed with the proprietary 580 server path on the Pascal test GPU: `ok=18 changed=2 failed=0`
  - `playbooks/container/nvidia-docker.yml` completed through the new Container Toolkit role path: `ok=21 changed=6 failed=0`
  - idempotence rerun completed: `ok=18 changed=0 failed=0`
  - `docker run --gpus=all --rm nvcr.io/nvidia/cuda:12.8.1-base-ubuntu24.04 nvidia-smi` passed