### PR TITLE
chore: bump slurm to 26.05.3

### DIFF
--- a/roles/slurm/defaults/main.yml
+++ b/roles/slurm/defaults/main.yml
@@ -7,7 +7,7 @@ hwloc_build_dir: /opt/deepops/build/hwloc
 pmix_build_dir: /opt/deepops/build/pmix
 
 slurm_workflow_build: yes
-slurm_version: "26.05.1"
+slurm_version: "26.05.3"
 slurm_src_url: "https://download.schedmd.com/slurm/slurm-{{ slurm_version }}.tar.bz2"
 slurm_build_make_clean: no
 slurm_build_dir_cleanup: no


### PR DESCRIPTION
Bump slurm 26.05.1 -> 26.05.3

### What this is
Bump the slurm version pin. In `roles/slurm/defaults/main.yml`, change `slurm_version` from `26.05.1` to `26.05.3`. The upstream latest value was verified against https://github.com/SchedMD/slurm/tags when this card was generated; do not attempt network verification (network is disabled). Update any version references to the same component inside the allowed paths only, keep the change minimal, and do not touch unrelated pins. If the file structure does not match this instruction (variable missing, value already changed, format drifted), stop and report GATE_REQUIRED: card is stale, instead of guessing.

### Verification
- Deterministic checks passed: diff check, public sanitizer, bump applied, old value gone, parent commit
- Two independent agent reviews approved head `4cb2c331ba81` (different model vendors; strict verdict contract)
- Published by the DeepOps maintenance loop's deterministic publisher after its publication gate (reviews, provenance, exact-head) passed
