### PR TITLE
fix(roce_backend): build MOFED ISO filename from target architecture

### DIFF
--- a/roles/roce_backend/README.md
+++ b/roles/roce_backend/README.md
@@ -78,7 +78,7 @@ For new Kubernetes RDMA/RoCE deployments, prefer NVIDIA Network Operator coverag
 # NVIDIA OFED parameters
 mofed_version: "24.10-4.1.4.0"
 mofed_site_place: "MLNX_OFED-24.10-4.1.4.0"
-mofed_file_name: "MLNX_OFED_LINUX-24.10-4.1.4.0-ubuntu24.04-x86_64.iso"
+mofed_file_name: "MLNX_OFED_LINUX-{{ mofed_version }}-ubuntu{{ ansible_distribution_version }}-{{ ansible_architecture }}.iso"
 ```
 
 

--- a/roles/roce_backend/vars/main.yml
+++ b/roles/roce_backend/vars/main.yml
@@ -35,7 +35,9 @@ num_vf: 8
 # new Kubernetes RDMA/RoCE deployments; this role is a legacy direct-host path.
 mofed_version: "24.10-4.1.4.0"
 mofed_site_place: "MLNX_OFED-24.10-4.1.4.0"
-mofed_file_name: "MLNX_OFED_LINUX-24.10-4.1.4.0-ubuntu24.04-x86_64.iso"
+# The ISO is published per architecture. Follow the mofed role, which already
+# builds this name from ansible_architecture (roles/mofed/defaults/main.yml).
+mofed_file_name: "MLNX_OFED_LINUX-{{ mofed_version }}-ubuntu{{ ansible_distribution_version }}-{{ ansible_architecture }}.iso"
 
 multus_ds: "https://raw.githubusercontent.com/k8snetworkplumbingwg/multus-cni/master/deployments/multus-daemonset.yml"
 sriov_dp_ds: "https://raw.githubusercontent.com/k8snetworkplumbingwg/sriov-network-device-plugin/master/deployments/sriovdp-daemonset.yaml"


### PR DESCRIPTION

### Problem

`roles/roce_backend/vars/main.yml` hardcodes the ISO filename, including the
distro version and architecture that the two variables above it already carry:

```yaml
mofed_version: "24.10-4.1.4.0"
mofed_file_name: "MLNX_OFED_LINUX-24.10-4.1.4.0-ubuntu24.04-x86_64.iso"
```

The ISO is published per distro release *and* per architecture, so this name is
wrong on aarch64, and also wrong on Ubuntu 22.04 even on x86_64.

Both are in scope. `README.md:43` lists "Ubuntu 22.04 LTS and 24.04 LTS", and
line 52 names them again "for generic Kubernetes and Slurm deployments";
`docs/deepops/testing.md:126` says "DeepOps currently uses Ubuntu 22.04 and
Ubuntu 24.04 for setup and Molecule GitHub Actions"; and per-release vars files
exist for both (`roles/nvidia-dgx/vars/ubuntu-22.04.yml`,
`roles/nhc/vars/ubuntu-22.04.yml`).

### Change

Build the name from `mofed_version`, `ansible_distribution_version`, and
`ansible_architecture` — the same expression `roles/mofed` already uses
(`roles/mofed/defaults/main.yml`), so the two roles stop disagreeing.

No architecture alias map is introduced here, unlike PR ① and ②. The point of
this change is to stop disagreeing with `roles/mofed`, and that role
(`roles/mofed/defaults/main.yml:6`) also interpolates `ansible_architecture`
directly without normalising aliases — adding a map here would reintroduce the
mismatch. The difference has no practical effect: `ansible_architecture` is
`uname -m`, which never reports `arm64` on Linux. For the record, an `arm64`
input would render `...-ubuntu24.04-arm64.iso`, which returns HTTP 404; only the
`aarch64` name exists.

README updated to match, since it quotes this block verbatim.

### Verification

All four combinations of {24.04, 22.04} × {x86_64, aarch64} are published, so
every name this expression renders resolves to a real ISO:

```
ubuntu24.04 x86_64   HTTP 200  content-length: 324743168   (today's hardcoded name)
ubuntu24.04 aarch64  HTTP 200  content-length: 318736384
ubuntu22.04 x86_64   HTTP 200  content-length: 328933376
ubuntu22.04 aarch64  HTTP 200  content-length: 322516992
```

The aarch64 24.04 ISO reports `content-type: application/x-iso9660-image`. The
three names other than the first are unreachable with the hardcoded value.
