### PR TITLE
Replace third-party MAAS role with a DeepOps-owned controller role

### DIFF
--- a/config.example/group_vars/all.yml
+++ b/config.example/group_vars/all.yml
@@ -257,20 +257,7 @@ maas_region_controller_url: 'http://{{ maas_region_controller }}:5240/MAAS'
 # controller itself still runs Ubuntu 22.04.
 maas_repo: "{{ 'ppa:maas/3.7' if ansible_distribution_version is version('24.04', '>=') else 'ppa:maas/3.5' }}"
 
-# Defines if maas user should generate ssh keys
-# Usable for remote KVM/libvirt power actions
-maas_setup_user: false
-
 maas_single_node_install: true
-
-maas_kvm_management: false
-
-# Avoid installing python-libmaas via pip: it shadows the packaged MAAS CLI
-# with /usr/local/bin/maas, which breaks DeepOps' MAAS operational workflow.
-maas_python_reqs:
-  - jinja2
-  - oauth
-  - pyyaml
 
 ################################################################################
 # NVIDIA Datacenter GPU Manager                                                #

--- a/playbooks/provisioning/maas.yml
+++ b/playbooks/provisioning/maas.yml
@@ -2,4 +2,4 @@
 - hosts: all
   become: yes
   roles:
-    - role: ansible-maas
+    - role: maas-controller

--- a/roles/maas-controller/defaults/main.yml
+++ b/roles/maas-controller/defaults/main.yml
@@ -1,0 +1,15 @@
+---
+# MAAS 3.7 is the current Ubuntu 24.04 line. Keep the 3.5 PPA when the MAAS
+# controller itself still runs Ubuntu 22.04.
+maas_repo: "{{ 'ppa:maas/3.7' if ansible_distribution_version is version('24.04', '>=') else 'ppa:maas/3.5' }}"
+
+# This role installs a single-node MAAS controller only. Multi-node
+# region/rack topologies are site-owned; see docs/pxe/maas.md.
+maas_single_node_install: true
+
+# Admin accounts to create on first install. Define real credentials in
+# config/group_vars; see config.example/group_vars/all.yml.
+maas_adminusers: []
+
+# URL the region controller advertises to nodes.
+maas_region_controller_url: "http://{{ ansible_default_ipv4.address }}:5240/MAAS"

--- a/roles/maas-controller/handlers/main.yml
+++ b/roles/maas-controller/handlers/main.yml
@@ -1,0 +1,5 @@
+---
+- name: restart maas-regiond
+  service:
+    name: maas-regiond
+    state: restarted

--- a/roles/maas-controller/tasks/main.yml
+++ b/roles/maas-controller/tasks/main.yml
@@ -1,0 +1,51 @@
+---
+- name: check supported install mode
+  assert:
+    that: maas_single_node_install | bool
+    fail_msg: >-
+      This role installs a single-node MAAS controller only. Multi-node
+      region/rack topologies should be deployed per the upstream MAAS
+      documentation.
+
+- name: add MAAS repository
+  apt_repository:
+    repo: "{{ maas_repo }}"
+    state: present
+
+- name: install MAAS
+  apt:
+    name: maas
+    state: present
+    update_cache: true
+
+- name: check whether admin accounts were created
+  stat:
+    path: /etc/maas/.admin_account_created
+  register: maas_admin_account_check
+
+- name: create MAAS admin accounts
+  command: >-
+    maas createadmin
+    --username {{ item.username }}
+    --email {{ item.email }}
+    --password {{ item.password }}
+  loop: "{{ maas_adminusers }}"
+  loop_control:
+    label: "{{ item.username }}"
+  no_log: true
+  register: maas_admin_account_created
+  when: not maas_admin_account_check.stat.exists
+
+- name: mark admin accounts as created
+  file:
+    path: /etc/maas/.admin_account_created
+    state: touch
+    mode: "0644"
+  when: maas_admin_account_created is changed
+
+- name: configure region controller URL
+  lineinfile:
+    path: /etc/maas/regiond.conf
+    regexp: '^maas_url:'
+    line: "maas_url: {{ maas_region_controller_url }}"
+  notify: restart maas-regiond

--- a/roles/requirements.yml
+++ b/roles/requirements.yml
@@ -56,9 +56,6 @@ roles:
 - src: robertdebock.kibana
   version: "1.2.6"
 
-- src: https://github.com/mrlesmithjr/ansible-maas.git
-  name: ansible-maas
-  version: '178a999c9bfc979ef32c42f4f59c034664df10d0'
 
 - src: https://github.com/DeepOps/ansible-role-chrony
   name: DeepOps.chrony


### PR DESCRIPTION
## Summary
- Replace the third-party Galaxy MAAS role with a DeepOps-owned `maas-controller` role covering exactly the surface this repository uses: MAAS PPA, package install, idempotent admin-account creation, and region controller URL configuration (~70 lines).
- Why: the Galaxy role has had no functional MAAS changes since 2023; DeepOps exercised roughly six of its eighteen tasks; and its pip installation of unmaintained MAAS client modules — which DeepOps never uses — fails on Ubuntu 24.04 (PEP 668 externally-managed environments), blocking MAAS 3.7 on Noble controllers. Long-lived checkouts additionally risk running a stale on-disk copy of the role that predates the requirements pin and cannot execute on current Ansible at all.
- Drop-in compatible: variable names are unchanged for existing site configs, and the same admin-created marker file is honored so existing deployments do not re-create accounts. The unused `maas_setup_user` / `maas_kvm_management` / `maas_python_reqs` knobs are removed from the example config. The Galaxy dependency is removed from `roles/requirements.yml`.

## Validation
- Full role lint (0 failures); `playbooks/provisioning/maas.yml` syntax check passes with the Galaxy role uninstalled — the dependency is genuinely gone.
- Live MAAS smoke on a GPU server (Ubuntu 22.04): install and configuration via the new role (`ok=7, failed=0`), all MAAS services active, API responding (version 3.5.13, full capability list).

## Notes
- Multi-node region/rack topologies were never exercised by this repository and are explicitly out of scope (the role asserts single-node mode); sites needing them should follow upstream MAAS documentation.
- Ubuntu 24.04 / MAAS 3.7 controller validation is planned for the current release train; this change removes the known blocker.
