### PR TITLE
fix(nvidia-mig-manager): select package matching target architecture

### DIFF
--- a/roles/nvidia-mig-manager/defaults/main.yml
+++ b/roles/nvidia-mig-manager/defaults/main.yml
@@ -1,3 +1,24 @@
 ---
-mig_manager_url_deb: https://github.com/NVIDIA/mig-parted/releases/download/v0.14.2/nvidia-mig-manager_0.14.2-1_amd64.deb
-mig_manager_url_rpm: https://github.com/NVIDIA/mig-parted/releases/download/v0.14.2/nvidia-mig-manager-0.14.2-1.x86_64.rpm
+# Release assets use different architecture spellings: the .deb uses Debian
+# names (amd64/arm64) while the .rpm uses kernel names (x86_64/aarch64).
+# Keep the two maps separate so a single ansible_architecture value resolves
+# to the right token for each package type.
+# 'arm64' matches existing practice in roles/nvidia-dgx/vars/ubuntu-24.04.yml.
+mig_manager_version: "0.14.2"
+mig_manager_release: "1"
+
+mig_manager_deb_arch_map:
+  x86_64: amd64
+  aarch64: arm64
+  arm64: arm64
+
+mig_manager_rpm_arch_map:
+  x86_64: x86_64
+  aarch64: aarch64
+  arm64: aarch64
+
+mig_manager_deb_arch: "{{ mig_manager_deb_arch_map.get(ansible_architecture, ansible_architecture) }}"
+mig_manager_rpm_arch: "{{ mig_manager_rpm_arch_map.get(ansible_architecture, ansible_architecture) }}"
+
+mig_manager_url_deb: https://github.com/NVIDIA/mig-parted/releases/download/v{{ mig_manager_version }}/nvidia-mig-manager_{{ mig_manager_version }}-{{ mig_manager_release }}_{{ mig_manager_deb_arch }}.deb
+mig_manager_url_rpm: https://github.com/NVIDIA/mig-parted/releases/download/v{{ mig_manager_version }}/nvidia-mig-manager-{{ mig_manager_version }}-{{ mig_manager_release }}.{{ mig_manager_rpm_arch }}.rpm


### PR DESCRIPTION

### Problem

`roles/nvidia-mig-manager/defaults/main.yml` pins both package URLs to x86_64:

```yaml
mig_manager_url_deb: .../nvidia-mig-manager_0.14.2-1_amd64.deb
mig_manager_url_rpm: .../nvidia-mig-manager-0.14.2-1.x86_64.rpm
```

On aarch64 the download either 404s or installs a package `dpkg`/`rpm` rejects
for the wrong architecture, so MIG configuration never comes up on ARM nodes
(GH200, Grace-Hopper).

### Change

Build both URLs from `ansible_architecture`.

The two asset families spell the architecture differently, so they need separate
maps — the `.deb` uses Debian names and the `.rpm` uses kernel names:

| ansible_architecture | .deb token | .rpm token |
|---|---|---|
| x86_64  | `amd64` | `x86_64` |
| aarch64 | `arm64` | `aarch64` |

`arm64` is accepted as an input value to match existing repository practice:
`roles/nvidia-dgx/vars/ubuntu-24.04.yml:2` already tests
`ansible_architecture in ['aarch64', 'arm64']`.

An unlisted architecture is passed through unchanged, which yields a URL for an
asset that does not exist — v0.14.2 publishes only x86_64 and aarch64 (`.deb`,
`.rpm`, `.tar.gz` for each). The download then fails with a clear 404 instead of
installing a package built for the wrong architecture, and MIG-capable hardware
is limited to those two architectures in any case.

The version and release number are also lifted into their own variables. This is
outside the architecture change, and the reason is duplication: the two URLs
repeat the version four times between them, so a bump previously meant editing
four places in two lines. x86_64 resolves to the same two URLs as before.

### Verification

Asset names read from the release itself:

```
$ gh api repos/NVIDIA/mig-parted/releases/tags/v0.14.2 --jq '.assets[].name'
nvidia-mig-manager-0.14.2-1.aarch64.rpm
nvidia-mig-manager-0.14.2-1.x86_64.rpm
nvidia-mig-manager_0.14.2-1_amd64.deb
nvidia-mig-manager_0.14.2-1_arm64.deb
...
```

All four rendered URLs return HTTP 206 to a ranged request (the redirect target
serves partial content):

```
HTTP/2 206 · nvidia-mig-manager_0.14.2-1_amd64.deb
HTTP/2 206 · nvidia-mig-manager_0.14.2-1_arm64.deb
HTTP/2 206 · nvidia-mig-manager-0.14.2-1.x86_64.rpm
HTTP/2 206 · nvidia-mig-manager-0.14.2-1.aarch64.rpm
```
