### PR TITLE
nvidia_dcgm: do not replace the DCGM that DGX OS already ships

### DIFF
--- a/roles/nvidia_dcgm/defaults/main.yml
+++ b/roles/nvidia_dcgm/defaults/main.yml
@@ -1,6 +1,15 @@
 ---
 dcgm_pkg_name: "datacenter-gpu-manager"
 
+# DGX OS ships its own DCGM and the package name differs per release.
+# install-dgx.yml converges on this package and removes the other series.
+dcgm_dgx_pkg_map:
+  "18.04": "datacenter-gpu-manager"           # DGX OS 4
+  "20.04": "datacenter-gpu-manager"           # DGX OS 5
+  "22.04": "datacenter-gpu-manager"           # DGX OS 6
+  "24.04": "datacenter-gpu-manager-4-cuda13"  # DGX OS 7
+dcgm_dgx_pkg_name: "{{ dcgm_dgx_pkg_map[ansible_distribution_version] | default('') }}"
+
 # RedHat family
 epel_package: "https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm"
 epel_key_url: "https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-{{ ansible_distribution_major_version }}"

--- a/roles/nvidia_dcgm/tasks/install-dgx.yml
+++ b/roles/nvidia_dcgm/tasks/install-dgx.yml
@@ -1,5 +1,12 @@
 ---
+# DGX OS ships its own DCGM (4.x on DGX OS 7). Never replace it with the
+# unversioned 3.x metapackage; only install when nothing is present.
+- name: gather package facts
+  package_facts:
+    manager: auto
+
 - name: install DCGM from repos
   package:
-    name: "datacenter-gpu-manager"
+    name: "{{ dcgm_pkg_name }}"
     state: present
+  when: ansible_facts.packages | select('match', '^datacenter-gpu-manager') | list | length == 0

--- a/roles/nvidia_dcgm/tasks/install-dgx.yml
+++ b/roles/nvidia_dcgm/tasks/install-dgx.yml
@@ -1,12 +1,37 @@
 ---
 # DGX OS ships its own DCGM (4.x on DGX OS 7). Never replace it with the
-# unversioned 3.x metapackage; only install when nothing is present.
+# unversioned 3.x metapackage from the CUDA repo; converge on the package
+# DGX OS expects and remove packages from the other series first.
 - name: gather package facts
   package_facts:
     manager: auto
 
-- name: install DCGM from repos
+- name: fail when this DGX OS release has no known DCGM package
+  fail:
+    msg: >-
+      No DCGM package is mapped for {{ ansible_distribution }}
+      {{ ansible_distribution_version }} on DGX; set dcgm_dgx_pkg_name to
+      the package shipped by this DGX OS release.
+  when: dcgm_dgx_pkg_name | length == 0
+
+- name: collect installed DCGM packages from the other series
+  set_fact:
+    dcgm_dgx_conflicting_pkgs: >-
+      {{ (_dcgm_installed | reject('match', _dcgm_v4_re) | list)
+         if (dcgm_dgx_pkg_name is match(_dcgm_v4_re))
+         else (_dcgm_installed | select('match', _dcgm_v4_re) | list) }}
+  vars:
+    _dcgm_installed: "{{ ansible_facts.packages | select('match', '^datacenter-gpu-manager') | list }}"
+    _dcgm_v4_re: '^datacenter-gpu-manager-4(-|$)'
+
+- name: remove DCGM packages from the other series
   package:
-    name: "{{ dcgm_pkg_name }}"
+    name: "{{ dcgm_dgx_conflicting_pkgs }}"
+    state: absent
+  when: dcgm_dgx_conflicting_pkgs | length > 0
+
+- name: install the DCGM package shipped by DGX OS
+  package:
+    name: "{{ dcgm_dgx_pkg_name }}"
     state: present
-  when: ansible_facts.packages | select('match', '^datacenter-gpu-manager') | list | length == 0
+  when: dcgm_dgx_pkg_name not in ansible_facts.packages


### PR DESCRIPTION
## Problem
`roles/nvidia_dcgm/tasks/install-dgx.yml` installs the unversioned `datacenter-gpu-manager` package on every DGX. In the CUDA apt repo that name resolves to DCGM 3.3.9. DGX OS 7.x already ships `datacenter-gpu-manager-4-cuda13` (4.5.2). The two series conflict, so apt removes the 4.x packages and installs 3.3.9. The task reports `ok`, so nothing in the play fails.

The regression is only visible afterwards on the node:

    $ dcgmi diag -r 1
    Detected unsupported Cuda version        # 3.3.9 ships cuda10/11/12 plugins only; driver reports CUDA 13.0
    $ dcgmi discovery -l | grep found
    8 GPUs found.
    0 NvSwitches found.                      # DGX B300 has two

The Ubuntu branch (`install-ubuntu.yml`) already uses `{{ dcgm_pkg_name }}`; only the DGX branch hardcodes the name. `roles/nvidia-dgx/vars/ubuntu-24.04.yml` lists `datacenter-gpu-manager-4-cuda13` for DGX OS 7, so the two roles currently disagree.

Reproduced on DGX B300, DGX OS 7.5.0, driver 580.126.20, `install_dcgm: true` (default) via `playbooks/slurm-cluster.yml`.

## Fix
Map each DGX OS release to the DCGM package it ships (`dcgm_dgx_pkg_map`, taken from `roles/nvidia-dgx/vars`; overridable via `dcgm_dgx_pkg_name`):

| DGX OS | Ubuntu | package |
|---|---|---|
| 4 | 18.04 | `datacenter-gpu-manager` |
| 5 | 20.04 | `datacenter-gpu-manager` |
| 6 | 22.04 | `datacenter-gpu-manager` (current upstream behaviour kept — see note) |
| 7 | 24.04 | `datacenter-gpu-manager-4-cuda13` |

On DGX the task now: fails clearly on an unmapped release; removes installed packages from the *other* DCGM series (`datacenter-gpu-manager` vs `datacenter-gpu-manager-4-*`); installs the mapped package when it is missing. A host already on the right package is untouched. Non-DGX branches are unchanged.

State → action on DGX OS 7:

| installed | remove | install |
|---|---|---|
| `-4-cuda13` + `-4-core` (healthy) | – | – |
| `datacenter-gpu-manager` 3.3.9 (this bug) | `datacenter-gpu-manager` | `-4-cuda13` |
| `-4-core` only (partial) | – | `-4-cuda13` |
| nothing | – | `-4-cuda13` |

Note on DGX OS 6: `roles/nvidia-dgx/vars/ubuntu-22.04.yml` lists no DCGM package, so the map keeps what this role installs there today. If DGX OS 6 has moved to a `-4-cuda12` package, that row should change; I could not verify it on hardware.

## Verification
Restored the DGX OS version on the node (`apt-get install datacenter-gpu-manager-4-cuda13=1:4.5.2-1 datacenter-gpu-manager-4-core=1:4.5.2-1`):

    $ dcgmi discovery -l | grep found
    8 GPUs found (Active).
    2 NvSwitches found.
    $ dcgmi diag -r 1
    DCGM Version 4.5.2, Driver 580.126.20, software: Pass on GPU0-7

Fabric Manager logs show the same two switches with 74 active links each. With the patched task, a re-run of `slurm-cluster.yml` leaves the 4.5.2 packages in place.
