### PR TITLE
chore: bump network-operator to 26.4.1

### DIFF
--- a/roles/nvidia-network-operator/vars/main.yaml
+++ b/roles/nvidia-network-operator/vars/main.yaml
@@ -6,7 +6,7 @@
 # if_name must match k8s network annotation name
 #
 
-nvidia_network_operator_version: "26.4.0"
+nvidia_network_operator_version: "26.4.1"
 nvidia_network_operator_image_tag: "network-operator-v{{ nvidia_network_operator_version }}"
 nvidia_network_operator_namespace: "network-operator"
 nvidia_network_operator_ipam_type: "nv-ipam"


### PR DESCRIPTION
Bump network-operator 26.4.0 -> 26.4.1

### What this is
Bump the network-operator version pin. In `roles/nvidia-network-operator/vars/main.yaml`, change `nvidia_network_operator_version` from `26.4.0` to `26.4.1`. The upstream latest value was verified against https://github.com/Mellanox/network-operator/releases when this card was generated; do not attempt network verification (network is disabled). Update any version references to the same component inside the allowed paths only, keep the change minimal, and do not touch unrelated pins. If the file structure does not match this instruction (variable missing, value already changed, format drifted), stop and report GATE_REQUIRED: card is stale, instead of guessing.

### Verification
- Deterministic checks passed: diff check, public sanitizer, bump applied, old value gone, parent commit
- Two independent agent reviews approved head `a1c81e973fbc` (different model vendors; strict verdict contract)
- Published by the DeepOps maintenance loop's deterministic publisher after its publication gate (reviews, provenance, exact-head) passed
