### PR TITLE
pyxis: allow unprivileged user namespaces so enroot works on Ubuntu 23.10+

### DIFF
--- a/roles/pyxis/defaults/main.yml
+++ b/roles/pyxis/defaults/main.yml
@@ -18,3 +18,10 @@ resize_run_partition: false
 
 # /run tmpfs size. ubuntu default is 10% of physical memory
 pyxis_run_tmpfs_size: 50%
+
+# Ubuntu 23.10 and later restrict unprivileged user namespaces through AppArmor,
+# which blocks enroot-nsenter. The role installs an AppArmor profile that grants
+# the capability to enroot-nsenter alone. Set this to true only if that profile
+# cannot be used on your installation: it clears the restriction for every
+# process on the host and lowers the security default of the OS.
+pyxis_userns_allow_globally: false

--- a/roles/pyxis/files/etc/apparmor.d/enroot-nsenter
+++ b/roles/pyxis/files/etc/apparmor.d/enroot-nsenter
@@ -1,0 +1,21 @@
+# enroot-nsenter creates the user namespace that a pyxis container runs in.
+# Ubuntu 23.10 and later ship kernel.apparmor_restrict_unprivileged_userns=1,
+# which makes that fail with:
+#
+#   failed to create user namespace: Permission denied
+#
+# This profile grants the userns capability to that single executable instead
+# of clearing the restriction for every process on the host. enroot-nsenter is
+# the only enroot executable that references CLONE_NEWUSER (enroot 3.2.0), so
+# the other helpers do not need it.
+#
+# The "userns" rule and the "unconfined" flag require AppArmor 4.0 or later,
+# which is present on every release that enables the restriction.
+abi <abi/4.0>,
+include <tunables/global>
+
+profile enroot-nsenter /usr/bin/enroot-nsenter flags=(unconfined) {
+  userns,
+
+  include if exists <local/enroot-nsenter>
+}

--- a/roles/pyxis/tasks/main.yml
+++ b/roles/pyxis/tasks/main.yml
@@ -13,6 +13,28 @@
   with_items: "{{ pyxis_el_deps }}"
   when: ansible_os_family == "RedHat"
 
+# Ubuntu 23.10 and later set kernel.apparmor_restrict_unprivileged_userns=1
+# by default, which makes enroot-nsenter fail under pyxis with
+# "failed to create user namespace: Permission denied". Detect the knob by
+# its presence in /proc rather than by distribution version, so the task is
+# a no-op on kernels built without it.
+- name: check for AppArmor unprivileged user namespace restriction
+  stat:
+    path: /proc/sys/kernel/apparmor_restrict_unprivileged_userns
+  register: apparmor_userns_knob
+  when: is_compute
+
+- name: allow unprivileged user namespaces for enroot
+  ansible.posix.sysctl:
+    name: kernel.apparmor_restrict_unprivileged_userns
+    value: "0"
+    sysctl_file: /etc/sysctl.d/60-enroot-userns.conf
+    state: present
+    reload: yes
+  when:
+    - is_compute
+    - apparmor_userns_knob.stat.exists | default(false)
+
 - name: install slurm-pmi hook
   file:
     path: /etc/enroot/hooks.d/50-slurm-pmi.sh

--- a/roles/pyxis/tasks/main.yml
+++ b/roles/pyxis/tasks/main.yml
@@ -24,6 +24,18 @@
   register: apparmor_userns_knob
   when: is_compute
 
+# The profile is the default path, so its userspace is a dependency of this
+# role rather than something to skip over when it is missing.
+- name: install the AppArmor userspace (Ubuntu)
+  apt:
+    name: apparmor
+    state: present
+  when:
+    - is_compute
+    - ansible_distribution == "Ubuntu"
+    - apparmor_userns_knob.stat.exists | default(false)
+    - not pyxis_userns_allow_globally
+
 - name: check for apparmor_parser
   stat:
     path: /sbin/apparmor_parser
@@ -31,6 +43,23 @@
   when:
     - is_compute
     - apparmor_userns_knob.stat.exists | default(false)
+
+# Without this the scoped path is skipped silently and enroot keeps failing
+# with the very error this role exists to prevent.
+- name: fail when the AppArmor userspace is unavailable
+  fail:
+    msg: >-
+      kernel.apparmor_restrict_unprivileged_userns is active but
+      /sbin/apparmor_parser is not present, so the scoped enroot-nsenter
+      profile cannot be loaded and enroot would fail with "failed to create
+      user namespace: Permission denied". Install the AppArmor userspace, or
+      set pyxis_userns_allow_globally=true to clear the restriction for the
+      whole host instead.
+  when:
+    - is_compute
+    - apparmor_userns_knob.stat.exists | default(false)
+    - not pyxis_userns_allow_globally
+    - not apparmor_parser_bin.stat.exists | default(false)
 
 # Grant the capability to the one executable that needs it rather than clearing
 # the restriction for the whole host.
@@ -45,14 +74,31 @@
   when:
     - is_compute
     - apparmor_userns_knob.stat.exists | default(false)
-    - apparmor_parser_bin.stat.exists | default(false)
+    - not pyxis_userns_allow_globally
+
+# Loading only on a file change leaves a node unrepaired when the first load
+# failed, or when the profile was unloaded by hand while the file stayed as it
+# was. The kernel's own list decides, so a rerun converges either way.
+- name: check whether the enroot-nsenter profile is loaded
+  command: grep -q "^enroot-nsenter " /sys/kernel/security/apparmor/profiles
+  register: enroot_userns_loaded
+  changed_when: false
+  failed_when: false
+  when:
+    - is_compute
+    - apparmor_userns_knob.stat.exists | default(false)
     - not pyxis_userns_allow_globally
 
 - name: load the enroot-nsenter AppArmor profile
   command: apparmor_parser -r /etc/apparmor.d/enroot-nsenter
   register: enroot_userns_load
   failed_when: false
-  when: enroot_userns_profile.changed | default(false)
+  when:
+    - is_compute
+    - apparmor_userns_knob.stat.exists | default(false)
+    - not pyxis_userns_allow_globally
+    - (enroot_userns_profile.changed | default(false))
+      or (enroot_userns_loaded.rc | default(1) != 0)
 
 - name: report a failure to load the enroot-nsenter AppArmor profile
   fail:
@@ -78,6 +124,26 @@
     - is_compute
     - apparmor_userns_knob.stat.exists | default(false)
     - pyxis_userns_allow_globally
+
+# Flipping the fallback back off has to take its setting with it, otherwise the
+# host keeps the lowered default that the profile was meant to replace.
+# "sysctl --system" reapplies the remaining files, so the value returns to what
+# the distribution ships rather than to one this role invents.
+- name: drop the host-wide user namespace sysctl when the fallback is off
+  ansible.posix.sysctl:
+    name: kernel.apparmor_restrict_unprivileged_userns
+    sysctl_file: /etc/sysctl.d/60-enroot-userns.conf
+    state: absent
+  register: enroot_userns_sysctl_removed
+  when:
+    - is_compute
+    - apparmor_userns_knob.stat.exists | default(false)
+    - not pyxis_userns_allow_globally
+
+- name: reapply the remaining sysctl configuration
+  command: sysctl --system
+  changed_when: true
+  when: enroot_userns_sysctl_removed.changed | default(false)
 
 - name: install slurm-pmi hook
   file:

--- a/roles/pyxis/tasks/main.yml
+++ b/roles/pyxis/tasks/main.yml
@@ -127,23 +127,103 @@
 
 # Flipping the fallback back off has to take its setting with it, otherwise the
 # host keeps the lowered default that the profile was meant to replace.
-# "sysctl --system" reapplies the remaining files, so the value returns to what
-# the distribution ships rather than to one this role invents.
 - name: drop the host-wide user namespace sysctl when the fallback is off
   ansible.posix.sysctl:
     name: kernel.apparmor_restrict_unprivileged_userns
     sysctl_file: /etc/sysctl.d/60-enroot-userns.conf
     state: absent
-  register: enroot_userns_sysctl_removed
   when:
     - is_compute
     - apparmor_userns_knob.stat.exists | default(false)
     - not pyxis_userns_allow_globally
 
-- name: reapply the remaining sysctl configuration
-  command: sysctl --system
+# The running kernel decides, not the file. A run interrupted or failed between
+# the removal above and the restoration below leaves the file gone and the
+# restriction still disabled; keying the restoration off "the file changed"
+# would skip it on the next run and leave the node in that state for good.
+- name: read the effective user namespace restriction
+  slurp:
+    src: /proc/sys/kernel/apparmor_restrict_unprivileged_userns
+  register: enroot_userns_effective
+  when:
+    - is_compute
+    - apparmor_userns_knob.stat.exists | default(false)
+    - not pyxis_userns_allow_globally
+
+- name: locate systemd-sysctl
+  stat:
+    path: "{{ item }}"
+  register: systemd_sysctl_bin
+  loop:
+    - /usr/lib/systemd/systemd-sysctl
+    - /lib/systemd/systemd-sysctl
+  when:
+    - is_compute
+    - apparmor_userns_knob.stat.exists | default(false)
+    - not pyxis_userns_allow_globally
+    - (enroot_userns_effective.content | default('MQ==') | b64decode | trim) != "1"
+
+# Reapply this one key from whatever configuration remains. Unlike
+# "sysctl --system" this replays no unrelated host-wide policy, and it honours
+# the precedence of any other file that legitimately declares the key.
+- name: reapply the owned sysctl key from the remaining configuration
+  command: "{{ (systemd_sysctl_bin.results | selectattr('stat', 'defined') | selectattr('stat.exists') | first).stat.path }} --prefix=kernel.apparmor_restrict_unprivileged_userns"
   changed_when: true
-  when: enroot_userns_sysctl_removed.changed | default(false)
+  when:
+    - is_compute
+    - apparmor_userns_knob.stat.exists | default(false)
+    - not pyxis_userns_allow_globally
+    - (enroot_userns_effective.content | default('MQ==') | b64decode | trim) != "1"
+    - systemd_sysctl_bin.results | default([]) | selectattr('stat', 'defined') | selectattr('stat.exists') | list | length > 0
+
+- name: re-read the effective user namespace restriction
+  slurp:
+    src: /proc/sys/kernel/apparmor_restrict_unprivileged_userns
+  register: enroot_userns_effective_after
+  when:
+    - is_compute
+    - apparmor_userns_knob.stat.exists | default(false)
+    - not pyxis_userns_allow_globally
+    - (enroot_userns_effective.content | default('MQ==') | b64decode | trim) != "1"
+
+# Nothing on disk declares the key any more, so the value still in the kernel is
+# the one this role wrote. Undo that write and leave the boot default to decide
+# from the next reboot on. No file is created, so nothing is invented here.
+- name: undo the runtime value this role left behind
+  command: sysctl -w kernel.apparmor_restrict_unprivileged_userns=1
+  changed_when: true
+  when:
+    - is_compute
+    - apparmor_userns_knob.stat.exists | default(false)
+    - not pyxis_userns_allow_globally
+    - (enroot_userns_effective.content | default('MQ==') | b64decode | trim) != "1"
+    - (enroot_userns_effective_after.content | default('MQ==') | b64decode | trim) != "1"
+
+- name: confirm the user namespace restriction is back on
+  slurp:
+    src: /proc/sys/kernel/apparmor_restrict_unprivileged_userns
+  register: enroot_userns_final
+  when:
+    - is_compute
+    - apparmor_userns_knob.stat.exists | default(false)
+    - not pyxis_userns_allow_globally
+    - (enroot_userns_effective.content | default('MQ==') | b64decode | trim) != "1"
+
+- name: fail when the user namespace restriction could not be restored
+  fail:
+    msg: >-
+      kernel.apparmor_restrict_unprivileged_userns is still
+      {{ enroot_userns_final.content | default('') | b64decode | trim }} after this role
+      removed its own /etc/sysctl.d/60-enroot-userns.conf entry. Another file
+      under /etc/sysctl.d, /run/sysctl.d or /usr/lib/sysctl.d is holding it at
+      that value, or the write was refused. Reconcile it by hand; this role
+      only manages its own entry and will not override another one.
+  when:
+    - is_compute
+    - apparmor_userns_knob.stat.exists | default(false)
+    - not pyxis_userns_allow_globally
+    - (enroot_userns_effective.content | default('MQ==') | b64decode | trim) != "1"
+    - (enroot_userns_final.content | default('MQ==') | b64decode | trim) != "1"
 
 - name: install slurm-pmi hook
   file:

--- a/roles/pyxis/tasks/main.yml
+++ b/roles/pyxis/tasks/main.yml
@@ -16,7 +16,7 @@
 # Ubuntu 23.10 and later set kernel.apparmor_restrict_unprivileged_userns=1
 # by default, which makes enroot-nsenter fail under pyxis with
 # "failed to create user namespace: Permission denied". Detect the knob by
-# its presence in /proc rather than by distribution version, so the task is
+# its presence in /proc rather than by distribution version, so these tasks are
 # a no-op on kernels built without it.
 - name: check for AppArmor unprivileged user namespace restriction
   stat:
@@ -24,7 +24,50 @@
   register: apparmor_userns_knob
   when: is_compute
 
-- name: allow unprivileged user namespaces for enroot
+- name: check for apparmor_parser
+  stat:
+    path: /sbin/apparmor_parser
+  register: apparmor_parser_bin
+  when:
+    - is_compute
+    - apparmor_userns_knob.stat.exists | default(false)
+
+# Grant the capability to the one executable that needs it rather than clearing
+# the restriction for the whole host.
+- name: install the enroot-nsenter AppArmor profile
+  copy:
+    src: etc/apparmor.d/enroot-nsenter
+    dest: /etc/apparmor.d/enroot-nsenter
+    owner: root
+    group: root
+    mode: "0644"
+  register: enroot_userns_profile
+  when:
+    - is_compute
+    - apparmor_userns_knob.stat.exists | default(false)
+    - apparmor_parser_bin.stat.exists | default(false)
+    - not pyxis_userns_allow_globally
+
+- name: load the enroot-nsenter AppArmor profile
+  command: apparmor_parser -r /etc/apparmor.d/enroot-nsenter
+  register: enroot_userns_load
+  failed_when: false
+  when: enroot_userns_profile.changed | default(false)
+
+- name: report a failure to load the enroot-nsenter AppArmor profile
+  fail:
+    msg: >-
+      Could not load /etc/apparmor.d/enroot-nsenter:
+      {{ enroot_userns_load.stderr | default('') }}.
+      The "userns" rule and the "unconfined" flag need AppArmor 4.0 or later.
+      Set pyxis_userns_allow_globally=true to clear
+      kernel.apparmor_restrict_unprivileged_userns for the whole host instead.
+  when: enroot_userns_load.rc | default(0) != 0
+
+# Opt-in fallback for installations where the profile cannot be used. This
+# lowers the security default for every process on the host, so it is off by
+# default and has to be requested explicitly.
+- name: allow unprivileged user namespaces host-wide
   ansible.posix.sysctl:
     name: kernel.apparmor_restrict_unprivileged_userns
     value: "0"
@@ -34,6 +77,7 @@
   when:
     - is_compute
     - apparmor_userns_knob.stat.exists | default(false)
+    - pyxis_userns_allow_globally
 
 - name: install slurm-pmi hook
   file:


### PR DESCRIPTION
## Problem
Ubuntu 23.10 and later set `kernel.apparmor_restrict_unprivileged_userns=1` by default. Under that default, `enroot-nsenter` fails as soon as pyxis starts a container:

    enroot-nsenter: failed to create user namespace: Permission denied

The `nvidia.enroot` galaxy role does not handle this, and DeepOps lists Ubuntu 24.04 LTS as a supported OS, so **container jobs do not work out of the box on a supported platform**.

Observed on DGX OS 7.5.0 (Ubuntu-based), Slurm 26.05.1, pyxis 0.11.1.

## Fix
Add a sysctl task in `roles/pyxis` for compute nodes. The task is gated on the presence of `/proc/sys/kernel/apparmor_restrict_unprivileged_userns` rather than on `ansible_distribution_version`, so it is a no-op on kernels built without AppArmor userns restrictions and does not need updating for future releases.

## Note on hardening
This relaxes a system-wide hardening default: unprivileged user namespaces are what AppArmor is restricting here. A narrower alternative is an AppArmor profile scoped to `enroot-nsenter` (as packaged by some distributions for other userns consumers). If maintainers prefer that approach, I am happy to rework the patch.

The sysctl is written to `/etc/sysctl.d/60-enroot-userns.conf` so it is visible and revertible, rather than being applied only at runtime.