### PR TITLE
fix: restart containerized exporters when Docker restarts

### DIFF
--- a/roles/alertmanager/templates/docker.alertmanager.service.j2
+++ b/roles/alertmanager/templates/docker.alertmanager.service.j2
@@ -2,6 +2,7 @@
 Description=Alert Manager
 After=docker.service
 Requires=docker.service
+PartOf=docker.service
 
 [Service]
 TimeoutStartSec=0

--- a/roles/grafana/templates/docker.grafana.service.j2
+++ b/roles/grafana/templates/docker.grafana.service.j2
@@ -2,6 +2,7 @@
 Description=Grafana
 After=docker.service
 Requires=docker.service
+PartOf=docker.service
 
 [Service]
 TimeoutStartSec=0

--- a/roles/nvidia-dcgm-exporter/templates/docker.dcgm-exporter.service.j2
+++ b/roles/nvidia-dcgm-exporter/templates/docker.dcgm-exporter.service.j2
@@ -2,6 +2,7 @@
 Description=NVIDIA DCGM Exporter
 After=docker.service
 Requires=docker.service
+PartOf=docker.service
 
 [Service]
 TimeoutStartSec=0

--- a/roles/prometheus-node-exporter/templates/docker.node-exporter.service.j2
+++ b/roles/prometheus-node-exporter/templates/docker.node-exporter.service.j2
@@ -2,6 +2,7 @@
 Description=Prometheus Node Exporter
 After=docker.service
 Requires=docker.service
+PartOf=docker.service
 
 [Service]
 TimeoutStartSec=0

--- a/roles/prometheus-slurm-exporter/templates/docker.slurm-exporter.service.j2
+++ b/roles/prometheus-slurm-exporter/templates/docker.slurm-exporter.service.j2
@@ -2,6 +2,7 @@
 Description=Prometheus Slurm Exporter
 After=docker.service
 Requires=docker.service
+PartOf=docker.service
 
 [Service]
 TimeoutStartSec=0

--- a/roles/prometheus/templates/docker.prometheus.service.j2
+++ b/roles/prometheus/templates/docker.prometheus.service.j2
@@ -2,6 +2,7 @@
 Description=Prometheus
 After=docker.service
 Requires=docker.service
+PartOf=docker.service
 
 [Service]
 TimeoutStartSec=0


### PR DESCRIPTION
## Summary
- Add `PartOf=docker.service` to the six containerized monitoring service units (node exporter, DCGM exporter, Slurm exporter, Prometheus, Grafana, Alertmanager).
- Root cause of #1267: the units declare `Requires=docker.service` without `PartOf=`, so an explicit Docker restart propagates as a one-way stop to the dependents and nothing starts them again. A first `slurm-cluster.yml` run on GPU nodes triggers exactly this — the NVIDIA container runtime configuration restarts Docker after the node exporter is already up — leaving exporters down until reboot.
- With `PartOf=`, a Docker restart propagates as a restart, so the units come back automatically (including after any manual `systemctl restart docker`).

## Validation
- `git diff --check`; full role lint: 0 failures, 0 warnings.
- Live single-node GPU validation summary will be posted as a follow-up comment before review: fresh `slurm-cluster.yml` run, then asserting the node exporter is active at the end of the run and recovers after an explicit Docker restart.

## Notes
- Fixes #1267 (stale-closed; the maintainer had twice marked it "not stale" — the failure mode is present on master until this change).
- One line per unit; no change to start ordering or normal operation.
