### PR TITLE
pyxis: fix include path so <slurm/spank.h> resolves with a custom slurm_install_prefix

### DIFF
--- a/roles/pyxis/tasks/pyxis.yml
+++ b/roles/pyxis/tasks/pyxis.yml
@@ -33,7 +33,7 @@
       - make
       - -j
   environment:
-    CPPFLAGS: "-I {{ slurm_install_prefix }}/include/slurm"
+    CPPFLAGS: "-I {{ slurm_install_prefix }}/include"
   register: result
   changed_when: "result.stdout != \"make: Nothing to be done for 'all'.\""
   notify:


### PR DESCRIPTION
## Problem
`roles/pyxis/tasks/pyxis.yml` passes `-I {{ slurm_install_prefix }}/include/slurm` to the pyxis build, but pyxis sources `#include <slurm/spank.h>`, so the compiler looks for `.../include/slurm/slurm/spank.h`. With the default prefix (`/usr/local`) this is masked because `/usr/local/include` is already on the compiler's default search path. With any other prefix the build fails:

    pyxis_dispatch.c:5:10: fatal error: slurm/spank.h: No such file or directory

Reproduced on DGX OS 7.5.0 with `slurm_install_prefix: /raid/slurm/usr/local` (DeepOps master, Slurm 26.05.3, pyxis 0.11.1).

## Fix
Pass `-I {{ slurm_install_prefix }}/include` instead. One-line change; behaviour with the default prefix is unchanged.

## Verification
After the change, `make -j` in `/usr/local/src/pyxis` completes and the slurm-cluster playbook proceeds past the pyxis role on the system above.