### PR TITLE
fix: diagnose and fix the 26.09 maas smoke failure

### DIFF
--- a/roles/maas-controller/tasks/main.yml
+++ b/roles/maas-controller/tasks/main.yml
@@ -9,7 +9,15 @@
 
 - name: add MAAS repository
   apt_repository:
-    repo: "{{ maas_repo }}"
+    # MAAS 3.5 has no Noble repository. Normalize the legacy override used by
+    # existing automation while preserving custom repositories.
+    repo: >-
+      {{
+        'ppa:maas/3.7'
+        if ansible_distribution_version is version('24.04', '>=')
+        and maas_repo == 'ppa:maas/3.5'
+        else maas_repo
+      }}
     state: present
 
 - name: install MAAS


### PR DESCRIPTION
Diagnose and fix the 26.09 MAAS smoke failure

### What this is
MAAS controller role on Ubuntu 24.04 (Noble): the `add MAAS repository` task applied the legacy default `ppa:maas/3.5`, but MAAS 3.5 publishes no Noble packages, so `apt_repository` failed on a missing Release file and the MAAS install never started. Normalize that legacy override to `ppa:maas/3.7` when the host runs Ubuntu 24.04 or newer, while preserving any custom `maas_repo` value. QA-fix scope only: touch only files needed for this failure.

### Verification
- Deterministic checks passed: diff check, public sanitizer, parent commit
- Two independent agent reviews approved head `e98829e1eae8` (different model vendors; strict verdict contract)
- Published by the DeepOps maintenance loop's deterministic publisher after its publication gate (reviews, provenance, exact-head) passed
