### PR TITLE
fix: handle non-dict parsed JSON in firmware version manifest parser

### DIFF
--- a/roles/nvidia-dgx-firmware/files/parse_manifest.py
+++ b/roles/nvidia-dgx-firmware/files/parse_manifest.py
@@ -3,7 +3,7 @@
 import json
 
 from collections import OrderedDict
-from sys import argv
+from sys import argv, exit
 
 
 def return_json(payload):
@@ -173,6 +173,11 @@ if argv[1] == 'parse_versioning':
             manifest_json = json.loads(line)
         except ValueError:
             pass
+
+    if not isinstance(manifest_json, dict):
+        print('No JSON could be loaded, is the container already running?')
+        exit(1)
+
     try:
         if manifest_json['ErrorWritingVersioning']:
             print('No JSON could be loaded, is the container already running?')

--- a/roles/nvidia-dgx-firmware/tests/test_parse_manifest.py
+++ b/roles/nvidia-dgx-firmware/tests/test_parse_manifest.py
@@ -1,0 +1,34 @@
+import subprocess
+import sys
+import tempfile
+import unittest
+
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).resolve().parents[1] / 'files' / 'parse_manifest.py'
+
+
+class ParseManifestTest(unittest.TestCase):
+    def test_parse_versioning_rejects_non_dict_json(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            manifest = Path(temp_dir) / 'versioning.json'
+            manifest.write_text('[1,2,3]\n')
+
+            result = subprocess.run(
+                [sys.executable, str(SCRIPT), 'parse_versioning', str(manifest)],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                universal_newlines=True,
+            )
+
+        self.assertEqual(result.returncode, 1)
+        self.assertEqual(
+            result.stdout,
+            'No JSON could be loaded, is the container already running?\n',
+        )
+        self.assertEqual(result.stderr, '')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- `roles/nvidia-dgx-firmware/files/parse_manifest.py` `parse_versioning` keeps the last `json.loads`-parseable line from the firmware container output, then indexes it with a string key (`manifest_json['ErrorWritingVersioning']`).
- If that last parseable line decodes to a non-dict (e.g. a JSON array), the string-key index raises `TypeError`. Only `KeyError` was caught, so the exception escaped and aborted the task.
- Guard that the parsed value is a `dict` before indexing; a non-dict now falls through to the existing "No JSON could be loaded" path and exits `1` cleanly instead of crashing.

## Validation
- `git diff --check origin/master...HEAD`
- `py_compile` of the changed script
- Reproduced the crash before the fix (non-dict last line → uncaught `TypeError`) and confirmed the clean `exit 1` after the fix.
- Added a self-contained regression test and ran it:
  `python -m unittest discover -s roles/nvidia-dgx-firmware/tests -v` → `Ran 1 test ... OK`
- Public sanitizer pass on the PR body and added diff lines.

## Notes
- Behavior is unchanged for well-formed manifests; this only hardens the parser against malformed/non-dict input.
- No pre-existing tests covered this script/role; the new test uses only the standard library and a tempfile, no external fixtures.
