### PR TITLE
Spare localusers from the epilog's killall

### DIFF
--- a/roles/slurm/templates/etc/slurm/epilog.d/40-lastuserjob-processes
+++ b/roles/slurm/templates/etc/slurm/epilog.d/40-lastuserjob-processes
@@ -1,6 +1,18 @@
 #!/usr/bin/env bash
 set -ex
 
+# Sibling 41-lastuserjob-ssh already consults this list before it touches a
+# user, so that operator accounts do not lose access when their job ends.
+# `killall -9 -u` is broader than anything 41 does -- it reaps every process
+# the user owns on this node, including their interactive login shell and its
+# sshd session -- so it has to honour the same exemption.
+#
+# Without this an operator who submits from a login shell on a compute node is
+# disconnected the moment the job's epilog runs.
+if grep -q -w "$SLURM_JOB_USER" /etc/slurm/localusers.backup ; then
+    exit 0  # don't kill these users' login sessions
+fi
+
 if [ "$SLURM_JOB_USER" != root ]; then
     if killall -9 -u "$SLURM_JOB_USER" ; then
         logger -s -t slurm-epilog 'Killed residual user processes'

--- a/roles/slurm/templates/etc/slurm/shared/bin/run-parts.sh
+++ b/roles/slurm/templates/etc/slurm/shared/bin/run-parts.sh
@@ -13,17 +13,27 @@ log () {
     logger -s -t slurm "$@"
 }
 
-# Find out if we are running in exclusive mode
+# Use an absolute path: slurmd's PATH does not include a custom
+# slurm_install_prefix, and with an empty command result both sides of the
+# comparison below were "" and every job was treated as exclusive.
+squeue_bin="{{ slurm_install_prefix }}/bin/squeue"
+
+# Find out if we are running in exclusive mode.
+# Ask squeue for allocated CPUs and node count directly instead of parsing
+# "scontrol show job": on recent Slurm the pattern TRES=cpu= matched both the
+# ReqTRES= and AllocTRES= lines, yielding a multi-line value that never
+# compared equal, so exclusive jobs were never detected.
 exclusive=0
-numcpus_sys=$(( $(grep -c ^processor /proc/cpuinfo) * $(scontrol show job "$SLURM_JOBID" | grep -Eio "TRES=.*node=[0-9]+" | cut -d= -f5) ))
-numcpus_job=$(scontrol show job "$SLURM_JOBID" | grep -Eio "TRES=cpu=[0-9]+" | cut -d= -f3)
-if [ "$numcpus_sys" == "$numcpus_job" ] ; then
+numcpus_job=$("$squeue_bin" -h -j "$SLURM_JOBID" -o %C 2>/dev/null)
+numnodes_job=$("$squeue_bin" -h -j "$SLURM_JOBID" -o %D 2>/dev/null)
+numcpus_sys=$(( $(grep -c ^processor /proc/cpuinfo) * ${numnodes_job:-1} ))
+if [ -n "$numcpus_job" ] && [ "$numcpus_sys" -eq "$numcpus_job" ] 2>/dev/null ; then
     exclusive=1
 fi
 
 # Find out if there are any more jobs on this node for this user
 last_user_job=0
-num_jobs=$(squeue -h -u "$SLURM_JOB_USER" -w "$HOSTNAME" -t running | wc -l)
+num_jobs=$("$squeue_bin" -h -u "$SLURM_JOB_USER" -w "$HOSTNAME" -t running | wc -l)
 if [ "$num_jobs" -eq 0 ]; then
     last_user_job=1
 fi

--- a/roles/slurm/templates/etc/slurm/shared/bin/run-parts.sh
+++ b/roles/slurm/templates/etc/slurm/shared/bin/run-parts.sh
@@ -23,19 +23,39 @@ squeue_bin="{{ slurm_install_prefix }}/bin/squeue"
 # "scontrol show job": on recent Slurm the pattern TRES=cpu= matched both the
 # ReqTRES= and AllocTRES= lines, yielding a multi-line value that never
 # compared equal, so exclusive jobs were never detected.
+#
+# The lookup runs inside a conditional on purpose. This script has "set -e", so
+# a bare assignment from a failing squeue aborts the whole prolog/epilog run and
+# fails the job; redirecting stderr does not suppress the exit status. A failed,
+# empty or non-numeric lookup must instead leave exclusive=0, which only skips
+# the *-exclusive-* scripts and lets every other script run.
 exclusive=0
-numcpus_job=$("$squeue_bin" -h -j "$SLURM_JOBID" -o %C 2>/dev/null)
-numnodes_job=$("$squeue_bin" -h -j "$SLURM_JOBID" -o %D 2>/dev/null)
-numcpus_sys=$(( $(grep -c ^processor /proc/cpuinfo) * ${numnodes_job:-1} ))
-if [ -n "$numcpus_job" ] && [ "$numcpus_sys" -eq "$numcpus_job" ] 2>/dev/null ; then
-    exclusive=1
+if job_alloc=$("$squeue_bin" -h -j "$SLURM_JOBID" -o "%C %D" 2>/dev/null); then
+    read -r numcpus_job numnodes_job <<<"$job_alloc" || true
+    if [[ "$numcpus_job" =~ ^[0-9]+$ ]] && [[ "$numnodes_job" =~ ^[0-9]+$ ]]; then
+        numcpus_sys=$(( $(grep -c ^processor /proc/cpuinfo) * numnodes_job ))
+        if [ "$numcpus_sys" -eq "$numcpus_job" ]; then
+            exclusive=1
+        fi
+    else
+        log "[WARN] squeue returned no usable allocation for job ${SLURM_JOBID} ('${job_alloc}'); treating the job as non-exclusive."
+    fi
+else
+    log "[WARN] squeue failed for job ${SLURM_JOBID}; treating the job as non-exclusive."
 fi
 
-# Find out if there are any more jobs on this node for this user
+# Find out if there are any more jobs on this node for this user.
+# Same reasoning as above with one difference: a failed lookup must not be read
+# as "no other jobs", because that would run the *-lastuserjob-* cleanup scripts
+# while another job of the same user is still on the node. Piping squeue into
+# "wc -l" also hides its exit status, so the status is captured explicitly.
 last_user_job=0
-num_jobs=$("$squeue_bin" -h -u "$SLURM_JOB_USER" -w "$HOSTNAME" -t running | wc -l)
-if [ "$num_jobs" -eq 0 ]; then
-    last_user_job=1
+if user_jobs=$("$squeue_bin" -h -u "$SLURM_JOB_USER" -w "$HOSTNAME" -t running 2>/dev/null); then
+    if [ -z "$user_jobs" ]; then
+        last_user_job=1
+    fi
+else
+    log "[WARN] squeue failed while counting jobs for ${SLURM_JOB_USER} on ${HOSTNAME}; not running the last-user-job scripts."
 fi
 
 # Re-implement run-parts since on centos it is just a bash script with no useful flags.


### PR DESCRIPTION
## What happens

`epilog.d/41-lastuserjob-ssh` checks `/etc/slurm/localusers.backup` before it touches a user:

```bash
if grep -q -w "$SLURM_JOB_USER" /etc/slurm/localusers.backup ; then
    exit 0  # don't revoke access for these users
fi
```

`epilog.d/40-lastuserjob-processes` does not, even though it is the broader of the two:

```bash
if [ "$SLURM_JOB_USER" != root ]; then
    if killall -9 -u "$SLURM_JOB_USER" ; then
```

`killall -9 -u` reaps **every** process the user owns on that node. That includes an interactive login shell and the `sshd` session carrying it.

So an operator listed in `localusers.backup` — listed there precisely so their access is not cut off — is disconnected the moment their job's epilog runs.

## How we hit it

Two-node cluster where the controller is also a compute node, so the account submitting jobs also has a login shell on a node that runs the epilog.

```
11:09:55  Running /etc/slurm/epilog.d/41-lastuserjob-ssh ...
11:09:55  Running /etc/slurm/epilog.d/42-lastuserjob-cleanup ...
11:10:03  epilog for JobId=2 ran for 8 seconds
```

and on the operator's terminal, at the same moment:

```
Connection to <node> closed by remote host.
```

`40` leaves no log line of its own here, because its `logger` call is inside `if killall ...; then` and `killall` takes down the shell that would have carried the message.

There is a second, downstream symptom. Node Health Check runs `check_ps_service -u root -d sshd sshd`; on a socket-activated `sshd` (Ubuntu 24.04) there is no persistent `sshd` process once the last session dies, so NHC failed 2.5 minutes later:

```
error: health_check failed: rc:1 output:ERROR: nhc: Health check failed:
       check_ps_service: Service sshd (process sshd) owned by root not running
```

That NHC check is arguably wrong on its own for socket activation, and is not addressed here.

## The change

Apply the guard `41` already uses, unchanged in form.

Cleanup behaviour is identical for every user **not** in `localusers.backup`. And with `ProctrackType=proctrack/cgroup` the job's own processes are already reaped by Slurm, so this script is a sweep for strays that escaped the cgroup rather than the primary teardown — skipping it for a handful of operator accounts does not leave the node dirty.

## Verified

Applied to both nodes of the cluster above:

```
guard fires for ubuntu (in localusers.backup)  : YES — killall skipped
guard fires for an ordinary user               : no  — killall still runs
```

## Not changed

`42-lastuserjob-cleanup` has the same asymmetry — it removes the user's files under `/tmp` and `/dev/shm` with no exemption check. Its blast radius is much smaller than `killall -9`, so it is left alone here rather than widened into this PR. Happy to follow up if you would rather the three scripts agree.
