### PR TITLE
Spare localusers from the epilog's killall

### DIFF
--- a/roles/slurm/templates/etc/slurm/epilog.d/40-lastuserjob-processes
+++ b/roles/slurm/templates/etc/slurm/epilog.d/40-lastuserjob-processes
@@ -1,6 +1,18 @@
 #!/usr/bin/env bash
 set -ex
 
+# Sibling 41-lastuserjob-ssh already consults this list before it touches a
+# user, so that operator accounts do not lose access when their job ends.
+# `killall -9 -u` is broader than anything 41 does -- it reaps every process
+# the user owns on this node, including their interactive login shell and its
+# sshd session -- so it has to honour the same exemption.
+#
+# Without this an operator who submits from a login shell on a compute node is
+# disconnected the moment the job's epilog runs.
+if grep -q -w "$SLURM_JOB_USER" /etc/slurm/localusers.backup ; then
+    exit 0  # don't kill these users' login sessions
+fi
+
 if [ "$SLURM_JOB_USER" != root ]; then
     if killall -9 -u "$SLURM_JOB_USER" ; then
         logger -s -t slurm-epilog 'Killed residual user processes'

--- a/roles/slurm/templates/etc/slurm/epilog.d/40-lastuserjob-processes
+++ b/roles/slurm/templates/etc/slurm/epilog.d/40-lastuserjob-processes
@@ -9,9 +9,32 @@ set -ex
 #
 # Without this an operator who submits from a login shell on a compute node is
 # disconnected the moment the job's epilog runs.
-if grep -q -w "$SLURM_JOB_USER" /etc/slurm/localusers.backup ; then
-    exit 0  # don't kill these users' login sessions
-fi
+#
+# The list is one account per line, so match whole lines literally (-x -F).
+# Accounts here routinely contain dots (`je.kim`), which a regex word match
+# would treat as "any character".
+localusers_backup='{{ slurm_config_dir }}/localusers.backup'
+
+# grep exits 0 when listed, 1 when definitely not listed, and >1 when the
+# lookup itself failed (missing or unreadable file, I/O error). A failed
+# lookup is not evidence of absence, so it must not authorise the killall.
+# `|| lookup_rc=$?` keeps the non-zero status from tripping `set -e`.
+lookup_rc=0
+grep -qxF -- "$SLURM_JOB_USER" "$localusers_backup" || lookup_rc=$?
+
+case "$lookup_rc" in
+    0)
+        exit 0  # listed: don't kill these users' login sessions
+        ;;
+    1)
+        : # definitely not listed: fall through to the cleanup below
+        ;;
+    *)
+        logger -s -t slurm-epilog \
+            "localusers lookup failed (grep rc=${lookup_rc}, file=${localusers_backup}); skipping process cleanup"
+        exit 0
+        ;;
+esac
 
 if [ "$SLURM_JOB_USER" != root ]; then
     if killall -9 -u "$SLURM_JOB_USER" ; then


### PR DESCRIPTION
## What happens

`epilog.d/41-lastuserjob-ssh` checks `/etc/slurm/localusers.backup` before it touches a user:

```bash
if grep -q -w "$SLURM_JOB_USER" /etc/slurm/localusers.backup ; then
    exit 0  # don't revoke access for these users
fi
```

`epilog.d/40-lastuserjob-processes` does not, even though it is the broader of the two:

```bash
if [ "$SLURM_JOB_USER" != root ]; then
    if killall -9 -u "$SLURM_JOB_USER" ; then
```

`killall -9 -u` reaps **every** process the user owns on that node. That includes an interactive login shell and the `sshd` session carrying it.

So an operator listed in `localusers.backup` — listed there precisely so their access is not cut off — is disconnected the moment their job's epilog runs.

## How we hit it

Two-node cluster where the controller is also a compute node, so the account submitting jobs also has a login shell on a node that runs the epilog.

```
11:09:55  slurm-epilog[36623]: START user=ubuntu job=2
11:09:55  Running /etc/slurm/epilog.d/40-lastuserjob-processes ...
11:09:55  slurm-epilog[36633]: Killed residual user processes
11:09:55  sshd[3167]: pam_unix(sshd:session): session closed for user ubuntu
11:09:55  Running /etc/slurm/epilog.d/41-lastuserjob-ssh ...
11:10:03  epilog for JobId=2 ran for 8 seconds
```

and on the operator's terminal, in that same second:

```
Connection to <node> closed by remote host.
```

That `sshd` pid is a long-lived login session, not one of the short-lived connections the job itself opened.

There is a second symptom nearby. Node Health Check runs `check_ps_service -u root -d sshd sshd` and fails on these nodes:

```
error: health_check failed: rc:1 output:ERROR: nhc: Health check failed:
       check_ps_service: Service sshd (process sshd) owned by root not running
```

It fails every interval, not only after a job, so it is a separate problem and is not addressed here. We have not established why yet: on these nodes both `ssh.socket` and `ssh.service` report active, so the simple "socket activation leaves no daemon" explanation does not hold. Mentioned only so it is not mistaken for a consequence of this change.

## The change

Apply the guard `41` already uses, unchanged in form.

Cleanup behaviour is identical for every user **not** in `localusers.backup`. And with `ProctrackType=proctrack/cgroup` the job's own processes are already reaped by Slurm, so this script is a sweep for strays that escaped the cgroup rather than the primary teardown — skipping it for a handful of operator accounts does not leave the node dirty.

## Verified

Applied to both nodes of the cluster above:

```
guard fires for ubuntu (in localusers.backup)  : YES — killall skipped
guard fires for an ordinary user               : no  — killall still runs
```

## Not changed

`42-lastuserjob-cleanup` has the same asymmetry — it removes the user's files under `/tmp` and `/dev/shm` with no exemption check. Its blast radius is much smaller than `killall -9`, so it is left alone here rather than widened into this PR. Happy to follow up if you would rather the three scripts agree.
