### PR TITLE
Refresh Container Toolkit airgap docs

### DIFF
--- a/docs/airgap/mirror-http-files.md
+++ b/docs/airgap/mirror-http-files.md
@@ -34,8 +34,7 @@ Then, for any files you need to make available for download, simply copy these f
 To configure DeepOps to make use of this server, you will need to configure the specific variables for the download URL of each file.
 The best place to find these variables is the `defaults/main.yml` file of each role you plan to make use of.
 
-For example, in the [nvidia-docker role](https://github.com/NVIDIA/ansible-role-nvidia-docker), the wrapper script is downloaded from the [nvidia-docker Github repositories](https://raw.githubusercontent.com/NVIDIA/nvidia-docker/master/nvidia-docker).
-
-To mirror this file offline, you would download the script and place it on your offline repo server, then configure the `nvidia_docker_wrapper_url` variable with the alternate URL.
+Current NVIDIA Container Toolkit installs use package repositories and `nvidia-ctk` runtime configuration rather than a standalone wrapper script.
+Mirror those package repositories with the Apt or RPM mirror workflows, then point the `nvidia_container_toolkit_*` repository variables at your local mirrors.
 
 Documentation on specific offline workflows (such as the [NGC ready offline doc](./ngc-ready.md)) may list specific files that need to be downloaded for those workflows.

--- a/docs/airgap/ngc-ready.md
+++ b/docs/airgap/ngc-ready.md
@@ -28,9 +28,8 @@ The following Apt repositories will need to be mirrored in the offline environme
 
 For instructions on mirroring these repositories, see the [doc on Apt mirrors](./mirror-apt-repos.md).
 
-The following files will need to be downloaded and made available in an HTTP mirror:
+The following files may need to be downloaded and made available in an HTTP mirror:
 
-- nvidia-docker wrapper (found [here](https://raw.githubusercontent.com/NVIDIA/nvidia-docker/master/nvidia-docker))
 - DCGM package (optional)
 
 For instructions on setting up an HTTP mirror, see the [doc on HTTP mirrors](./mirror-http-files.md).
@@ -53,10 +52,9 @@ The following RPM repositories will need to be mirrored in the offline environme
 
 For instructions on mirroring these repositories, see the [doc on RPM mirrors](./mirror-rpm-repos.md).
 
-The following files will need to be downloaded and made available in an HTTP mirror:
+The following files may need to be downloaded and made available in an HTTP mirror:
 
 - EPEL package (found [here](https://fedoraproject.org/wiki/EPEL))
-- nvidia-docker wrapper (found [here](https://raw.githubusercontent.com/NVIDIA/nvidia-docker/master/nvidia-docker))
 - DCGM package (optional)
 
 For instructions on setting up an HTTP mirror, see the [doc on HTTP mirrors](./mirror-http-files.md).
@@ -134,8 +132,8 @@ To configure alternate URLs for these repositories, set the following variables 
 docker_ubuntu_repo_base_url: "http://<your-package-mirror>/<your-path-to-docker-repo>"
 docker_ubuntu_repo_gpgkey: "http://<your-package-mirror>/<your-path-to-docker-gpgkey>"
 
-nvidia_docker_repo_base_url: "http://<your-package-mirror>/<your-path-to-nvidia-docker-base-dir>"
-nvidia_docker_repo_gpg_url: "http://<your-package-mirror>/<your-path-to-nvidia-docker-gpgkey>"
+nvidia_container_toolkit_repo_base_url: "http://<your-package-mirror>/<your-path-to-libnvidia-container>"
+nvidia_container_toolkit_repo_gpg_url: "http://<your-package-mirror>/<your-path-to-libnvidia-container-gpgkey>"
 ```
 
 **Enterprise Linux**
@@ -144,17 +142,13 @@ nvidia_docker_repo_gpg_url: "http://<your-package-mirror>/<your-path-to-nvidia-d
 docker_rh_repo_base_url: "http://<your-package-mirror>/<your-path-to-docker-repo>"
 docker_rh_repo_gpgkey: "http://<your-package-mirror>/<your-path-to-docker-gpgkey>"
 
-nvidia_docker_repo_base_url: "http://<your-package-mirror>/<your-path-to-nvidia-docker-base-dir>"
-nvidia_docker_repo_gpg_url: "http://<your-package-mirror>/<your-path-to-nvidia-docker-gpgkey>"
+nvidia_container_toolkit_rpm_repo_url: "http://<your-package-mirror>/<your-path-to-nvidia-container-toolkit.repo>"
 ```
 
 ### Configure DeepOps to use your mirrors for HTTP downloads
 
-In all cases, you will need to provide a URL to download the nvidia-docker wrapper:
-
-```bash
-nvidia_docker_wrapper_url: "http://<your-http-mirror>/<your-path>/nvidia-docker"
-```
+Current NVIDIA Container Toolkit installs do not need a standalone `nvidia-docker` wrapper file.
+Use this section only for other direct HTTP downloads required by the roles you enable.
 
 If installing on Enterprise Linux, you will need to provide a URL for the EPEL package.
 For example,


### PR DESCRIPTION
## Summary

Refreshes airgap documentation to match the current NVIDIA Container Toolkit path. The docs now point users toward mirrored package repositories and `nvidia-ctk` runtime configuration instead of the old standalone `nvidia-docker` wrapper.

This PR is now retargeted to `master` after #1350 merged.

## Validation

- Rebased onto current `master` after #1350 merged.
- `git diff --check origin/master...HEAD`
- Public sanitizer passed for the generated PR body and the two touched docs.
- Targeted stale-wrapper search passed for the touched docs.
- OS compatibility audit summary after this branch: `high=2`, `medium=28`, `low=79`.

Remaining high audit findings are legacy DGX package-list entries for Ubuntu 18.04/20.04, not the airgap docs updated here.
