### PR TITLE
chore: bump k8s-device-plugin to 0.20.0

### DIFF
--- a/roles/nvidia-k8s-gpu-device-plugin/defaults/main.yml
+++ b/roles/nvidia-k8s-gpu-device-plugin/defaults/main.yml
@@ -2,6 +2,6 @@
 k8s_gpu_plugin_helm_repo: "https://nvidia.github.io/k8s-device-plugin"
 k8s_gpu_plugin_chart_name: "nvdp/nvidia-device-plugin"
 k8s_gpu_plugin_release_name: "nvidia-device-plugin"
-k8s_gpu_plugin_chart_version: "0.19.3"
+k8s_gpu_plugin_chart_version: "0.20.0"
 k8s_gpu_plugin_init_error: "false"
 k8s_gpu_mig_strategy: "mixed"


### PR DESCRIPTION
Bump k8s-device-plugin 0.19.3 -> 0.20.0

### What this is
Bump the k8s-device-plugin version pin. In `roles/nvidia-k8s-gpu-device-plugin/defaults/main.yml`, change `k8s_gpu_plugin_chart_version` from `0.19.3` to `0.20.0`. The upstream latest value was verified against https://github.com/NVIDIA/k8s-device-plugin/releases when this card was generated; do not attempt network verification (network is disabled). Update any version references to the same component inside the allowed paths only, keep the change minimal, and do not touch unrelated pins. If the file structure does not match this instruction (variable missing, value already changed, format drifted), stop and report GATE_REQUIRED: card is stale, instead of guessing.

### Verification
- Deterministic checks passed: diff check, public sanitizer, bump applied, old value gone, parent commit
- Two independent agent reviews approved head `4fbdd31f0d0e` (different model vendors; strict verdict contract)
- Published by the DeepOps maintenance loop's deterministic publisher after its publication gate (reviews, provenance, exact-head) passed
