### PR TITLE
nvidia-peer-memory: prefer in-tree nvidia_peermem over legacy nv_peer_mem

### DIFF
--- a/roles/nvidia-peer-memory/tasks/main.yml
+++ b/roles/nvidia-peer-memory/tasks/main.yml
@@ -4,11 +4,32 @@
     path: /etc/dgx-release
   register: is_dgx
 
+# Driver R470.42.01 and later ship nvidia_peermem in-tree. On those
+# systems the out-of-tree nv_peer_mem DKMS module does not exist.
+- name: Check for in-tree nvidia_peermem module
+  command: modinfo nvidia_peermem
+  register: nvidia_peermem_info
+  failed_when: false
+  changed_when: false
+  when:
+    - ansible_local['gpus']['count']
+    - is_dgx.stat.exists
+
+- name: Load in-tree nvidia_peermem
+  modprobe:
+    name: nvidia_peermem
+    state: present
+  when:
+    - ansible_local['gpus']['count']
+    - is_dgx.stat.exists
+    - nvidia_peermem_info.rc == 0
+
 - name: Autoinstall DKMS modules
   command: dkms autoinstall
   when:
     - ansible_local['gpus']['count']
     - is_dgx.stat.exists
+    - nvidia_peermem_info.rc != 0
 
 - name: Modprobe nv_peer_mem
   modprobe:
@@ -17,6 +38,7 @@
   when:
     - ansible_local['gpus']['count']
     - is_dgx.stat.exists
+    - nvidia_peermem_info.rc != 0
 
 - name: Start nv_peer_mem service
   service:
@@ -25,3 +47,4 @@
   when:
     - ansible_local['gpus']['count']
     - is_dgx.stat.exists
+    - nvidia_peermem_info.rc != 0

--- a/roles/nvidia-peer-memory/tasks/main.yml
+++ b/roles/nvidia-peer-memory/tasks/main.yml
@@ -22,14 +22,14 @@
   when:
     - ansible_local['gpus']['count']
     - is_dgx.stat.exists
-    - nvidia_peermem_info.rc == 0
+    - nvidia_peermem_info.rc | default(1) == 0
 
 - name: Autoinstall DKMS modules
   command: dkms autoinstall
   when:
     - ansible_local['gpus']['count']
     - is_dgx.stat.exists
-    - nvidia_peermem_info.rc != 0
+    - nvidia_peermem_info.rc | default(1) != 0
 
 - name: Modprobe nv_peer_mem
   modprobe:
@@ -38,7 +38,7 @@
   when:
     - ansible_local['gpus']['count']
     - is_dgx.stat.exists
-    - nvidia_peermem_info.rc != 0
+    - nvidia_peermem_info.rc | default(1) != 0
 
 - name: Start nv_peer_mem service
   service:
@@ -47,4 +47,4 @@
   when:
     - ansible_local['gpus']['count']
     - is_dgx.stat.exists
-    - nvidia_peermem_info.rc != 0
+    - nvidia_peermem_info.rc | default(1) != 0

--- a/roles/nvidia-peer-memory/tasks/main.yml
+++ b/roles/nvidia-peer-memory/tasks/main.yml
@@ -15,14 +15,34 @@
     - ansible_local['gpus']['count']
     - is_dgx.stat.exists
 
-- name: Load in-tree nvidia_peermem
-  modprobe:
-    name: nvidia_peermem
-    state: present
+# A host upgraded from a pre-R470 driver may still carry the legacy
+# nv_peer_mem service and module. Retire them before loading the in-tree
+# module so the two never coexist. Every step is a no-op once converged.
+- name: Use in-tree nvidia_peermem
   when:
     - ansible_local['gpus']['count']
     - is_dgx.stat.exists
     - nvidia_peermem_info.rc | default(1) == 0
+  block:
+    - name: Populate service facts
+      service_facts:
+
+    - name: Stop and disable legacy nv_peer_mem service
+      service:
+        name: nv_peer_mem
+        state: stopped
+        enabled: false
+      when: "'nv_peer_mem.service' in ansible_facts.services"
+
+    - name: Unload legacy nv_peer_mem module
+      modprobe:
+        name: nv_peer_mem
+        state: absent
+
+    - name: Load in-tree nvidia_peermem
+      modprobe:
+        name: nvidia_peermem
+        state: present
 
 - name: Autoinstall DKMS modules
   command: dkms autoinstall


### PR DESCRIPTION
## Problem
`roles/nvidia-peer-memory` assumes the out-of-tree `nv_peer_mem` DKMS module on DGX systems. Since driver R470.42.01 the equivalent `nvidia_peermem` module ships in-tree with the driver and `nv_peer_mem` is not available, so the role fails on current DGX OS:

    modprobe: FATAL: Module nv_peer_mem not found in directory /lib/modules/6.8.0-106-generic

There is no variable to disable the role from `slurm-cluster.yml`; only the `nvidia-peer-memory` tag.

Reproduced on DGX OS 7.5.0, driver 580.126.20.

## Fix
Probe for `nvidia_peermem` with `modinfo`. When present, retire any legacy state first — stop and disable `nv_peer_mem.service` if it exists, unload `nv_peer_mem` — then load `nvidia_peermem`, and skip the legacy DKMS/`nv_peer_mem`/service path. When the in-tree module is absent, behaviour is unchanged.

Every step is idempotent (`service_facts` gates the service task; `modprobe` only acts when the module state differs), so a second run reports `ok` throughout.

## Verification
Failure reproduced on DGX OS 7.5.0 / driver 580.126.20. On the same system `lsmod` shows the in-tree module already loaded (`nvidia_peermem 16384 0`, used by `ib_uverbs`), so the new probe takes the in-tree branch and the legacy DKMS/nv_peer_mem path is skipped.
