### PR TITLE
prometheus-slurm-exporter: mount Slurm client tools onto the container PATH

### DIFF
--- a/roles/prometheus-slurm-exporter/templates/docker.slurm-exporter.service.j2
+++ b/roles/prometheus-slurm-exporter/templates/docker.slurm-exporter.service.j2
@@ -12,7 +12,7 @@ ExecStartPre=-/usr/bin/docker rm %n
 {% if not slurm_exporter_build_image %}
 ExecStartPre=/usr/bin/docker pull {{ slurm_exporter_container }}
 {% endif %}
-ExecStart=/usr/bin/docker run --rm --network host --name %n -v {{ slurm_install_prefix }}/bin/sdiag:{{ slurm_install_prefix }}/bin/sdiag -v {{ slurm_install_prefix }}/bin/sinfo:{{ slurm_install_prefix }}/bin/sinfo -v {{ slurm_install_prefix }}/bin/squeue:{{ slurm_install_prefix }}/bin/squeue -v /etc/slurm:/etc/slurm:ro -v {{ slurm_install_prefix }}/lib:{{ slurm_install_prefix }}/lib:ro -v /etc/hosts:/etc/hosts:ro -v /var/run/munge:/var/run/munge:ro {{ slurm_exporter_container }}
+ExecStart=/usr/bin/docker run --rm --network host --name %n -v {{ slurm_install_prefix }}/bin/sdiag:/usr/local/bin/sdiag -v {{ slurm_install_prefix }}/bin/sinfo:/usr/local/bin/sinfo -v {{ slurm_install_prefix }}/bin/squeue:/usr/local/bin/squeue -v /etc/slurm:/etc/slurm:ro -v {{ slurm_install_prefix }}/lib:{{ slurm_install_prefix }}/lib:ro -v /etc/hosts:/etc/hosts:ro -v /var/run/munge:/var/run/munge:ro {{ slurm_exporter_container }}
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
## Problem

`roles/prometheus-slurm-exporter/templates/docker.slurm-exporter.service.j2` mounts the Slurm client tools into the container at the *host* path:

```
-v {{ slurm_install_prefix }}/bin/sinfo:{{ slurm_install_prefix }}/bin/sinfo
```

The exporter invokes them by name, so the destination must be on the container's `PATH`. With the default `slurm_install_prefix` the destination is `/usr/local/bin`, which already is; with a custom prefix it is not, and every scrape run dies:

```
exec: "sinfo": executable file not found in $PATH
```

`Restart=always` means `systemctl status` keeps reporting `active` and the play completes normally. The only visible symptoms are an empty Grafana dashboard and, in Prometheus, `Get "http://<node>:8080/metrics": EOF`. On our node the unit had restarted 3289 times before anyone noticed.

Reproduced on DGX B300 / DGX OS 7.5.0 with `slurm_install_prefix: /raid/slurm/usr/local`.

## Fix

Pin the three destination paths to `/usr/local/bin`. Behaviour with the default prefix is unchanged, since that is where they already landed.

The library mount is deliberately left as-is: shared objects are resolved by path, not by `PATH`.

## Verification

After changing the destinations on the affected node:

```
$ systemctl status docker.slurm-exporter.service | grep Active
     Active: active (running) since ...; 20s ago      # previously restarting every ~15s

$ curl -s localhost:8080/metrics | grep -c "^slurm"
34

$ curl -s localhost:9090/api/v1/targets | grep -o '"health":"[a-z]*"' | sort | uniq -c
      4 "health":"up"
```

The Grafana SLURM dashboard populates as expected.
