### PR TITLE
feat: report per-node validation detail

### DIFF
--- a/scripts/validation/tests/test_validation_scripts.py
+++ b/scripts/validation/tests/test_validation_scripts.py
@@ -51,18 +51,37 @@ class TestSlurmParsers(unittest.TestCase):
         out = "node1 gpu:4\nnode1 gpu:4\n"
         self.assertEqual(validate_slurm.parse_gres_gpus(out), 4)
 
+    def test_node_details_are_unique_normalized_and_sorted(self):
+        states = "node-b down*\nnode-a IDLE+\nnode-b idle\n"
+        gres = "node-b gpu:h100:8(S:0-1)\nnode-a gpu:2\nnode-b gpu:4\n"
+        self.assertEqual(
+            validate_slurm.build_node_details(states, gres),
+            [
+                {"name": "node-a", "state": "idle", "gpus_configured": 2},
+                {"name": "node-b", "state": "down", "gpus_configured": 8},
+            ],
+        )
+
+    def test_node_details_default_missing_gres_to_zero(self):
+        self.assertEqual(
+            validate_slurm.build_node_details("node1 mixed\n", ""),
+            [{"name": "node1", "state": "mixed", "gpus_configured": 0}],
+        )
+
 
 class TestK8sParsers(unittest.TestCase):
     def test_summarize_nodes(self):
         doc = {
             "items": [
                 {
+                    "metadata": {"name": "node-a"},
                     "status": {
                         "conditions": [{"type": "Ready", "status": "True"}],
                         "allocatable": {"nvidia.com/gpu": "8"},
                     }
                 },
                 {
+                    "metadata": {"name": "node-b"},
                     "status": {
                         "conditions": [{"type": "Ready", "status": "False"}],
                         "allocatable": {},
@@ -70,8 +89,57 @@ class TestK8sParsers(unittest.TestCase):
                 },
             ]
         }
-        total, ready, gpus = validate_k8s.summarize_nodes(doc)
+        total, ready, gpus, nodes = validate_k8s.summarize_nodes(doc)
         self.assertEqual((total, ready, gpus), (2, 1, 8))
+        self.assertEqual(
+            nodes,
+            [
+                {"name": "node-a", "ready": True, "gpus_allocatable": 8},
+                {"name": "node-b", "ready": False, "gpus_allocatable": 0},
+            ],
+        )
+
+    def test_summarize_nodes_details_are_sorted_and_malformed_gpus_are_zero(self):
+        doc = {
+            "items": [
+                {
+                    "metadata": {"name": "node-b"},
+                    "status": {
+                        "conditions": [{"type": "Ready", "status": "False"}],
+                        "allocatable": {"nvidia.com/gpu": None},
+                    },
+                },
+                {
+                    "metadata": {"name": "node-a"},
+                    "status": {
+                        "conditions": [{"type": "Ready", "status": "True"}],
+                        "allocatable": {"nvidia.com/gpu": "not-a-count"},
+                    },
+                },
+                {
+                    "metadata": {"name": "node-c"},
+                    "status": {
+                        "conditions": [{"type": "Ready", "status": "True"}],
+                        "allocatable": {"nvidia.com/gpu": "4"},
+                    },
+                },
+            ]
+        }
+        total, ready, gpus, nodes = validate_k8s.summarize_nodes(doc)
+        self.assertEqual((total, ready, gpus), (3, 2, 4))
+        self.assertEqual(
+            nodes,
+            [
+                {"name": "node-a", "ready": True, "gpus_allocatable": 0},
+                {"name": "node-b", "ready": False, "gpus_allocatable": 0},
+                {"name": "node-c", "ready": True, "gpus_allocatable": 4},
+            ],
+        )
+
+    def test_parse_gpu_count_rejects_other_malformed_values(self):
+        for value in (True, -1, "-2", 1.5, [], {}):
+            with self.subTest(value=value):
+                self.assertEqual(validate_k8s.parse_gpu_count(value), 0)
 
     def test_summarize_gpu_pods(self):
         doc = {

--- a/scripts/validation/validate_k8s.py
+++ b/scripts/validation/validate_k8s.py
@@ -7,8 +7,8 @@ Run this anywhere ``kubectl`` can reach the cluster after deploying
 CUDA smoke pod that requests one GPU.
 
 The default output is one human-readable line per check. With ``--json`` the
-script prints a single flat JSON object with stable field names so automation
-and AI agents can consume the result directly.
+script prints a JSON object with stable field names so automation and AI
+agents can consume the result directly.
 
 Exit codes: 0 = all checks passed, 1 = one or more checks failed,
 2 = usage or environment error (kubectl not found).
@@ -38,26 +38,47 @@ def run(cmd, timeout=60, input_text=None):
         return 127, "", "command not found: %s" % cmd[0]
 
 
+def parse_gpu_count(value):
+    """Return a non-negative integer GPU count, or zero if malformed."""
+    if isinstance(value, bool) or not isinstance(value, (int, str)):
+        return 0
+    try:
+        count = int(value)
+    except (ValueError, OverflowError):
+        return 0
+    return count if count >= 0 else 0
+
+
 def summarize_nodes(nodes_json):
     """Summarize a ``kubectl get nodes -o json`` document.
 
-    Returns (nodes_total, nodes_ready, gpus_allocatable).
+    Returns (nodes_total, nodes_ready, gpus_allocatable, nodes), where nodes
+    is a stable name-sorted list of per-node details.
     """
     total = ready = gpus = 0
+    nodes = []
     for item in nodes_json.get("items", []):
         total += 1
+        node_ready = False
         for cond in item.get("status", {}).get("conditions", []):
             if cond.get("type") == "Ready" and cond.get("status") == "True":
                 ready += 1
+                node_ready = True
                 break
         alloc = item.get("status", {}).get("allocatable", {})
-        try:
-            gpus += int(alloc.get("nvidia.com/gpu", "0"))
-        except ValueError:
-            # A malformed allocatable value counts as zero GPUs; the
-            # gpus_allocatable check will then fail loudly for this cluster.
-            continue
-    return total, ready, gpus
+        # A malformed allocatable value counts as zero GPUs; the aggregate
+        # gpus_allocatable check will then fail loudly for this cluster.
+        node_gpus = parse_gpu_count(alloc.get("nvidia.com/gpu", "0"))
+        gpus += node_gpus
+        nodes.append(
+            {
+                "name": item.get("metadata", {}).get("name", ""),
+                "ready": node_ready,
+                "gpus_allocatable": node_gpus,
+            }
+        )
+    nodes.sort(key=lambda node: node["name"])
+    return total, ready, gpus, nodes
 
 
 def summarize_gpu_pods(pods_json):
@@ -172,6 +193,7 @@ def main():
         "api_reachable": False,
         "nodes_total": 0,
         "nodes_ready": 0,
+        "nodes": [],
         "gpus_allocatable": 0,
         "gpu_stack_pods_total": 0,
         "gpu_stack_pods_ready": 0,
@@ -187,12 +209,14 @@ def main():
     else:
         result["api_reachable"] = True
         try:
-            total, ready, gpus = summarize_nodes(json.loads(out))
+            total, ready, gpus, nodes = summarize_nodes(json.loads(out))
         except json.JSONDecodeError:
             result["failures"].append("could not parse kubectl node output")
             total = ready = gpus = 0
+            nodes = []
         result["nodes_total"] = total
         result["nodes_ready"] = ready
+        result["nodes"] = nodes
         result["gpus_allocatable"] = gpus
         if total == 0:
             result["failures"].append("cluster reports zero nodes")

--- a/scripts/validation/validate_slurm.py
+++ b/scripts/validation/validate_slurm.py
@@ -6,8 +6,8 @@ Run this on a Slurm controller, login, or compute node after deploying
 health, GPU (GRES) configuration, and optionally runs a single-GPU job.
 
 The default output is one human-readable line per check. With ``--json`` the
-script prints a single flat JSON object with stable field names so automation
-and AI agents can consume the result directly.
+script prints a JSON object with stable field names so automation and AI
+agents can consume the result directly.
 
 Exit codes: 0 = all checks passed, 1 = one or more checks failed,
 2 = usage or environment error (Slurm commands not found).
@@ -39,6 +39,24 @@ def run(cmd, timeout=60):
         return 127, "", "command not found: %s" % cmd[0]
 
 
+def normalize_sinfo_state(state):
+    """Return a lowercase Slurm state without trailing status flags."""
+    return state.strip().rstrip("*+~#!%$@^-").lower()
+
+
+def parse_sinfo_node_states(output):
+    """Parse node states, keeping the first row for each unique node."""
+    nodes = {}
+    for line in output.splitlines():
+        parts = line.split()
+        if len(parts) != 2:
+            continue
+        node, state = parts
+        if node not in nodes:
+            nodes[node] = normalize_sinfo_state(state)
+    return nodes
+
+
 def parse_sinfo_states(output):
     """Parse ``sinfo -h -N -o '%n %T'`` output into node-state counts.
 
@@ -46,35 +64,46 @@ def parse_sinfo_states(output):
     states maps state name (lowercase, trailing '*' stripped) to a count.
     """
     states = {}
-    seen = set()
-    for line in output.splitlines():
-        parts = line.split()
-        if len(parts) != 2:
-            continue
-        node, state = parts
-        if node in seen:
-            continue
-        seen.add(node)
-        state = state.strip().rstrip("*+~#!%$@^-").lower()
+    nodes = parse_sinfo_node_states(output)
+    for state in nodes.values():
         states[state] = states.get(state, 0) + 1
     available_states = ("idle", "mixed", "allocated", "completing")
     available = sum(states.get(s, 0) for s in available_states)
-    total = len(seen)
+    total = len(nodes)
     return total, available, total - available, states
+
+
+def parse_gres_gpu_counts(output):
+    """Parse configured GPU counts, keeping one value per unique node."""
+    nodes = {}
+    for line in output.splitlines():
+        parts = line.split(None, 1)
+        if len(parts) != 2 or parts[0] in nodes:
+            continue
+        count = 0
+        for match in re.finditer(r"gpu(?::[^:,(\s]+)?:(\d+)", parts[1]):
+            count += int(match.group(1))
+        nodes[parts[0]] = count
+    return nodes
 
 
 def parse_gres_gpus(output):
     """Parse ``sinfo -h -N -o '%n %G'`` output into a total GPU count."""
-    total = 0
-    seen = set()
-    for line in output.splitlines():
-        parts = line.split(None, 1)
-        if len(parts) != 2 or parts[0] in seen:
-            continue
-        seen.add(parts[0])
-        for match in re.finditer(r"gpu(?::[^:,(\s]+)?:(\d+)", parts[1]):
-            total += int(match.group(1))
-    return total
+    return sum(parse_gres_gpu_counts(output).values())
+
+
+def build_node_details(states_output, gres_output):
+    """Return stable per-node state and configured GPU details."""
+    states = parse_sinfo_node_states(states_output)
+    gpu_counts = parse_gres_gpu_counts(gres_output)
+    return [
+        {
+            "name": name,
+            "state": states[name],
+            "gpus_configured": gpu_counts.get(name, 0),
+        }
+        for name in sorted(states)
+    ]
 
 
 def main():
@@ -117,6 +146,7 @@ def main():
         "nodes_available": 0,
         "nodes_unavailable": 0,
         "node_states": {},
+        "nodes": [],
         "gpus_configured": 0,
         "gpu_job_ran": False,
         "gpu_job_ok": False,
@@ -128,10 +158,12 @@ def main():
     if rc == 0 and out:
         result["slurm_version"] = out.split()[-1]
 
+    states_output = ""
     rc, out, err = run(["sinfo", "-h", "-N", "-o", "%n %T"])
     if rc != 0:
         result["failures"].append("sinfo failed: %s" % (err or "rc=%s" % rc))
     else:
+        states_output = out
         result["controller_reachable"] = True
         total, avail, unavail, states = parse_sinfo_states(out)
         result["nodes_total"] = total
@@ -146,9 +178,12 @@ def main():
                 % (unavail, ", ".join(sorted(k for k in states if k not in ("idle", "mixed", "allocated", "completing"))))
             )
 
+    gres_output = ""
     rc, out, _ = run(["sinfo", "-h", "-N", "-o", "%n %G"])
     if rc == 0:
+        gres_output = out
         result["gpus_configured"] = parse_gres_gpus(out)
+    result["nodes"] = build_node_details(states_output, gres_output)
     if result["controller_reachable"] and result["gpus_configured"] == 0:
         result["failures"].append("no GPUs (gres/gpu) configured on any node")
 

--- a/skills/validate-gpu-cluster/SKILL.md
+++ b/skills/validate-gpu-cluster/SKILL.md
@@ -35,6 +35,9 @@ contract: `docs/deepops/validation.md`.
      (`nodes_total`, `gpus_configured`/`gpus_allocatable`).
    - `ok: false` — report each entry in `failures` verbatim; they name the
      failing subsystem and the next diagnostic step.
+   - Use the name-sorted `nodes` list to identify individual failures. Slurm
+     entries report `name`, normalized `state`, and `gpus_configured`;
+     Kubernetes entries report `name`, `ready`, and `gpus_allocatable`.
 
 3. When a GPU check fails, do not conclude "driver broken" from a bare
    `nvidia-smi` over SSH — on Slurm nodes GPUs are hidden outside jobs.


### PR DESCRIPTION
Add per-node detail to DeepOps validators

### What this is
Implement the 26.09 public validator improvement: add stable per-node detail to the --json output of validate_slurm.py and validate_k8s.py while preserving existing aggregate fields and exit behavior. Slurm detail must report each unique node's normalized state and configured GRES GPU count. Kubernetes detail must report each node's Ready status and allocatable nvidia.com/gpu count, handling malformed values as zero. Add focused stdlib unit tests, update the validator skill only where needed, and keep human output compatible. Do not access a live scheduler or cluster; use parser fixtures only. Do not push or open a PR.

### Verification
- Deterministic checks passed: diff check, validation tests, python compile, public sanitizer, parent commit
- Two independent agent reviews approved head `abf0007eb062` (different model vendors; strict verdict contract)
- Published by the DeepOps maintenance loop's deterministic publisher after its publication gate (reviews, provenance, exact-head) passed
