### PR TITLE
chore: bump spack to v1.2.2

### DIFF
--- a/roles/spack/defaults/main.yml
+++ b/roles/spack/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 spack_repo: "https://github.com/spack/spack.git"
 spack_install_dir: "/sw/spack"
-spack_version: "v1.2.0"
+spack_version: "v1.2.2"
 spack_user: "root"
 spack_group: "root"
 


### PR DESCRIPTION
Bump spack v1.2.0 -> v1.2.2

### What this is
Bump the spack version pin. In `roles/spack/defaults/main.yml`, change `spack_version` from `v1.2.0` to `v1.2.2`. The upstream latest value was verified against https://github.com/spack/spack/releases when this card was generated; do not attempt network verification (network is disabled). Update any version references to the same component inside the allowed paths only, keep the change minimal, and do not touch unrelated pins. If the file structure does not match this instruction (variable missing, value already changed, format drifted), stop and report GATE_REQUIRED: card is stale, instead of guessing.

### Verification
- Deterministic checks passed: diff check, public sanitizer, bump applied, old value gone, parent commit
- Two independent agent reviews approved head `63b396e4649f` (different model vendors; strict verdict contract)
- Published by the DeepOps maintenance loop's deterministic publisher after its publication gate (reviews, provenance, exact-head) passed
