### PR TITLE
slurm: use ssh.service on Debian-family when hiding GPUs from login shells

### DIFF
--- a/roles/slurm/tasks/login-compute-setup.yml
+++ b/roles/slurm/tasks/login-compute-setup.yml
@@ -1,18 +1,18 @@
 ---
 
 - name: Hide GPUs for regular user logins via sshd.service.
+  vars:
+    ssh_unit: "{{ 'sshd.service' if ansible_os_family == 'RedHat' else 'ssh.service' }}"
   shell: |
     set -o pipefail
-    deviceprop=$(systemctl show sshd.service -p DeviceAllow | grep -i nvidiactl)
+    deviceprop=$(systemctl show {{ ssh_unit }} -p DeviceAllow | grep -i nvidiactl)
 
     if [ -z "$deviceprop" ] ; then
-      systemctl set-property sshd.service DeviceAllow="/dev/nvidiactl"
+      systemctl set-property {{ ssh_unit }} DeviceAllow="/dev/nvidiactl"
     fi
   args:
     executable: /bin/bash
-    creates: "{{ '/etc/systemd/system.control/sshd.service.d/50-DeviceAllow.conf' \
-                 if ansible_os_family == 'RedHat' else \
-                 '/etc/systemd/system.control/ssh.service.d/50-DeviceAllow.conf' }}"
+    creates: "/etc/systemd/system.control/{{ ssh_unit }}.d/50-DeviceAllow.conf"
   when: is_controller
   tags:
     - config


### PR DESCRIPTION
## Problem
`roles/slurm/tasks/login-compute-setup.yml` hardcodes `sshd.service` in the "Hide GPUs for regular user logins" task. On Debian-family systems the OpenSSH unit is `ssh.service`, so the task fails:

    Failed to set unit properties on sshd.service: Unit sshd.service not found.

The task's `creates:` argument already branches on `ansible_os_family` (`ssh.service.d` for non-RedHat), so only the shell command was out of step.

Reproduced on DGX OS 7.5.0 (Ubuntu-based) with `slurm_login_on_compute: true`.

## Fix
Introduce a single `ssh_unit` task var and use it in both the shell command and `creates:`. Behaviour on RedHat-family is unchanged.

## Verification
Applied the equivalent `systemctl set-property ssh.service DeviceAllow=/dev/nvidiactl` on the DGX; a fresh SSH session shows `nvidia-smi` → `No devices were found`, as intended.
