### PR TITLE
fix: make memory fact locale-safe and integer-valued

### DIFF
--- a/roles/facts/files/memory.fact
+++ b/roles/facts/files/memory.fact
@@ -1,2 +1,5 @@
 #!/bin/bash
-echo "{ \"total_mb\": $(free -m | grep Mem: | awk '{print $2*0.95}') }"
+# printf "%d" keeps the value an integer regardless of locale: the default
+# awk print emits a float whose decimal separator follows LC_NUMERIC, which
+# on comma-decimal locales produces invalid JSON and breaks the local fact.
+echo "{ \"total_mb\": $(free -m | awk '/^Mem:/ {printf "%d", $2*0.95}') }"

--- a/roles/slurm/templates/etc/slurm/slurm.conf
+++ b/roles/slurm/templates/etc/slurm/slurm.conf
@@ -133,6 +133,10 @@ GresTypes=gpu
 {% endif %}
 {% for node_name in groups['slurm-node'] %}
 {% set memory =  hostvars[node_name]["ansible_local"]["memory"] -%}
+{# If the custom fact failed JSON parsing Ansible hands us a string;
+   parse it here so a bad fact fails loudly instead of with an opaque
+   attribute error on total_mb. -#}
+{% if memory is string %}{% set memory = memory | from_json -%}{% endif -%}
 {% set cpu_topology =  hostvars[node_name]["ansible_local"]["topology"]["cpu_topology"] -%}
 {% set gpu_topology =  hostvars[node_name]["ansible_local"]["topology"]["gpu_topology"] -%}
     NodeName={{ node_name }}{{ " " -}}


### PR DESCRIPTION
## Summary
- Make the `memory` custom fact locale-safe and integer-valued: compute `total_mb` with `awk printf "%d"` instead of the default float `print`.
- Root cause of #1321: awk's default output renders floats using the host's `LC_NUMERIC` decimal separator. On comma-decimal locales the fact emitted `{ "total_mb": 60760,1 }` — invalid JSON — so Ansible silently provided the fact as a raw string and `slurm.conf` templating failed with the reported `AnsibleUnsafeText ... has no attribute 'total_mb'` error. This also explains why the error only reproduced for some users: it depends on the host locale.
- Harden the `slurm.conf` template to parse a string-typed fact (`from_json`) so any future malformed fact fails clearly instead of with an opaque attribute error.

## Validation
- `bash -n` on the fact script; the fact output parses as JSON with an integer `total_mb`.
- Demonstrated the defect mechanism: `awk '{print $2*0.95}'` emits `60760.1` (locale-dependent separator), `printf "%d"` cannot emit a separator.
- `ansible-playbook --syntax-check playbooks/slurm-cluster.yml`; full role lint: 0 failures.
- Live single-node GPU validation summary will be posted as a follow-up comment before review: fresh Slurm deployment asserting `RealMemory` templates as an integer and the fact parses under a comma-decimal locale on the deployed node.

## Notes
- Fixes #1321. `printf "%d"` truncates toward zero, preserving the intended 5% headroom; output is unchanged on hosts where the value was already integral.
