### PR TITLE
chore: bump gpu-operator to v26.7.0

### DIFF
--- a/roles/nvidia-gpu-operator/defaults/main.yml
+++ b/roles/nvidia-gpu-operator/defaults/main.yml
@@ -12,7 +12,7 @@ gpu_operator_nvaie_helm_repo: "https://helm.ngc.nvidia.com/nvaie"
 gpu_operator_nvaie_chart_name: "nvaie/gpu-operator"
 
 # NVAIE GPU Operator may require different version, check NGC enterprise collection.
-gpu_operator_chart_version: "v26.3.3"
+gpu_operator_chart_version: "v26.7.0"
 
 k8s_gpu_mig_strategy: "mixed"
 


### PR DESCRIPTION
Bump gpu-operator v26.3.3 -> v26.7.0

### What this is
Bump the gpu-operator version pin. In `roles/nvidia-gpu-operator/defaults/main.yml`, change `gpu_operator_chart_version` from `v26.3.3` to `v26.7.0`. The upstream latest value was verified against https://github.com/NVIDIA/gpu-operator/releases when this card was generated; do not attempt network verification (network is disabled). Update any version references to the same component inside the allowed paths only, keep the change minimal, and do not touch unrelated pins. If the file structure does not match this instruction (variable missing, value already changed, format drifted), stop and report GATE_REQUIRED: card is stale, instead of guessing.

### Verification
- Deterministic checks passed: diff check, public sanitizer, bump applied, old value gone, parent commit
- Two independent agent reviews approved head `7b1a9a09e1c2` (different model vendors; strict verdict contract)
- Published by the DeepOps maintenance loop's deterministic publisher after its publication gate (reviews, provenance, exact-head) passed
