### PR TITLE
fix(nhc): match sshd despite its rewritten process title

### DIFF
--- a/roles/nhc/templates/nhc.conf.j2
+++ b/roles/nhc/templates/nhc.conf.j2
@@ -17,7 +17,12 @@
 {% endfor %}
 
 # Check that expected processes are running
- {{ ansible_hostname }} || check_ps_service -u root -d {{ nhc_ssh_daemon }} sshd
+# OpenSSH rewrites its process title, so every sshd has argv[0] "sshd:" with a
+# trailing colon -- listener, privsep parent and session alike. check_ps_service
+# defaults its match to "*$DAEMON", which requires the token to END with the
+# daemon name, so "sshd:" never matches and the check reports the service down
+# on a node where sshd is running normally. Widen the pattern.
+ {{ ansible_hostname }} || check_ps_service -u root -m '*{{ nhc_ssh_daemon }}*' -d {{ nhc_ssh_daemon }} sshd
  {{ ansible_hostname }} || check_ps_service -u root slurmd
 
 {% if ansible_local.gpus.count > 0 %}


### PR DESCRIPTION
## Problem

On every node this role configures, NHC reports sshd as down while sshd is running normally. With the default `HealthCheckInterval`, that is a failure on every interval.

```
ERROR:  nhc:  Health check failed:  check_ps_service:  Service sshd is not running.
```

## Root cause

`check_ps_service` in `lbnl_ps.nhc` defaults its match pattern to `*$DAEMON` when `-m` is not given:

```bash
# lbnl_ps.nhc:405
MATCH="*$DAEMON"
```

and compares it against the **first whitespace-separated token** of the process arguments:

```bash
# lbnl_ps.nhc:192
ARGS=( ${PS_ARGS[$THIS_PID]} )
```

OpenSSH rewrites its process title. Every sshd -- listener, privsep parent and session alike -- therefore carries `argv[0]` of `sshd:`, **with a trailing colon**:

```
  PID USER     COMMAND
 2967 root     sshd: /usr/sbin/sshd -D [listener] 0 of 10-100 startups
39859 root     sshd: ubuntu [priv]
39914 ubuntu   sshd: ubuntu@notty
```

The glob `*sshd` requires the token to *end* with `sshd`. `sshd:` does not, so no process ever matches and the check reports the service down.

`slurmd` on the line immediately below is unaffected, and that is the control: it does not rewrite its title, so its `argv[0]` is the plain path `/usr/local/sbin/slurmd`, which `*slurmd` matches.

This is not about socket activation or a renamed binary. On the affected nodes a resident root listener exists (`PPID 1`), `pgrep -u root -x sshd` finds it, and both `ssh.socket` and `ssh.service` are active. The process title alone accounts for the failure.

## Fix

Pass `-m '*sshd*'` so the pattern tolerates the trailing colon.

## Verification

Two Ubuntu 24.04 nodes, OpenSSH_9.6p1 Ubuntu-3ubuntu13.19.

Before -- one failing check on each node:

```
ERROR:  nhc:  Health check failed:  check_ps_service:  Service sshd is not running.
```

After:

```
dgx-vm1   nhc exit code: 0   ERROR lines: 0
dgx-vm2   nhc exit code: 0   ERROR lines: 0
```

No node was left drained, and no other check changed behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)