### PR TITLE
fix: pick the Enroot RPM distro tag from the version being installed

### DIFF
--- a/config.example/group_vars/all.yml
+++ b/config.example/group_vars/all.yml
@@ -190,6 +190,17 @@ enroot_config: |
   ENROOT_RUNTIME_PATH {{ enroot_runtime_path }}
   ENROOT_CACHE_PATH {{ enroot_cache_path }}
   ENROOT_DATA_PATH {{ enroot_data_path }}
+
+# The nvidia.enroot role builds its RPM URLs with a hardcoded el7 tag. Enroot
+# moved to el8 artifacts in 3.4.1 and stopped publishing el7 ones, so pick the
+# tag from the version being installed. The tag tracks the Enroot release
+# rather than the host distribution because Enroot ships no el9 artifacts --
+# RHEL 9 installs the el8 packages too. The deb URLs need no equivalent
+# override; their filenames have not changed.
+enroot_rpm_packages:
+  - "https://github.com/NVIDIA/enroot/releases/download/v{{ enroot_version }}/enroot-{{ enroot_version_string }}.{{ 'el8' if enroot_version is version('3.4.1', '>=') else 'el7' }}.x86_64.rpm"
+  - "https://github.com/NVIDIA/enroot/releases/download/v{{ enroot_version }}/enroot+caps-{{ enroot_version_string }}.{{ 'el8' if enroot_version is version('3.4.1', '>=') else 'el7' }}.x86_64.rpm"
+
 enroot_environ_config_files: []
 enroot_environ_config_files_dgx:
   - filename: 50-mellanox.env


### PR DESCRIPTION
The nvidia.enroot role builds its RPM URLs with a hardcoded el7 tag
(defaults/main.yml:27-28). Enroot moved to el8 artifacts in 3.4.1 and stopped
publishing el7 ones, so raising enroot_version to any release from 3.4.1
onward makes the RPM download 404 on RHEL-family hosts. That is nine versions,
3.4.1 through 4.2.1.

Derive the tag from enroot_version instead. The tag tracks the Enroot release
rather than the host distribution because Enroot ships no el9 artifacts, so
RHEL 9 installs the el8 packages as well.

This goes in all.yml because that is where the Enroot settings already live --
enroot_config, enroot_runtime_path, enroot_cache_path and enroot_data_path are
all defined there. The conditional follows the shape already used for
maas_repo in the same file.

Verified by rendering the URLs and probing them: 3.2.0 resolves to el7,
3.4.1 and 4.2.1 resolve to el8, all six 200. The deb URLs need no equivalent
change; their filenames have not changed across these releases.

3.4.0 stays broken and is out of scope here: it ships
enroot_3.4.0-1_amd64.deb next to enroot-3.4.0-2.el7.x86_64.rpm, and the role
derives both filenames from a single enroot_release, so no value of that
variable satisfies both. It is the only release out of eighteen where the two
disagree, and it predates the el8 switch.

Companion to the docs change that raises the example versions in
docs/deepops/update-deepops.md; that PR documents this override as a manual
step, and this one removes the need for it.