### PR TITLE
Scope the Slurm epilog cleanup to the job that ended

### DIFF
--- a/roles/slurm/templates/etc/slurm/epilog.d/42-lastuserjob-cleanup
+++ b/roles/slurm/templates/etc/slurm/epilog.d/42-lastuserjob-cleanup
@@ -1,9 +1,71 @@
 #!/usr/bin/env bash
 set -ex
 
+# Sibling 40-lastuserjob-processes spares the accounts listed in
+# localusers.backup so that operators keep their login session when a job of
+# theirs ends. Deleting every file they own under /tmp and /dev/shm undoes that
+# from the other side: the session survives but loses the editor swap files,
+# sockets and scratch it is holding open. Honour the same exemption.
+#
+# The list is one account per line, so match whole lines literally (-x -F).
+# Accounts here routinely contain dots (`je.kim`), which a regex word match
+# would treat as "any character".
+localusers_backup='{{ slurm_config_dir }}/localusers.backup'
+
+# grep exits 0 when listed, 1 when definitely not listed, and >1 when the
+# lookup itself failed (missing or unreadable file, I/O error). A failed lookup
+# is not evidence of absence, so it must not authorise the deletion.
+# `|| lookup_rc=$?` keeps the non-zero status from tripping `set -e`.
+lookup_rc=0
+grep -qxF -- "$SLURM_JOB_USER" "$localusers_backup" || lookup_rc=$?
+
+case "$lookup_rc" in
+    0)
+        exit 0  # listed: leave these users' files alone
+        ;;
+    1)
+        : # definitely not listed: fall through to the cleanup below
+        ;;
+    *)
+        logger -s -t slurm-epilog \
+            "localusers lookup failed (grep rc=${lookup_rc}, file=${localusers_backup}); skipping file cleanup"
+        exit 0
+        ;;
+esac
+
 if [[ -n "$SLURM_JOB_USER" && "$SLURM_JOB_USER" != "root" ]]; then
-    logger -s -t slurm-epilog 'Removed residual user files'
+    # `find -user` needs the account to resolve. When the directory service is
+    # unavailable find exits non-zero without printing anything, and the old
+    # `||:` turned that into a silent no-op. Worse, a partial listing would
+    # still be piped into `rm -fr`. Resolve the name once, up front, and skip
+    # the whole step when it fails: an unresolvable owner is not evidence that
+    # nothing is owned.
+    if ! id -u -- "$SLURM_JOB_USER" >/dev/null 2>&1; then
+        logger -s -t slurm-epilog \
+            "cannot resolve ${SLURM_JOB_USER}; skipping file cleanup rather than deleting on a partial listing"
+        exit 0
+    fi
+
     for dir in /tmp /dev/shm ; do
-	find "${dir}" -user "${SLURM_JOB_USER}" -print0 | xargs -0 -r rm -fr ||:
+        [ -d "$dir" ] || continue
+
+        # -xdev keeps the walk on this filesystem. Without it the walk descends
+        # into anything mounted underneath -- a job_container/tmpfs private
+        # /tmp, a user sshfs, a bind mount of shared storage -- and deletes
+        # files that belong to another node's still-running job.
+        #
+        # find's exit status is checked instead of being swallowed: a failed or
+        # partial walk must not authorise deleting whatever it did manage to
+        # list. The listing is materialised first for the same reason; piping
+        # straight into xargs hides find's status behind xargs'.
+        victims=$(mktemp) || continue
+        if find "$dir" -xdev -user "$SLURM_JOB_USER" -print0 >"$victims" 2>/dev/null; then
+            xargs -0 -r rm -fr <"$victims" ||:
+            logger -s -t slurm-epilog "Removed residual user files under ${dir}"
+        else
+            logger -s -t slurm-epilog \
+                "find failed under ${dir} for ${SLURM_JOB_USER}; leaving it alone"
+        fi
+        rm -f "$victims"
     done
 fi

--- a/roles/slurm/templates/etc/slurm/shared/bin/run-parts.sh
+++ b/roles/slurm/templates/etc/slurm/shared/bin/run-parts.sh
@@ -49,9 +49,24 @@ fi
 # as "no other jobs", because that would run the *-lastuserjob-* cleanup scripts
 # while another job of the same user is still on the node. Piping squeue into
 # "wc -l" also hides its exit status, so the status is captured explicitly.
+#
+# RUNNING alone is too narrow. A job that is SUSPENDED (scontrol suspend, or
+# preempted with SuspendTime) or STOPPED still owns its processes, its files in
+# /tmp and /dev/shm, and its enroot directories; a job that is CONFIGURING or
+# RESIZING has an allocation on this node and is about to. None of those appear
+# under "-t running", so the *-lastuserjob-* scripts would run and reap them.
+#
+# COMPLETING is deliberately absent. The epilog runs while its own job is in
+# that state, so including it would make every job find itself, leave
+# last_user_job at 0, and disable the cleanup entirely.
+lastuserjob_states='running,suspended,stopped,configuring,resizing'
 last_user_job=0
-if user_jobs=$("$squeue_bin" -h -u "$SLURM_JOB_USER" -w "$HOSTNAME" -t running 2>/dev/null); then
-    if [ -z "$user_jobs" ]; then
+if user_jobs=$("$squeue_bin" -h -u "$SLURM_JOB_USER" -w "$HOSTNAME" -t "$lastuserjob_states" -o '%i' 2>/dev/null); then
+    # Drop this job's own entry defensively. It should not be in the states
+    # above, but an id match is cheap and keeps a future state addition from
+    # silently switching the cleanup off.
+    other_jobs=$(printf '%s\n' "$user_jobs" | grep -vxF "$SLURM_JOB_ID" || :)
+    if [ -z "$other_jobs" ]; then
         last_user_job=1
     fi
 else

--- a/tests/slurm-epilog/render.py
+++ b/tests/slurm-epilog/render.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+"""Render one Slurm prolog/epilog template so the tests exercise the deployed form.
+
+These files are Jinja templates, so they cannot be run -- or even parsed by
+`bash -n` -- as they sit in the repository. Testing a hand-trimmed copy would
+test something the cluster never runs, so the harness renders first and runs
+the result.
+"""
+import sys
+
+from jinja2 import Environment, FileSystemLoader, StrictUndefined
+
+# Values a deployment supplies. Kept here rather than in the shell harness so
+# that a template referencing an unset variable fails loudly (StrictUndefined)
+# instead of rendering an empty string and changing what is under test.
+VARS = {
+    "slurm_config_dir": "/etc/slurm",
+    "slurm_install_prefix": "/usr",
+    "enroot_runtime_path": "/run/enroot/user-$(id -u)",
+    "enroot_cache_path": "/var/lib/enroot-cache/user-$(id -u)",
+    "enroot_data_path": "/tmp/enroot-data/user-$(id -u)",
+}
+
+
+def main():
+    if len(sys.argv) != 3:
+        sys.exit("usage: render.py <template-path> <output-path>")
+
+    template_path, output_path = sys.argv[1], sys.argv[2]
+
+    # keep_trailing_newline so the rendered script ends the way the original
+    # does; a missing final newline changes nothing functionally but makes
+    # diffs against the template noisy.
+    env = Environment(
+        loader=FileSystemLoader("/"),
+        undefined=StrictUndefined,
+        keep_trailing_newline=True,
+    )
+    rendered = env.get_template(template_path.lstrip("/")).render(**VARS)
+
+    with open(output_path, "w") as handle:
+        handle.write(rendered)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/slurm-epilog/run-tests.sh
+++ b/tests/slurm-epilog/run-tests.sh
@@ -1,0 +1,272 @@
+#!/usr/bin/env bash
+# Regression tests for the Slurm epilog cleanup scope.
+#
+# The slurm role is excluded from the molecule CI because it needs systemd
+# services a container cannot run, so these scripts have had no automated
+# cover. What they do is destructive -- `killall -9 -u`, `rm -fr` -- and the
+# failure mode is silent: a cleanup that reaps a bystander looks exactly like a
+# cleanup that worked. The cases below pin the guards that decide *whether* to
+# reap; they need neither Slurm nor root.
+#
+# The templates are rendered first (render.py) so that what runs here is the
+# form a deployment gets, not a trimmed copy.
+#
+# Usage: tests/slurm-epilog/run-tests.sh
+set -uo pipefail
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo="$(cd "$here/../.." && pwd)"
+templates="$repo/roles/slurm/templates/etc/slurm"
+
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+
+pass=0
+fail=0
+
+ok() { printf '  ok   %s\n' "$1"; pass=$((pass + 1)); }
+no() { printf '  FAIL %s\n' "$1"; printf '       %s\n' "${2-}"; fail=$((fail + 1)); }
+
+render() {
+    # $1 = template path relative to $templates, $2 = output path
+    python3 "$here/render.py" "$templates/$1" "$2" || return 1
+    chmod +x "$2"
+    # A rendered script that does not parse would fail every behavioural case
+    # below with the same opaque message; check the syntax separately so the
+    # cause is named.
+    bash -n "$2"
+}
+
+# ---------------------------------------------------------------------------
+# run-parts.sh: which jobs count as "the user still has work on this node"
+# ---------------------------------------------------------------------------
+#
+# The harness drives the real script with a stub squeue on PATH. The stub reads
+# its scripted answer from $SQUEUE_FIXTURE so each case controls both the
+# output and the exit status.
+
+setup_runparts() {
+    local dir="$work/runparts"
+    rm -rf "$dir"
+    mkdir -p "$dir/bin" "$dir/parts"
+
+    render "shared/bin/run-parts.sh" "$dir/run-parts.sh" || return 1
+
+    # The script calls squeue twice: once for the exclusive check (-o "%C %D"),
+    # once for the last-user-job count. Answer the first with a non-exclusive
+    # allocation so only the second is under test.
+    # The stub must honour -t. A stub that answers the same way whatever states
+    # were asked for would let the pre-fix script pass the SUSPENDED case too,
+    # and the test would prove nothing. $SQUEUE_JOBS is "id:STATE" per line and
+    # the stub returns only the ids whose state was requested -- which is what
+    # the real squeue does, and what the fix depends on.
+    cat > "$dir/bin/squeue" <<'STUB'
+#!/usr/bin/env bash
+want_states=""
+prev=""
+for arg in "$@"; do
+    if [ "$arg" = "%C %D" ]; then
+        echo "1 1"
+        exit 0
+    fi
+    case "$prev" in
+        -t|--states) want_states="$arg" ;;
+    esac
+    case "$arg" in
+        -t*) [ "$arg" != "-t" ] && want_states="${arg#-t}" ;;
+        --states=*) want_states="${arg#--states=}" ;;
+    esac
+    prev="$arg"
+done
+
+if [ -n "${SQUEUE_RC:-}" ] && [ "$SQUEUE_RC" != 0 ]; then
+    exit "$SQUEUE_RC"
+fi
+
+[ -n "${SQUEUE_JOBS:-}" ] || exit 0
+
+printf '%s\n' "$SQUEUE_JOBS" | while IFS=: read -r id state; do
+    [ -n "$id" ] || continue
+    # No -t at all means squeue's default; the scripts under test always pass
+    # one, so treat a missing filter as "match everything" rather than guess.
+    if [ -z "$want_states" ]; then
+        printf '%s\n' "$id"
+        continue
+    fi
+    case ",${want_states}," in
+        *",${state},"*) printf '%s\n' "$id" ;;
+    esac
+done
+exit 0
+STUB
+    chmod +x "$dir/bin/squeue"
+
+    # The script resolves squeue as {{ slurm_install_prefix }}/bin/squeue, so
+    # the stub has to sit at that absolute path rather than merely on PATH.
+    mkdir -p "$dir/usr/bin"
+    cp "$dir/bin/squeue" "$dir/usr/bin/squeue"
+    sed -i "s#^squeue_bin=.*#squeue_bin=\"$dir/usr/bin/squeue\"#" "$dir/run-parts.sh"
+
+    # run-parts.sh appends every child script's output to a fixed path under
+    # /var/log/slurm. A machine running the tests need not have it, and a
+    # failed redirect makes the child look like it failed, so send it to the
+    # fixture instead.
+    mkdir -p "$dir/log"
+    sed -i "s#/var/log/slurm/prolog-epilog#$dir/log/prolog-epilog#" "$dir/run-parts.sh"
+
+    # A marker script that records whether it ran. The -lastuserjob- infix is
+    # what run-parts.sh gates on.
+    cat > "$dir/parts/42-lastuserjob-marker" <<STUB
+#!/usr/bin/env bash
+touch "$dir/RAN"
+STUB
+    chmod +x "$dir/parts/42-lastuserjob-marker"
+
+    printf '%s' "$dir"
+}
+
+runparts_case() {
+    # $1 = label, $2 = expected ran|skipped, $3 = jobs as "id:STATE" lines,
+    # $4 = SQUEUE_RC
+    local label="$1" expect="$2" jobs="${3-}" rc="${4-0}"
+    local dir
+    dir="$(setup_runparts)" || { no "$label" "harness setup failed"; return; }
+
+    rm -f "$dir/RAN"
+    local out
+    out=$(
+        SLURM_JOB_USER=alice SLURM_JOB_ID=1000 SLURMD_NODENAME=node1 \
+        HOSTNAME=node1 SLURM_JOBID=1000 \
+        SQUEUE_JOBS="$jobs" SQUEUE_RC="$rc" \
+        "$dir/run-parts.sh" "$dir/parts" 2>&1
+    )
+
+    local actual=skipped
+    [ -e "$dir/RAN" ] && actual=ran
+
+    if [ "$actual" = "$expect" ]; then
+        ok "$label"
+    else
+        no "$label" "expected $expect, got $actual -- $(printf '%s' "$out" | tail -2 | tr '\n' ' ')"
+    fi
+}
+
+echo "run-parts.sh -- last-user-job gate"
+runparts_case "no other job of this user runs the cleanup"            ran     ""
+runparts_case "another RUNNING job blocks the cleanup"                skipped "1001:running"
+# The reason this issue exists: a suspended job owns processes and files but
+# never appeared under "-t running".
+runparts_case "a SUSPENDED job blocks the cleanup"                    skipped "1002:suspended"
+runparts_case "a CONFIGURING job blocks the cleanup"                  skipped "1003:configuring"
+# A failed lookup is not evidence of absence.
+runparts_case "squeue failure blocks the cleanup"                     skipped "" 1
+# The epilog's own job must not count as "another job", or the cleanup would
+# never run again.
+runparts_case "the job's own id does not block its cleanup"           ran     "1000:running"
+runparts_case "own id plus a sibling job still blocks"                skipped "1000:running
+1004:running"
+
+# ---------------------------------------------------------------------------
+# 42-lastuserjob-cleanup: whose files may be deleted
+# ---------------------------------------------------------------------------
+
+setup_cleanup() {
+    local dir="$work/cleanup"
+    rm -rf "$dir"
+    mkdir -p "$dir/etc/slurm" "$dir/bin"
+
+    render "epilog.d/42-lastuserjob-cleanup" "$dir/42-cleanup" || return 1
+    # Point the rendered script at the fixture's localusers.backup.
+    sed -i "s#^localusers_backup=.*#localusers_backup='$dir/etc/slurm/localusers.backup'#" "$dir/42-cleanup"
+
+    printf '%s' "$dir"
+}
+
+echo
+echo "42-lastuserjob-cleanup -- deletion guards"
+
+# --- listed operator: files must survive -----------------------------------
+dir="$(setup_cleanup)"
+printf 'alice\nbob\n' > "$dir/etc/slurm/localusers.backup"
+out=$(SLURM_JOB_USER=alice "$dir/42-cleanup" 2>&1); rc=$?
+if [ "$rc" = 0 ] && ! printf '%s' "$out" | grep -q 'Removed residual'; then
+    ok "a user listed in localusers.backup is spared"
+else
+    no "a user listed in localusers.backup is spared" "rc=$rc out=$(printf '%s' "$out" | tail -1)"
+fi
+
+# --- unreadable list: must not authorise deletion --------------------------
+dir="$(setup_cleanup)"
+# No localusers.backup at all -> grep exits 2, which is "lookup failed", not
+# "not listed".
+out=$(SLURM_JOB_USER=alice "$dir/42-cleanup" 2>&1); rc=$?
+if [ "$rc" = 0 ] && printf '%s' "$out" | grep -q 'localusers lookup failed'; then
+    ok "an unreadable localusers.backup stops the cleanup"
+else
+    no "an unreadable localusers.backup stops the cleanup" "rc=$rc out=$(printf '%s' "$out" | tail -1)"
+fi
+
+# --- unresolvable account: must not delete on a partial listing ------------
+dir="$(setup_cleanup)"
+: > "$dir/etc/slurm/localusers.backup"
+out=$(SLURM_JOB_USER=nosuchuser-$$ "$dir/42-cleanup" 2>&1); rc=$?
+if [ "$rc" = 0 ] && printf '%s' "$out" | grep -q 'cannot resolve'; then
+    ok "an unresolvable owner stops the cleanup"
+else
+    no "an unresolvable owner stops the cleanup" "rc=$rc out=$(printf '%s' "$out" | tail -1)"
+fi
+
+# --- root and empty user are left alone ------------------------------------
+dir="$(setup_cleanup)"
+: > "$dir/etc/slurm/localusers.backup"
+out=$(SLURM_JOB_USER=root "$dir/42-cleanup" 2>&1); rc=$?
+if [ "$rc" = 0 ] && ! printf '%s' "$out" | grep -q 'Removed residual'; then
+    ok "root is left alone"
+else
+    no "root is left alone" "rc=$rc out=$(printf '%s' "$out" | tail -1)"
+fi
+
+# --- the walk stays on one filesystem --------------------------------------
+# -xdev is what keeps the epilog out of a job_container/tmpfs private /tmp, a
+# user's sshfs, or a bind mount of shared storage that another node's job is
+# still using. Proving it needs a real mount, so this case is skipped when the
+# harness cannot make one.
+# The script skips root by design, so the fixture needs a real unprivileged
+# account that owns the files.
+victim_user=""
+for candidate in nobody rocky ubuntu daemon; do
+    if id -u -- "$candidate" >/dev/null 2>&1; then
+        victim_user="$candidate"
+        break
+    fi
+done
+
+if [ "$(id -u)" = 0 ] && [ -n "$victim_user" ] && command -v mount >/dev/null 2>&1; then
+    dir="$(setup_cleanup)"
+    : > "$dir/etc/slurm/localusers.backup"
+
+    mkdir -p "$dir/tmp/sub"
+    if mount -t tmpfs tmpfs "$dir/tmp/sub" 2>/dev/null; then
+        touch "$dir/tmp/on-this-fs" "$dir/tmp/sub/on-the-submount"
+        chown "$victim_user" "$dir/tmp/on-this-fs" "$dir/tmp/sub/on-the-submount"
+        # Redirect the script's two hard-coded directories at the fixture.
+        sed -i "s#^    for dir in /tmp /dev/shm ; do#    for dir in $dir/tmp ; do#" "$dir/42-cleanup"
+        SLURM_JOB_USER="$victim_user" "$dir/42-cleanup" >/dev/null 2>&1
+
+        if [ ! -e "$dir/tmp/on-this-fs" ] && [ -e "$dir/tmp/sub/on-the-submount" ]; then
+            ok "-xdev keeps the walk off a submount"
+        else
+            no "-xdev keeps the walk off a submount" \
+               "this-fs exists=$([ -e "$dir/tmp/on-this-fs" ] && echo yes || echo no), submount exists=$([ -e "$dir/tmp/sub/on-the-submount" ] && echo yes || echo no)"
+        fi
+        umount "$dir/tmp/sub" 2>/dev/null
+    else
+        printf '  skip -xdev keeps the walk off a submount (could not mount tmpfs)\n'
+    fi
+else
+    printf '  skip -xdev keeps the walk off a submount (needs root and an unprivileged account)\n'
+fi
+
+echo
+printf '%d passed, %d failed\n' "$pass" "$fail"
+[ "$fail" = 0 ]


### PR DESCRIPTION
Closes part of #1407.

## What the issue asked, and what was already there

`run-parts.sh` already gates every `*-lastuserjob-*` script on the user having no other job on this node, and already refuses to treat a failed `squeue` lookup as "no other jobs". The ordinary concurrent-job case the issue worries about was covered. These commits close the gaps that remained; the two scoping items that need a rewrite (`40` by cgroup, `50` by enroot path) are left for follow-ups, as the issue asks.

## 1. Suspended and configuring jobs were invisible to the gate

The gate asked squeue for `RUNNING` alone. A job that is `SUSPENDED` — `scontrol suspend`, or preemption with `SuspendTime` — still owns its processes, its files under `/tmp` and `/dev/shm`, and its enroot directories. So does a `STOPPED` job. A `CONFIGURING` or `RESIZING` job holds an allocation on the node and is about to. None of them appear under `-t running`, so `40-lastuserjob-processes` would `killall -9` them and `42-lastuserjob-cleanup` would `rm -fr` their files.

The state list is now `running,suspended,stopped,configuring,resizing`.

**`COMPLETING` is deliberately absent.** The epilog runs while its own job is in that state, so including it would make every job find itself, leave `last_user_job` at `0`, and switch the cleanup off entirely. The job's own id is filtered out as well — cheap, and it keeps a future state addition from silently doing that.

State names verified against `squeue --helpstate` on Slurm 26.05.1.

## 2. The file cleanup reached files the job did not own

`42-lastuserjob-cleanup` walked `/tmp` and `/dev/shm` and removed everything owned by the job's user. Three ways that hit bystanders:

**The `localusers.backup` exemption was missing.** `40-lastuserjob-processes` spares those accounts so an operator keeps their login session when a job of theirs ends (#1404). Deleting every file they own undoes that from the other side: the session survives but loses the editor swap files, sockets and scratch it is holding open. The same exemption now applies, with the same treatment of a failed lookup — `grep` exiting `>1` means the list could not be read, which is not evidence that the user is absent from it.

**`find`'s exit status was discarded by `||:`.** When the directory service is unavailable, `find -user` exits non-zero and prints nothing — and a partial listing would still have been piped into `rm -fr`. The account is resolved once up front and the step is skipped when it cannot be: an unresolvable owner is not evidence that nothing is owned. The listing is materialised before deletion for the same reason, since piping straight into `xargs` hides `find`'s status behind `xargs`'.

**`-xdev` was missing.** The walk descended into anything mounted underneath — a `job_container/tmpfs` private `/tmp`, a user's sshfs, a bind mount of shared storage — and deleted files belonging to another node's still-running job.

## 3. Tests

The `slurm` role is excluded from the molecule CI because it needs systemd services a container cannot run, so these scripts had no automated cover. What they do is destructive and the failure mode is silent: a cleanup that reaps a bystander looks exactly like one that worked.

The harness renders the Jinja templates and runs the result. A trimmed copy would test something the cluster never runs, and the templates cannot even be parsed by `bash -n` as they sit in the tree.

Twelve cases pin the guards that decide *whether* to reap. Run on Rocky Linux 9.8:

```
this branch                12 passed, 0 failed
roles/ from master          5 passed, 7 failed
```

The seven that fail before the change:

| case | pre-fix behaviour |
|---|---|
| a SUSPENDED job blocks the cleanup | cleanup ran |
| a CONFIGURING job blocks the cleanup | cleanup ran |
| the job's own id does not block its cleanup | cleanup skipped |
| a user listed in localusers.backup is spared | `find` ran against them |
| an unreadable localusers.backup stops the cleanup | proceeded anyway |
| an unresolvable owner stops the cleanup | proceeded anyway |
| `-xdev` keeps the walk off a submount | **the file on the submount was deleted** |

One note on the harness itself: the `squeue` stub filters on the `-t` argument rather than answering the same way whatever was asked. An earlier version ignored it, and the pre-fix script passed the SUSPENDED case too — the test proved nothing until the stub honoured the filter.

Requires `python3` with `jinja2`, which CI already installs alongside ansible. The mount-boundary case needs root and an unprivileged account, and skips itself when either is missing.

## Not in this PR

Per the issue, kept separate:

- **`40-lastuserjob-processes` scoped by cgroup.** `ProctrackType=proctrack/cgroup` makes the job's cgroup the authoritative scope, but the processes this script exists to catch are the ones that *escaped* it. Narrowing to the cgroup alone would quietly drop that purpose, so it needs a per-PID check against other jobs' cgroups and `user.slice` — and real-hardware verification before it can land.
- **`50-lastuserjob-all-enroot-dirs` scoped by job.** The default paths are per-user, not per-job (`/run/enroot/user-$(id -u)`, `/tmp/enroot-data/user-$(id -u)`). Sites that move `enroot_data_path` onto shared storage get a cross-node hazard the per-node gate cannot see. Fixing it properly means changing the defaults in `config.example`, which is a behaviour change that deserves its own review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)